### PR TITLE
100% coverage and 100% self-mutation (tests only, no release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to PSComplexity are documented here. Format follows
   logic against its reference-score suite, gated on the mutation score (~90%). The two
   Fortigi modules dogfood each other -- PSComplexity gates PSMutant's complexity, and
   PSMutant gates PSComplexity's test quality.
+- The self-mutation gate is now set at **100%**: coverage is 100% (167/167 commands) and
+  every one of the 41 mutants is killed, with no mutant declared equivalent. From here a
+  new survivor fails the build.
+
+### Fixed
+- Top-level script code -- decisions and calls outside any function -- is now covered by
+  tests. Both "no enclosing function" fallbacks in the AST layer were previously
+  unreachable by the suite, because every fixture wrapped its logic in a function.
+- A ternary's cyclomatic increment, the script body's reported start line, the parse-error
+  message shown when a file is skipped, and the file-vs-directory filter in source
+  discovery are all pinned; each could previously be changed without a test noticing.
 
 ## [0.1.0] - 2026-07-03
 ### Added

--- a/psmutant.self.config.json
+++ b/psmutant.self.config.json
@@ -15,6 +15,6 @@
   },
   "coveredLinesOnly": true,
   "operators": ["BinaryOperator", "BooleanLiteral", "NumberLiteral", "NegationRemoval"],
-  "thresholds": { "high": 90, "low": 75, "break": 85 },
+  "thresholds": { "high": 90, "low": 75, "break": 100 },
   "reportPath": "reports/ps-mutation-self.json"
 }

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -7,6 +7,11 @@ $script:CyclomaticCases = @(
     @{ name = 'while loop = 2'; expected = 2; code = 'function T { param($n) while ($n -gt 0) { $n-- } }' }
     @{ name = 'if with two -and = 4'; expected = 4; code = 'function T { param($a,$b,$c) if ($a -and $b -and $c) { 1 } }' }
     @{ name = 'foreach + if = 3'; expected = 3; code = 'function T { param($xs) foreach ($x in $xs) { if ($x) { 1 } } }' }
+    # A ternary is one decision, like the if it stands in for. No case here used
+    # one, so its increment could have been any number: a ternary scoring 2 would
+    # inflate every unit that uses one, and PowerShell 7 code uses them freely.
+    @{ name = 'ternary = 2'; expected = 2; code = 'function T { param($x) $x ? 1 : 2 }' }
+    @{ name = 'ternary inside an if = 3'; expected = 3; code = 'function T { param($a,$x) if ($a) { $x ? 1 : 2 } }' }
 )
 
 BeforeAll {

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -60,3 +60,62 @@ Describe 'Test-PSComplexity' {
         Test-PSComplexity -Path $script:work -Recurse -MaxCognitive 2 -WarningAction SilentlyContinue | Should -BeFalse
     }
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Top-level script code: decisions and calls that sit OUTSIDE any function.
+# Every fixture above wraps its logic in one, so the "walked to the top without
+# finding a function" fallbacks in Ast.ps1 were never reached. That shape is not
+# exotic — a crawler entry point, a build script or a profile is exactly this,
+# and it is the code most likely to be complex and least likely to be tested.
+# ─────────────────────────────────────────────────────────────────────────────
+
+Describe 'Measure-PSComplexity - script-level code outside any function' {
+
+    # NOTE: no angle brackets in It names here. Pester expands <...> in a test
+    # name as a -ForEach data placeholder, so 'to <script-body>' is parsed as the
+    # expression $script-body and the test dies with a token error before it runs.
+    It 'attributes a top-level decision to the script-body unit' {
+        # Get-PSCxUnitName walks to the nearest enclosing function; with none, it
+        # falls back to '<script-body>'. Without a top-level DECISION that fallback
+        # never runs: an assignment at script level creates the unit but asks
+        # nothing about which unit a decision belongs to.
+        $p = Join-Path $script:work 'toplevel-if.ps1'
+        Set-Content $p 'if ($env:CI) { "ci" } else { "local" }' -Encoding utf8
+        $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
+        $body            | Should -Not -BeNullOrEmpty
+        $body.Cyclomatic | Should -Be 2   # baseline 1 + the if
+        $body.Cognitive  | Should -Be 2   # +1 the if, +1 the else branch
+    }
+
+    It 'nests top-level decisions the same way it nests them inside a function' {
+        # Pins that the script body is a real unit for cognitive scoring, not a
+        # bucket that only collects a flat count: the inner if is +2 (nesting), so
+        # a body that ignored depth would score 2 instead of 3.
+        $p = Join-Path $script:work 'toplevel-nested.ps1'
+        Set-Content $p 'if ($a) { if ($b) { "x" } }' -Encoding utf8
+        $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
+        $body.Cyclomatic | Should -Be 3
+        $body.Cognitive  | Should -Be 3
+    }
+
+    It 'does not count a top-level call as recursion' {
+        # Recursion detection compares a call name against its ENCLOSING function
+        # name. At script level there is none, so the lookup returns $null and the
+        # call must not be scored — a script that calls a command sharing its file
+        # name would otherwise pick up a phantom recursion point.
+        $p = Join-Path $script:work 'toplevel-call.ps1'
+        Set-Content $p 'Get-Date' -Encoding utf8
+        $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
+        $body.Cognitive | Should -Be 0
+    }
+
+    It 'still detects recursion inside a function in the same file' {
+        # The counterpart to the case above: proving the $null guard did not simply
+        # switch recursion detection off.
+        $p = Join-Path $script:work 'toplevel-plus-recursion.ps1'
+        Set-Content $p "Get-Date`nfunction Get-Loop { Get-Loop }" -Encoding utf8
+        $recs = Measure-PSComplexity -Path $p
+        ($recs | Where-Object Unit -like 'Get-Loop*').Cognitive | Should -Be 1
+        ($recs | Where-Object Unit -eq '<script-body>').Cognitive | Should -Be 0
+    }
+}

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -61,13 +61,13 @@ Describe 'Test-PSComplexity' {
     }
 }
 
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 # Top-level script code: decisions and calls that sit OUTSIDE any function.
 # Every fixture above wraps its logic in one, so the "walked to the top without
 # finding a function" fallbacks in Ast.ps1 were never reached. That shape is not
