### PR TITLE
Skip the publish step when that version is already on the gallery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,34 @@ jobs:
           $ver = (Import-PowerShellDataFile ./PSComplexity.psd1).ModuleVersion
           if ($tag -ne $ver) { throw "Tag $tag does not match ModuleVersion $ver" }
 
+      # A gallery version cannot be replaced or withdrawn, only unlisted, so a repeat
+      # publish is the one outcome here that can never be undone. It is reachable by an
+      # ordinary route too: publishing by hand (workflow_dispatch with dryRun off) and
+      # then tagging the same commit for traceability. That second step should be a
+      # no-op, not a red run.
+      #
+      # The skip is annotated as a WARNING on purpose. Skipping is right when the
+      # version was published deliberately, but the same path is hit by a mistake --
+      # forgetting to bump ModuleVersion -- where a silently green run would look like
+      # a release that shipped when nothing did. The annotation surfaces it in the run
+      # summary either way.
+      - name: Skip if this version is already published
+        id: exists
+        shell: pwsh
+        run: |
+          $ver = (Import-PowerShellDataFile ./PSComplexity.psd1).ModuleVersion
+          $found = Find-Module PSComplexity -RequiredVersion $ver -ErrorAction SilentlyContinue
+          if ($found) {
+              Write-Host "::warning::PSComplexity $ver is already on the PowerShell Gallery (published $($found.PublishedDate)) - skipping the publish step. If you meant to release new code, bump ModuleVersion."
+              "already=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+          else {
+              Write-Host "PSComplexity $ver is not on the gallery yet."
+              "already=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
       - name: Publish to PSGallery
+        if: steps.exists.outputs.already != 'true'
         shell: pwsh
         env:
           PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}


### PR DESCRIPTION
Same guard as Fortigi/PSMutant#18 — where it has since skipped a real tag push cleanly, so this is a proven shape rather than a proposed one.

A gallery version cannot be replaced or withdrawn, only unlisted, so a repeat publish is the one outcome in this workflow that can never be undone. It is reachable by an entirely ordinary route: publish by hand (`workflow_dispatch` with `dryRun` off), then tag that same commit for traceability. The second step should be a no-op, not a red run.

## The change

The publish step becomes conditional on a `Find-Module` lookup of the manifest's `ModuleVersion`. Verified against the live gallery:

```
0.2.0: published (17/08/2026 19:27:08) -> SKIP
0.2.1: not on gallery                  -> PUBLISH
```

## One deliberate difference from PSMutant's version

**The skip is annotated as a GitHub `::warning::`, not a plain log line.**

Skipping is correct when the version was published on purpose. But the identical path is reached by a *mistake* — forgetting to bump `ModuleVersion` before tagging — and there the guard turns what used to be a loud red failure into a silently green run that shipped nothing. That is the one way this change could make things worse.

The annotation keeps it visible in the run summary and the checks UI without failing the build, so the deliberate case stays quiet-ish and the mistake stays noticeable. Worth backporting to PSMutant for parity, and I'm happy to do that.

## What it does not do

If the lookup itself fails — gallery down, transient network — `$found` is null and the run proceeds to publish, which then errors on a duplicate exactly as it does today. This removes the routine collision; it does not pretend to make publishing transactional. Failing toward "attempt the publish" is the right direction, since the alternative is silently skipping a release that genuinely needed to go out.

`publish.yml` only — no source or test changes.

## Unrelated but worth noting

This repo has **no `v0.2.0` tag** (only `v0.1.0`), although 0.2.0 is published and `main` matches it. Once this merges, tagging it would run cleanly through the guard — same situation PSMutant was just in.
