### PR TITLE
Measure PowerShell class members as units

### DIFF
--- a/PSComplexity.psd1
+++ b/PSComplexity.psd1
@@ -1,11 +1,11 @@
 @{
     RootModule           = 'PSComplexity.psm1'
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
     GUID                 = '961aa886-4f8e-40c0-9d25-68fd4c52e69f'
     Author               = 'Fortigi'
     CompanyName          = 'Fortigi'
     Copyright            = '(c) Fortigi. MIT licensed.'
-    Description          = 'Cyclomatic and cognitive complexity for PowerShell. Cognitive complexity is a faithful port of the SonarSource metric (nesting-aware -- the better signal for "hard to understand"), validated against reference scores. Measures per unit (function/filter + script body) via the PowerShell AST; ships a Test-PSComplexity gate for CI.'
+    Description          = 'Cyclomatic and cognitive complexity for PowerShell. Cognitive complexity is a faithful port of the SonarSource metric (nesting-aware -- the better signal for "hard to understand"), validated against reference scores. Measures per unit (function/filter, class method/constructor, initialised class property, + script body) via the PowerShell AST; ships a Test-PSComplexity gate for CI.'
     PowerShellVersion    = '7.2'
     CompatiblePSEditions = @('Core')
 
@@ -19,7 +19,7 @@
             Tags         = @('complexity', 'cyclomatic', 'cognitive', 'code-quality', 'ast', 'metrics', 'maintainability', 'lint', 'ci')
             LicenseUri   = 'https://github.com/Fortigi/PSComplexity/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Fortigi/PSComplexity'
-            ReleaseNotes = 'Initial release: per-unit cyclomatic and (faithful, reference-validated) cognitive complexity via the PowerShell AST; Measure-PSComplexity and a Test-PSComplexity CI gate.'
+            ReleaseNotes = '0.2.0: PowerShell class members are measured as units. Methods and constructors report as Class.Member (previously a method appeared under its bare name, so two classes with the same method name -- or a class method and a function of that name -- collided in one row and in any per-unit baseline). An initialised class property is now its own unit instead of folding its decisions into the script body, and recursion through $this.Method() or [Class]::Method() counts as it does for functions. 0.1.0: initial release.'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 Cyclomatic complexity counts control-flow branches (how many paths to test). **Cognitive
 complexity** — the [SonarSource](https://www.sonarsource.com/docs/CognitiveComplexity.pdf)
 metric — measures how hard code is to *understand*: it rewards flat code and penalises
-nesting. PSComplexity computes both per unit (each function/filter, plus one
-`<script-body>` per file) straight from the PowerShell AST, and ships a CI gate.
+nesting. PSComplexity computes both per unit (each function/filter, each class method,
+constructor and initialised property, plus one `<script-body>` per file) straight from
+the PowerShell AST, and ships a CI gate.
 
 > To our knowledge PSComplexity is the first module on the PowerShell Gallery to offer a
 > faithful cognitive-complexity metric (cyclomatic exists only in the unmaintained
@@ -40,8 +41,15 @@ if (-not (Test-PSComplexity ./src -Recurse -MaxCyclomatic 15 -MaxCognitive 15)) 
 File        Unit                 Line Cyclomatic Cognitive
 ----        ----                 ---- ---------- ---------
 src\Foo.ps1 Get-Foo                12          8         9
+src\Foo.ps1 Order.Process          31          5        10
 src\Foo.ps1 <script-body>          1           1         0
 ```
+
+Class members are reported as `Class.Member`, so two classes with a method of the same
+name — or a class method and a function of that name — stay distinct, in the output and
+in any per-unit baseline built from it. A class property is a unit only when it has an
+initialiser: that is code which runs, and it belongs to the property rather than to the
+enclosing script body.
 
 ## The two metrics
 

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -1,15 +1,29 @@
 <#
 .SYNOPSIS
-    Shared AST helpers for PSComplexity: unit discovery, nearest-function
-    attribution, and nesting-depth computation.
+    Shared AST helpers for PSComplexity: unit discovery, nearest-unit attribution,
+    and nesting-depth computation.
 
 .DESCRIPTION
-    A "unit" is a function/filter body, plus one synthetic '<script-body>' per file for
-    top-level code. Every increment is attributed to the nearest enclosing function, so
-    nested functions are measured independently.
+    A "unit" is anything that owns a body and is gated on its own:
+
+      * a function/filter                -> 'name@line'
+      * a class method or constructor    -> 'Class.Member@line'
+      * an initialised class property    -> 'Class.Property@line'
+      * one synthetic '<script-body>' per file, for top-level code
+
+    Every increment is attributed to the nearest enclosing unit, so nested functions
+    -- and methods of a class declared inside a function -- are measured independently.
+
+    Class members are units because the gate is per-unit: folding a class's methods
+    into the enclosing scope either hides a genuinely complex method inside a large
+    total, or inflates a script body that is itself fine. A property INITIALISER is
+    its own unit for the same reason and at the same granularity as a method: it is
+    code that runs (at construction), it is not top-level code, and naming the
+    property is what lets a gate point at the thing to fix. A property with no
+    initialiser has no body and so is not a unit.
 
     Nesting depth (used by cognitive complexity) counts the flow-structuring ancestors
-    between a node and its enclosing function -- if/loops/switch/catch/trap/ternary AND
+    between a node and its enclosing unit -- if/loops/switch/catch/trap/ternary AND
     nested script-block lambdas (e.g. a ForEach-Object body). That mirrors SonarSource's
     B3 nesting-level rule, where nested functions/lambdas raise the nesting level.
 #>
@@ -21,29 +35,69 @@ $script:PSCxNestingTypes = @(
     'CatchClauseAst', 'TrapStatementAst', 'TernaryExpressionAst', 'ScriptBlockExpressionAst'
 )
 
-function Get-PSCxUnitKey {
-    # Nearest enclosing function 'name@line', else '<script-body>'.
-    [OutputType([string])]
+# Ancestor types that OWN a body: the walk up stops here, both for attribution and
+# for nesting. A method body bounds its contents exactly as a function body does.
+$script:PSCxUnitBoundaryTypes = @(
+    'FunctionDefinitionAst', 'FunctionMemberAst', 'PropertyMemberAst'
+)
+
+function Resolve-PSCxUnitBoundary {
+    # A class method's body is itself a FunctionDefinitionAst, nested inside the
+    # FunctionMemberAst. Both are body owners, so without this the same method is
+    # discovered twice -- once unqualified. The MEMBER is the unit: it is the node
+    # that knows the class name.
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Boundary)
+    if ($Boundary -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $Boundary.Parent -is [System.Management.Automation.Language.FunctionMemberAst]) {
+        return $Boundary.Parent
+    }
+    return $Boundary
+}
+
+function Get-PSCxUnitBoundary {
+    # Nearest enclosing body-owner, or $null for top-level code.
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
     $p = $Node.Parent
     while ($p) {
-        if ($p -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
-            return '{0}@{1}' -f $p.Name, $p.Extent.StartLineNumber
-        }
+        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) { return Resolve-PSCxUnitBoundary -Boundary $p }
         $p = $p.Parent
     }
+    return $null
+}
+
+function Get-PSCxUnitName {
+    # 'name@line' for a function; 'Class.Member@line' for a class member (whose
+    # Parent is the TypeDefinitionAst carrying the class name). A constructor is
+    # named after its class, so it reads 'Order.Order@line'.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Boundary)
+    if ($Boundary -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+        return '{0}@{1}' -f $Boundary.Name, $Boundary.Extent.StartLineNumber
+    }
+    return '{0}.{1}@{2}' -f $Boundary.Parent.Name, $Boundary.Name, $Boundary.Extent.StartLineNumber
+}
+
+function Get-PSCxUnitKey {
+    # Nearest enclosing unit key, else '<script-body>'.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Node)
+    $boundary = Get-PSCxUnitBoundary -Node $Node
+    if ($boundary) { return Get-PSCxUnitName -Boundary $boundary }
     return '<script-body>'
 }
 
 function Get-PSCxNesting {
-    # Count of nesting-raising ancestors up to (not crossing) the enclosing function.
+    # Count of nesting-raising ancestors up to (not crossing) the enclosing unit.
     [OutputType([int])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
     $depth = 0
     $p = $Node.Parent
-    while ($p -and $p -isnot [System.Management.Automation.Language.FunctionDefinitionAst]) {
+    while ($p -and $p.GetType().Name -notin $script:PSCxUnitBoundaryTypes) {
         if ($p.GetType().Name -in $script:PSCxNestingTypes) { $depth++ }
         $p = $p.Parent
     }
@@ -51,27 +105,49 @@ function Get-PSCxNesting {
 }
 
 function Get-PSCxUnitTable {
-    # Baseline unit -> start-line map: every function + the script body, so a
-    # decision-free unit still reports (cyclomatic 1 / cognitive 0).
+    # Baseline unit -> start-line map: every function, every class method and
+    # initialised property, plus the script body -- so a decision-free unit still
+    # reports (cyclomatic 1 / cognitive 0).
     [OutputType([hashtable])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     $units = @{ '<script-body>' = 1 }
-    foreach ($fn in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
-        $units['{0}@{1}' -f $fn.Name, $fn.Extent.StartLineNumber] = $fn.Extent.StartLineNumber
+    # No .GetNewClosure() here, unlike the per-type loops in Cyclomatic/Cognitive:
+    # those capture a local loop variable and need one. This predicate captures
+    # nothing, and a closure built INSIDE a function loses the module scope, so
+    # $script:PSCxUnitBoundaryTypes would come back empty and match nothing.
+    $isBodyOwner = {
+        param($x)
+        if ($x -is [System.Management.Automation.Language.PropertyMemberAst]) { return [bool]$x.InitialValue }
+        return $x.GetType().Name -in $script:PSCxUnitBoundaryTypes
+    }
+    foreach ($node in $Ast.FindAll($isBodyOwner, $true)) {
+        $unit = Resolve-PSCxUnitBoundary -Boundary $node
+        $units[(Get-PSCxUnitName -Boundary $unit)] = $unit.Extent.StartLineNumber
     }
     return $units
 }
 
 function Get-PSCxEnclosingFunctionName {
-    # Name of the nearest enclosing function (for recursion detection), else $null.
+    # Name of the nearest enclosing FUNCTION, for bare-command recursion detection.
+    # $null when the nearest body-owner is a class member: a bare command inside a
+    # method is a command lookup, never a call to the method, so walking past the
+    # method to an outer function would attribute recursion to the wrong unit.
     [OutputType([string])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
-    $p = $Node.Parent
-    while ($p) {
-        if ($p -is [System.Management.Automation.Language.FunctionDefinitionAst]) { return $p.Name }
-        $p = $p.Parent
-    }
+    $boundary = Get-PSCxUnitBoundary -Node $Node
+    if ($boundary -is [System.Management.Automation.Language.FunctionDefinitionAst]) { return $boundary.Name }
+    return $null
+}
+
+function Get-PSCxEnclosingMethod {
+    # Nearest enclosing class method/constructor, else $null. Method recursion goes
+    # through a member invocation ($this.X()), not a command, so it needs the AST
+    # node -- the class name on it is what tells a static self-call apart.
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Node)
+    $boundary = Get-PSCxUnitBoundary -Node $Node
+    if ($boundary -is [System.Management.Automation.Language.FunctionMemberAst]) { return $boundary }
     return $null
 }

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -98,13 +98,47 @@ function Get-PSCxCogRecursionRow {
     }
 }
 
+function Test-PSCxSelfInvocation {
+    # True if a member call targets the enclosing class itself: $this.X() for an
+    # instance method, [ClassName]::X() for a static one. $other.X() from inside X
+    # is a call to a DIFFERENT object and is not recursion.
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Node, [Parameter(Mandatory)] $Method)
+    $expr = $Node.Expression
+    if ($expr -is [System.Management.Automation.Language.VariableExpressionAst]) {
+        return $expr.VariablePath.UserPath -eq 'this'
+    }
+    if ($expr -is [System.Management.Automation.Language.TypeExpressionAst]) {
+        return $expr.TypeName.Name -eq $Method.Parent.Name
+    }
+    return $false
+}
+
+function Get-PSCxCogMethodRecursionRow {
+    # direct recursion inside a class method: +1, same as the function case. A method
+    # cannot recurse by bare command name, so Get-PSCxCogRecursionRow never sees it.
+    [OutputType([pscustomobject[]])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Ast)
+    foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.InvokeMemberExpressionAst] }, $true)) {
+        $method = Get-PSCxEnclosingMethod -Node $n
+        if (-not $method) { continue }
+        if ($n.Member.Value -ne $method.Name) { continue }
+        if (Test-PSCxSelfInvocation -Node $n -Method $method) {
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+        }
+    }
+}
+
 function Get-PSCxCognitiveMap {
     # unit key -> cognitive complexity (summed rows; decision-free unit = 0).
     [OutputType([hashtable])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     $rows = @(Get-PSCxCogIfRow -Ast $Ast) + @(Get-PSCxCogBlockRow -Ast $Ast) + @(Get-PSCxCogTernaryRow -Ast $Ast) +
-            @(Get-PSCxCogBooleanRow -Ast $Ast) + @(Get-PSCxCogJumpRow -Ast $Ast) + @(Get-PSCxCogRecursionRow -Ast $Ast)
+            @(Get-PSCxCogBooleanRow -Ast $Ast) + @(Get-PSCxCogJumpRow -Ast $Ast) + @(Get-PSCxCogRecursionRow -Ast $Ast) +
+            @(Get-PSCxCogMethodRecursionRow -Ast $Ast)
     $map = @{}
     foreach ($row in $rows) { $map[$row.Key] = [int]$map[$row.Key] + $row.Amount }
     $out = @{}

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -54,6 +54,88 @@ Describe 'Cognitive complexity - reference scores' {
     }
 }
 
+Describe 'Cognitive complexity - class members' {
+    BeforeAll {
+        function script:Get-UnitCognitive {
+            param([string]$Code, [string]$Unit)
+            $file = Join-Path ([System.IO.Path]::GetTempPath()) "cxcls-$([System.Guid]::NewGuid().ToString('N')).ps1"
+            Set-Content $file $Code -Encoding utf8
+            try { (Measure-PSComplexity -Path $file | Where-Object Unit -eq $Unit).Cognitive }
+            finally { Remove-Item $file -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'counts an instance method calling itself through $this as recursion' {
+        # A method cannot recurse by bare command name, so the function-recursion
+        # collector never sees this. Without the member-invocation rule the if is
+        # the only increment and the score is 1.
+        $code = 'class C { [int] Walk($o) { if ($o) { return $this.Walk($o.Next) } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 2
+    }
+
+    It 'counts a static method calling itself through the class name' {
+        $code = 'class C { static [int] Helper($o) { if ($o) { return [C]::Helper($o.Next) } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should -Be 2
+    }
+
+    It 'does not count a call to the SAME method name on another object' {
+        # $other.Walk() is a different object's method. Only the if counts.
+        $code = 'class C { [int] Walk($o) { if ($o) { return $o.Walk(1) } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+    }
+
+    It 'does not count a call to a DIFFERENT method on $this' {
+        $code = 'class C { [int] Walk($o) { if ($o) { return $this.Other(1) } return 0 } [int] Other($x) { return 1 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+    }
+
+    It 'does not count a same-named static method on a DIFFERENT class' {
+        $code = 'class D { static [int] Helper($x) { return 1 } }
+class C { static [int] Helper($o) { if ($o) { return [D]::Helper(1) } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should -Be 1
+    }
+
+    It 'does not count a same-named call on the result of an expression' {
+        # The target is neither $this nor a type name, so it cannot be known to be
+        # this object -- (...).Walk() is a call on whatever that expression returned.
+        $code = 'class C { [int] Walk($o) { if ($o) { return (Get-Item .).Walk(1) } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+    }
+
+    It 'ignores a member invocation outside any class' {
+        # Guards the "no enclosing method" path: without it the rule dereferences
+        # $null looking for a method name.
+        $code = '$o = Get-Item .; $o.Refresh()'
+        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should -Be 0
+    }
+
+    It 'does not treat a bare command matching the method name as recursion' {
+        # Inside a method, `Walk` is a command lookup, never a call to the method.
+        # The method body is itself a FunctionDefinitionAst named Walk, so reading
+        # the enclosing FUNCTION name here would score a phantom recursive call.
+        $code = 'class C { [int] Walk($o) { if ($o) { Walk } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+    }
+
+    It 'still counts recursion for a plain function of the same shape' {
+        $code = 'function Walk { param($o) if ($o) { return (Walk $o.Next) } return 0 }'
+        Get-UnitCognitive -Code $code -Unit 'Walk' | Should -Be 2
+    }
+
+    It 'measures nesting inside a method from the method boundary, not the class' {
+        # if(+1) > if(+2) > foreach(+3) > if(+4) = 10, exactly as the same body
+        # scores in a plain function.
+        $code = 'class C { [int] Process($o) { if ($o.A) { if ($o.B) { foreach ($x in $o.C) { if ($x) { return 1 } } } } return 0 } }'
+        Get-UnitCognitive -Code $code -Unit 'C.Process' | Should -Be 10
+    }
+
+    It 'attributes a property initialiser to the property, not the script body' {
+        $code = 'class C { [int] $Threshold = $(if ($env:X) { 5 } else { 1 }) }'
+        Get-UnitCognitive -Code $code -Unit 'C.Threshold'  | Should -Be 2
+        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should -Be 0
+    }
+}
+
 Describe 'Test-PSCxLogicalRunStart' {
     It 'flags the outer node of a same-operator chain as the single run start' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput('$a -and $b -and $c', [ref]$null, [ref]$null)

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -171,3 +171,71 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         ($wv -join ' ') | Should -Not -BeLike "*weird.ps1'*"
     }
 }
+
+Describe 'Measure-PSComplexity - class members as units' {
+    BeforeAll {
+        $script:clsFile = Join-Path $script:work 'cls.ps1'
+        Set-Content $script:clsFile @'
+class Order {
+    [int] $Threshold = $(if ($env:X) { 5 } else { 1 })
+    [string] $Plain
+    Order() { if ($env:Y) { $this.Plain = 'y' } }
+    [int] Process([object]$o) {
+        if ($o.A) { if ($o.B) { foreach ($x in $o.C) { if ($x) { return 1 } } } }
+        return 0
+    }
+    static [int] Helper() { return 1 }
+}
+class Invoice {
+    [int] Process([object]$o) { return 0 }
+}
+function Process { if (1) { } }
+'@ -Encoding utf8
+        $script:clsRecs = Measure-PSComplexity -Path $script:clsFile
+    }
+
+    It 'qualifies a method with its class name' {
+        # A method body is itself a FunctionDefinitionAst, so an unqualified 'Process'
+        # is what you get without treating the member as the unit -- and then three
+        # different units in this file all answer to that one name.
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cyclomatic | Should -Be 5
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cognitive  | Should -Be 10
+    }
+
+    It 'reports each method exactly once' {
+        @($script:clsRecs | Where-Object Unit -eq 'Order.Process') | Should -HaveCount 1
+    }
+
+    It 'keeps same-named methods on different classes apart, and apart from a function' {
+        $names = @($script:clsRecs | Where-Object { $_.Unit -like '*Process*' } | ForEach-Object Unit | Sort-Object)
+        $names | Should -Be @('Invoice.Process', 'Order.Process', 'Process')
+    }
+
+    It 'names a constructor after its class' {
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Order').Cyclomatic | Should -Be 2
+    }
+
+    It 'reports a static method' {
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Helper').Cyclomatic | Should -Be 1
+    }
+
+    It 'makes an initialised property its own unit and leaves the script body alone' {
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Threshold').Cyclomatic | Should -Be 2
+        ($script:clsRecs | Where-Object Unit -eq '<script-body>').Cyclomatic  | Should -Be 1
+    }
+
+    It 'does not create a unit for a property with no initialiser' {
+        # No initialiser means no code, so there is nothing to measure or gate.
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Plain') | Should -BeNullOrEmpty
+    }
+
+    It 'reports the line of the member, not of the class' {
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Line | Should -Be 5
+    }
+
+    It 'lets the gate fail a single over-complex method' {
+        # The point of the whole change: a per-unit ceiling can now name the method.
+        Test-PSComplexity -Path $script:clsFile -MaxCognitive 9 -WarningAction SilentlyContinue | Should -BeFalse
+        Test-PSComplexity -Path $script:clsFile -MaxCognitive 10 -WarningAction SilentlyContinue | Should -BeTrue
+    }
+}


### PR DESCRIPTION
Closes #1.

Class methods, constructors and initialised properties are now units in their own right, reported as `Class.Member`.

## The issue's premise was partly wrong, and that changed the fix

#1 said class methods "do not appear as units at all". They do. A method body is *itself* a `FunctionDefinitionAst`, nested inside the `FunctionMemberAst`, so unit discovery already found it. Measured on `main`, the example from the issue reports:

```
Unit          Line Cyclomatic Cognitive
<script-body>    1          2         2
Process          3          5        10
```

Not one `<script-body>` unit — `Process` is there, with the right numbers. Three things *are* broken, and they are what this branch fixes.

**1. Naming.** The inner node carries only the bare method name. This file produced three units all called `Process`:

```powershell
class Order   { [int] Process([object]$o) { ... } }
class Invoice { [int] Process([object]$o) { ... } }
function Process { ... }
```

Indistinguishable in the output, and worse in a per-unit baseline built from it, where they collapse onto a single key — one unit's complexity silently licensing another's. Now `Order.Process`, `Invoice.Process`, `Process`.

**2. Property initialisers.** This part of #1 was exactly right: they were charged to `<script-body>`. That is the `2/2` above, for a file whose top level is empty. They now belong to the property.

**3. Method recursion was never counted — and a phantom one was.** A method recurses through `$this.X()` or `[Class]::X()`, an `InvokeMemberExpressionAst`; the recursion rule only looked at `CommandAst`. Meanwhile the enclosing-function walk found that inner `FunctionDefinitionAst`, so:

```powershell
class C { [int] Walk($o) { if ($o) { Walk } return 0 } }
```

scored a recursive call PowerShell would never make. A method is not a command.

## The open question in #1

Property initialisers are attributed to the **property**, not the class and not the script body. It is code that runs (at construction), it is not top-level code, and naming the property is what lets a per-unit gate point at the thing to fix. A property with no initialiser has no body, so it is not a unit at all.

## Two things worth knowing about the implementation

Both `FunctionMemberAst` and its inner `FunctionDefinitionAst` are body-owners, so they must resolve to the member. Without that this change *adds* a duplicate unit instead of fixing anything — which is what the first cut did.

The discovery predicate must **not** use `.GetNewClosure()`. A closure built inside a function loses the module scope, so `$script:PSCxUnitBoundaryTypes` came back empty and matched nothing: 29 tests failed with every unit missing. The per-type loops in `Cyclomatic.ps1` / `Cognitive.ps1` *do* need their closure — they capture a local loop variable. Opposite requirements, a few lines apart; there is a comment at the call site.

## Quality

| | Before | After |
|---|---|---|
| Tests | 42 | **62** |
| Line coverage | 100% | **100%** |
| Self-mutation | 41/41 | **49/49 (100%)** |

PSScriptAnalyzer clean, and the module still passes its own complexity gate — the new recursion rule is 5 cyclomatic / 7 cognitive against a ceiling of 15.

Version **0.2.0**: new functionality, not a patch. The tag must match `ModuleVersion`, which is bumped here.
