### PR TITLE
fix: measure a flat directory, and a path with a bracket in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to PSComplexity are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
 ## [Unreleased]
+
+## [0.2.1] - 2026-08-21
+### Fixed
+- **A directory scanned without `-Recurse` measured nothing at all, and the gate passed.**
+  `-Include` is ignored for a directory unless `-Recurse` is also given, so
+  `Measure-PSComplexity ./src` returned zero units for a folder full of code and
+  `Test-PSComplexity ./src -MaxCyclomatic 1 -MaxCognitive 1` returned `$true` against 27
+  units that all breached. Discovery now filters on the file extension instead.
+- **A path containing `[` or `]` matched nothing.** `-Path` treats brackets as a wildcard
+  character class, so a real directory named `my[1]proj` scored a confident, empty zero. An
+  existing path is now resolved literally; a path that names nothing on disk still falls
+  through to wildcard matching, so patterns like `./src/*.ps1` keep working.
+- The test that pinned non-recursive scanning asserted only that the nested unit was
+  absent, which is equally true when discovery finds nothing -- so it certified the bug
+  instead of catching it. It now asserts the flat unit is present in the same call.
+
 ### Added
 - CI self-assessment: the **PSMutant** module mutation-tests PSComplexity's own metric
   logic against its reference-score suite, gated on the mutation score (~90%). The two
@@ -20,6 +36,11 @@ All notable changes to PSComplexity are documented here. Format follows
 - A ternary's cyclomatic increment, the script body's reported start line, the parse-error
   message shown when a file is skipped, and the file-vs-directory filter in source
   discovery are all pinned; each could previously be changed without a test noticing.
+
+## [0.2.0] - 2026-08-19
+### Added
+- PowerShell class members are measured as units, reported as `Class.Member`. See the
+  manifest release notes for the full entry; this heading was missing when 0.2.0 shipped.
 
 ## [0.1.0] - 2026-07-03
 ### Added

--- a/PSComplexity.psd1
+++ b/PSComplexity.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'PSComplexity.psm1'
-    ModuleVersion        = '0.2.0'
+    ModuleVersion        = '0.2.1'
     GUID                 = '961aa886-4f8e-40c0-9d25-68fd4c52e69f'
     Author               = 'Fortigi'
     CompanyName          = 'Fortigi'
@@ -19,7 +19,7 @@
             Tags         = @('complexity', 'cyclomatic', 'cognitive', 'code-quality', 'ast', 'metrics', 'maintainability', 'lint', 'ci')
             LicenseUri   = 'https://github.com/Fortigi/PSComplexity/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Fortigi/PSComplexity'
-            ReleaseNotes = '0.2.0: PowerShell class members are measured as units. Methods and constructors report as Class.Member (previously a method appeared under its bare name, so two classes with the same method name -- or a class method and a function of that name -- collided in one row and in any per-unit baseline). An initialised class property is now its own unit instead of folding its decisions into the script body, and recursion through $this.Method() or [Class]::Method() counts as it does for functions. 0.1.0: initial release.'
+            ReleaseNotes = '0.2.1: FIXED - a directory scanned without -Recurse measured NOTHING, and the gate passed over it. -Include is ignored for a directory unless -Recurse is also given, so Measure-PSComplexity ./src returned zero units for a folder full of code and Test-PSComplexity returned $true against units that all breached the ceiling. If you have been gating a flat directory, that gate has never measured anything. Also fixed: a path containing [ or ] matched nothing, because -Path reads brackets as a wildcard character class - so a directory named my[1]proj scored a confident, empty zero. An existing path is now resolved literally, and a pattern that names nothing on disk still falls through to wildcard matching. 0.2.0: PowerShell class members are measured as units. Methods and constructors report as Class.Member (previously a method appeared under its bare name, so two classes with the same method name -- or a class method and a function of that name -- collided in one row and in any per-unit baseline). An initialised class property is now its own unit instead of folding its decisions into the script body, and recursion through $this.Method() or [Class]::Method() counts as it does for functions. 0.1.0: initial release.'
         }
     }
 }

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -9,8 +9,19 @@ function Get-PSCxSourceFile {
     [CmdletBinding()]
     param([Parameter(Mandatory)] [string]$Path, [switch]$Recurse)
     if (Test-Path -LiteralPath $Path -PathType Leaf) { return [string[]]@((Resolve-Path -LiteralPath $Path).Path) }
-    $gci = @{ Path = $Path; Include = @('*.ps1', '*.psm1'); File = $true; Recurse = [bool]$Recurse }
-    return [string[]]@(Get-ChildItem @gci | ForEach-Object { $_.FullName })
+
+    # Take an existing path literally, and as a wildcard only when nothing is there. -Path
+    # glob-parses '[', so a real directory named 'my[1]proj' matches nothing and the scan
+    # reports a clean zero over code it never opened.
+    $gci = @{ File = $true; Recurse = [bool]$Recurse }
+    if (Test-Path -LiteralPath $Path) { $gci.LiteralPath = $Path } else { $gci.Path = $Path }
+
+    # Filter on the extension rather than with -Include, which a directory ignores unless
+    # -Recurse is also present: a flat folder would resolve to zero files and every number
+    # after it would describe the empty set.
+    return [string[]]@(Get-ChildItem @gci |
+            Where-Object { $_.Extension -in '.ps1', '.psm1' } |
+            ForEach-Object { $_.FullName })
 }
 
 function Measure-PSComplexity {

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -31,9 +31,41 @@ Describe 'Measure-PSComplexity' {
         $recs = Measure-PSComplexity -Path $script:work -Recurse
         ($recs | Where-Object Unit -eq 'Get-B') | Should -Not -BeNullOrEmpty
     }
-    It 'does not recurse without -Recurse' {
+    It 'measures a flat directory without -Recurse, and only that directory' {
+        # Two assertions, and the FIRST one is the test. Asserting only that the nested
+        # unit is absent passes just as well when discovery found nothing at all, which
+        # is what it used to do -- so the gate returned $true over breaching code.
         $recs = Measure-PSComplexity -Path $script:work
+        ($recs | Where-Object Unit -eq 'Get-A') | Should -Not -BeNullOrEmpty
         ($recs | Where-Object Unit -eq 'Get-B') | Should -BeNullOrEmpty
+    }
+    It 'gives a directory the same units with and without -Recurse when nothing is nested' {
+        # The flat and recursive forms must agree on a flat folder. They did not: one
+        # measured every file and the other measured none, and nothing compared them.
+        $flatDir = Join-Path $script:work 'flatonly'
+        New-Item -ItemType Directory -Path $flatDir -Force | Out-Null
+        Set-Content (Join-Path $flatDir 'c.ps1') 'function Get-C { if ($z) { 1 } }' -Encoding utf8
+
+        $shallow = @(Measure-PSComplexity -Path $flatDir)
+        $deep    = @(Measure-PSComplexity -Path $flatDir -Recurse)
+        $shallow.Count | Should -BeGreaterThan 0
+        $shallow.Count | Should -Be $deep.Count
+    }
+    It 'measures a directory whose name contains wildcard characters' {
+        # -Path glob-parses '[': a real directory called 'my[1]proj' matched nothing, so
+        # a monorepo folder with a bracket in its name scored a confident, empty zero.
+        $odd = Join-Path $script:work 'my[1]proj'
+        New-Item -ItemType Directory -Path $odd -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $odd 'd.ps1') 'function Get-D { if ($q) { 1 } }' -Encoding utf8
+
+        $recs = @(Measure-PSComplexity -Path $odd -Recurse)
+        ($recs | Where-Object Unit -eq 'Get-D') | Should -Not -BeNullOrEmpty
+    }
+    It 'still accepts a wildcard path that matches nothing literally' {
+        # Resolving an existing path literally must not cost wildcard support: a pattern
+        # names no file on disk, so it has to keep falling through to -Path.
+        $recs = @(Measure-PSComplexity -Path (Join-Path $script:work '*.ps1'))
+        ($recs | Where-Object Unit -eq 'Get-A') | Should -Not -BeNullOrEmpty
     }
     It 'skips an unparseable file with a warning' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'broken.ps1') -WarningAction SilentlyContinue