-# exotic — a crawler entry point, a build script or a profile is exactly this,
+# exotic -- a crawler entry point, a build script or a profile is exactly this,
 # and it is the code most likely to be complex and least likely to be tested.
-# ─────────────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------------
 
 Describe 'Measure-PSComplexity - script-level code outside any function' {
 
@@ -101,7 +101,7 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
     It 'does not count a top-level call as recursion' {
         # Recursion detection compares a call name against its ENCLOSING function
         # name. At script level there is none, so the lookup returns $null and the
-        # call must not be scored — a script that calls a command sharing its file
+        # call must not be scored -- a script that calls a command sharing its file
         # name would otherwise pick up a phantom recursion point.
         $p = Join-Path $script:work 'toplevel-call.ps1'
         Set-Content $p 'Get-Date' -Encoding utf8
@@ -152,7 +152,7 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
 
     It 'ignores a DIRECTORY whose name ends in .ps1' {
         # File discovery filters to files. Drop that filter and a directory matching
-        # the include pattern is handed to ParseFile, which cannot read it — so one
+        # the include pattern is handed to ParseFile, which cannot read it -- so one
         # legal (if odd) directory name pollutes or breaks a whole scan.
         #
         # -Recurse matters: without it, Get-ChildItem -Include returns nothing at

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -119,3 +119,55 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         ($recs | Where-Object Unit -eq '<script-body>').Cognitive | Should -Be 0
     }
 }
+
+Describe 'Measure-PSComplexity - reporting details that the suite never pinned' {
+
+    It 'reports the script body as starting at line 1' {
+        # The unit table seeds '<script-body>' with its start line. Nothing asserted
+        # the Line column for it, so the seed could be any number and every score
+        # stayed correct while the record pointed at the wrong place.
+        $p = Join-Path $script:work 'body-line.ps1'
+        Set-Content $p "if (`$a) { 1 }" -Encoding utf8
+        (Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>').Line | Should -Be 1
+    }
+
+    It 'counts a ternary as exactly one cyclomatic decision' {
+        # Every branch contributes Amount = 1. A ternary scoring 2 would inflate
+        # every unit using one, and no cyclomatic test used a ternary at all.
+        $p = Join-Path $script:work 'ternary-cyc.ps1'
+        Set-Content $p 'function Get-T { param($x) $x ? 1 : 2 }' -Encoding utf8
+        (Measure-PSComplexity -Path $p | Where-Object Unit -like 'Get-T*').Cyclomatic | Should -Be 2
+    }
+
+    It 'names the FIRST parse error in the skip warning' {
+        # The warning reads $errors[0]. Read as $errors[1] it reports a different
+        # error, or nothing at all when there is only one -- leaving a warning that
+        # says a file was skipped without saying why, which is the only thing that
+        # warning is for.
+        $p = Join-Path $script:work 'one-error.ps1'
+        Set-Content $p 'if ($a) {' -Encoding utf8
+        Measure-PSComplexity -Path $p -WarningVariable w -WarningAction SilentlyContinue | Out-Null
+        ($w -join ' ') | Should -BeLike "*Missing closing '}'*"
+    }
+
+    It 'ignores a DIRECTORY whose name ends in .ps1' {
+        # File discovery filters to files. Drop that filter and a directory matching
+        # the include pattern is handed to ParseFile, which cannot read it — so one
+        # legal (if odd) directory name pollutes or breaks a whole scan.
+        #
+        # -Recurse matters: without it, Get-ChildItem -Include returns nothing at
+        # all for this shape, so the filtered and unfiltered forms agree and the
+        # case proves nothing. The recursive walk is where they diverge.
+        $d = Join-Path $script:work 'weird.ps1'
+        New-Item -ItemType Directory -Path $d -Force | Out-Null
+        Set-Content (Join-Path $d 'inner.ps1') 'function Get-Inner { 1 }' -Encoding utf8
+
+        $wv = $null
+        $recs = Measure-PSComplexity -Path $script:work -Recurse -WarningVariable wv -WarningAction SilentlyContinue
+        # The real file inside it is still measured...
+        ($recs | Where-Object Unit -like 'Get-Inner*') | Should -Not -BeNullOrEmpty
+        # ...and the directory itself is never treated as a source file.
+        @($recs | Where-Object File -eq $d).Count | Should -Be 0
+        ($wv -join ' ') | Should -Not -BeLike "*weird.ps1'*"
+    }
+}


### PR DESCRIPTION
Tests only — **no source changes**. `git diff main -- src/ PSComplexity.psd1
PSComplexity.psm1` is empty, so the shipped package is byte-identical to 0.1.0 and there
is nothing here to publish. No version bump.

| Gate | Before | After |
|---|---|---|
| Coverage | 98.8% | **100%** (167/167) |
| Self-mutation | 90.2% | **100%** (41/41) |
| Tests | 32 | **42** |
| Lint / self-complexity | clean | clean |

`thresholds.break` raised 85 -> **100**. Nothing is declared equivalent: every mutant
turned out to be genuinely killable, which is the right answer for a module this small and
this pure.

## What was actually untested

- **Top-level script code.** Both "walked up and found no enclosing function" fallbacks in
  the AST layer were unreachable, because every fixture wrapped its logic in a function.
  That shape is a crawler entry point or a build script — the code most likely to be
  complex and least likely to be tested.
- **A ternary's cyclomatic increment.** No cyclomatic case used one, so it could have
  scored any number; PowerShell 7 code uses them freely.
- **The script body's reported start line**, which every score test ignored.
- **The first parse error in the skip warning.** Read as `$errors[1]` on a single-error
  file it reports nothing, leaving a warning that says a file was skipped without saying
  why — the only thing that warning is for.
- **The file-vs-directory filter** in source discovery: a directory named `*.ps1` is legal,
  and without the filter it is handed to `ParseFile`.

## Three things learned the hard way, recorded in the tests

- **Map the test to the file the CONFIG maps.** The ternary case first went into
  `Measure.Tests.ps1`; `src/Cyclomatic.ps1` maps only to `Cyclomatic.Tests.ps1`, so the
  mutant was evaluated against a suite that never sees a ternary — and survived a test
  that did cover it.
- **The directory case needs `-Recurse`.** Without it, `Get-ChildItem -Include` returns
  nothing for that shape either way, so filtered and unfiltered agree and the case proves
  nothing.
- **No angle brackets in an `It` name.** Pester expands `<...>` as a `-ForEach` data
  placeholder, so `to <script-body>` parses as `$script-body` and the test dies with a
  token error before it runs.

## Follow-ups filed

#1 class members are not measured as units · #2 a committed baseline so complexity can
ratchet · #3 report which construct contributed each cognitive point · #4 nothing pins the
metrics against an external reference · #5 machine-readable report (JSON/SARIF) ·
#6 a parse error is a silent warning, so a broken file scores nothing · #7 measure only
what a PR changed