### PR DESCRIPTION
Closes #29. Closes #34.

## The bug, run rather than read

`Get-ChildItem` ignores `-Include` for a directory unless `-Recurse` is also given. So discovery resolved a flat directory to **zero files** — not an error, not a warning, a clean and confident zero.

Against this repo's own `src/`:

| | before | after |
|---|---|---|
| `Measure-PSComplexity ./src` (no `-Recurse`) | **0 units** | 27 units |
| `Measure-PSComplexity ./src -Recurse` | 27 units | 27 units |
| `Test-PSComplexity ./src -MaxCyclomatic 1 -MaxCognitive 1` | **`True`** | `False` |

Ceilings of 1, twenty-seven units that all breach, and the gate said yes.

## The same failure, a second cause

`-Path` reads `[` as a wildcard character class. Three sibling directories with byte-identical contents:

```
plain        -> 2 units
my[1]proj    -> 0 units      <- and the gate over it at ceilings of 0 returned True
a b          -> 2 units
```

## The fix

Filter on the file **extension** rather than with `-Include`, and resolve an **existing** path with `-LiteralPath`. A path that names nothing on disk still falls through to `-Path`, so `./src/*.ps1` keeps working — pinned by its own test, because that fallback is exactly what a later simplification removes without anything appearing to break.

`Get-PSCxSourceFile` goes to cyclomatic 3 / cognitive 3.

## Why nobody caught it — #34

```powershell
It 'does not recurse without -Recurse' {
    $recs = Measure-PSComplexity -Path $script:work
    ($recs | Where-Object Unit -eq 'Get-B') | Should -BeNullOrEmpty
}
```

`Get-B` is nested, so its absence is equally true when discovery found **nothing at all**. The test certified the bug rather than catching it. It now asserts the flat unit is *present* in the same call — the filtered case paired with a kept one.

All three new discovery tests were run against the unfixed resolver first and **fail** there. The wildcard-fallback test passes against both, which is what a regression guard should do.

## Versioning

0.2.0 → **0.2.1**, and the entries under `[Unreleased]` move into it — they are post-0.2.0 work already on `main`. Also adds the missing `## [0.2.0]` heading: that version is on the Gallery with no CHANGELOG entry at all, the instance #24 names.

## Gates

65 tests pass. Lint clean **with no severity filter** (not just Error/Warning — see #19). Self-complexity 3/3 for the changed function. Self-mutation 100%, 49/49.

**Discount that last number.** The new guard is an `if` with no comparison, literal or negation in it, so the default operator set produces no mutant for it — the count is unchanged at 49 because nothing new was mutable. This change is held by tests, not by the mutation gate. That is #13 in miniature.
