### PR TITLE
ci: move the estate to Pester 6.1.0, and prove Pester 5 consumers still work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         shell: pwsh
         run: |
           Install-Module Pester -RequiredVersion 6.1.0 -Force -Scope CurrentUser
+          # The OLD Pester the compatibility gate proves consumers against. It must match the
+          # -PesterVersion passed below; both belong in a shared pins file (#26).
+          Install-Module Pester -RequiredVersion 5.7.1 -Force -Scope CurrentUser
           Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
 
       - name: Module manifest is valid + imports
@@ -73,4 +76,4 @@ jobs:
       # separates "this Pester cannot run here" from "this module is broken".
       - name: Pester compatibility (a Pester 5 consumer)
         shell: pwsh
-        run: ./tools/Test-PSCxPesterCompatibility.ps1
+        run: ./tools/Test-PSCxPesterCompatibility.ps1 -PesterVersion 5.7.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pinned Pester + PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module Pester -RequiredVersion 5.8.0 -Force -Scope CurrentUser
+          Install-Module Pester -RequiredVersion 6.1.0 -Force -Scope CurrentUser
           Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
 
       - name: Module manifest is valid + imports
@@ -46,6 +46,7 @@ jobs:
       - name: Tests (reference scores + self-complexity gate)
         shell: pwsh
         run: |
+          Import-Module Pester -RequiredVersion 6.1.0 -Force
           Import-Module ./PSComplexity.psd1 -Force
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'
@@ -60,8 +61,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh
         run: |
-          Install-Module PSMutant -RequiredVersion 0.1.0 -Force -Scope CurrentUser
-          Import-Module PSMutant -Force
+          Install-Module PSMutant -RequiredVersion 0.3.1 -Force -Scope CurrentUser
+          Import-Module Pester -RequiredVersion 6.1.0 -Force
+          Import-Module PSMutant -RequiredVersion 0.3.1 -Force
           $r = Invoke-PSMutation -ConfigFile ./psmutant.self.config.json -SourceRoot . -Quiet
           Write-Host "Self mutation score: $($r.Score)% ($($r.Killed)/$($r.Total))"
           if ($r.ExitCode -ne 0) { throw "Mutation score $($r.Score)% is below the break threshold" }
+
+      # Consumers gate on this module from inside THEIR Pester run, which is not the one
+      # tests/ uses. Proven by running, in a child process, with a control assertion that
+      # separates "this Pester cannot run here" from "this module is broken".
+      - name: Pester compatibility (a Pester 5 consumer)
+        shell: pwsh
+        run: ./tools/Test-PSCxPesterCompatibility.ps1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pinned Pester + PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module Pester -RequiredVersion 5.8.0 -Force -Scope CurrentUser
+          Install-Module Pester -RequiredVersion 6.1.0 -Force -Scope CurrentUser
           Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
 
       - name: Full quality gate (lint + tests + self-complexity)
@@ -38,6 +38,7 @@ jobs:
           }
           if ($f) { $f | Format-Table -AutoSize; throw "$($f.Count) lint finding(s) -- not publishing" }
           Import-Module ./PSComplexity.psd1 -Force
+          Import-Module Pester -RequiredVersion 6.1.0 -Force
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'; $cfg.Run.PassThru = $true; $cfg.Output.Verbosity = 'Normal'
           $r = Invoke-Pester -Configuration $cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ All notable changes to PSComplexity are documented here. Format follows
   message shown when a file is skipped, and the file-vs-directory filter in source
   discovery are all pinned; each could previously be changed without a test noticing.
 
+### Internal
+- The test estate moves to **Pester 6.1.0**, pinned in `ci.yml` and `publish.yml`, and every
+  step now imports it with `-RequiredVersion` rather than letting the name resolve -- an
+  unimported pin documents an intention, it does not enforce one.
+- `tools/Test-PSCxPesterCompatibility.ps1` proves a **Pester 5** consumer can still gate on
+  this module. The module has no Pester dependency, so the promise is cheap to keep and was
+  previously not checked at all.
+- The mutation-gate step moves from PSMutant 0.1.0 to 0.3.1.
+
 ## [0.2.0] - 2026-08-19
 ### Added
 - PowerShell class members are measured as units, reported as `Class.Member`. See the

--- a/tools/Test-PSCxPesterCompatibility.ps1
+++ b/tools/Test-PSCxPesterCompatibility.ps1
@@ -77,6 +77,15 @@ function Invoke-PSCxCompatSuite {
 }
 
 if ($Child) {
+    # ABSENT is a third answer, distinct from "broken here" and "the module is wrong". The
+    # import failure alone says "no valid module file was found", and the caller then
+    # reported that PSComplexity does not work under this Pester -- blaming the module for
+    # a version nobody installed.
+    if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq [version]$PesterVersion })) {
+        Write-Output "MISSING: Pester $PesterVersion is not installed on this machine."
+        Write-Output 'The gate proves nothing without it. Install it, or pass -PesterVersion.'
+        exit 3
+    }
     Import-Module Pester -RequiredVersion $PesterVersion -Force
     Import-Module (Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'PSComplexity.psd1') -Force
 
@@ -103,6 +112,7 @@ try {
         -PesterVersion $PesterVersion -FixtureRoot $root -Child
     $code = $LASTEXITCODE
 
+    if ($code -eq 3) { throw "Pester $PesterVersion is not installed; the gate could not run." }
     if ($code -eq 2) { throw "Pester $PesterVersion is unusable on this PowerShell; the gate could not run." }
     if ($code -ne 0) { throw "PSComplexity does not work correctly under Pester $PesterVersion." }
     Write-Output 'Pester compatibility gate passed.'

--- a/tools/Test-PSCxPesterCompatibility.ps1
+++ b/tools/Test-PSCxPesterCompatibility.ps1
@@ -1,0 +1,113 @@
+# Compatibility gate: prove a consumer can gate on PSComplexity from inside a Pester 5 run,
+# while this repo's own suite runs on Pester 6. The two are different promises and only one
+# of them is covered by the test estate.
+#
+# The child runs in a SEPARATE PROCESS. Pester loads assemblies, assemblies are per-process,
+# and this script is invoked from a job that has already imported a different Pester -- so
+# importing the old one in-process collides instead of testing anything.
+#
+# The script re-invokes ITSELF with -Child rather than spawning a here-string, so the
+# analyzer and the parser see every line that runs. A child contract written as an unparsed
+# string is code no gate can read.
+[CmdletBinding()]
+param(
+    # The OLD Pester to prove compatibility against -- deliberately not the one tests/ uses.
+    [string]$PesterVersion = '5.7.1',
+    [switch]$Child,
+    [string]$FixtureRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Build-PSCxCompatFixture {
+    param([Parameter(Mandatory)] [string]$Root)
+
+    $src = Join-Path $Root 'src'
+    New-Item -ItemType Directory -Path $src -Force | Out-Null
+
+    # One unit well inside any ceiling, and one far over it. BOTH are needed: a fixture that
+    # only passes cannot tell a working gate from one that returns $true unconditionally,
+    # which is the exact defect this module shipped with.
+    Set-Content -LiteralPath (Join-Path $src 'Simple.ps1') `
+        'function Get-Simple { param($x) if ($x) { 1 } else { 2 } }' -Encoding utf8
+
+    $deep = 'function Get-Deep { param($a)' + [Environment]::NewLine
+    foreach ($i in 1..12) { $deep += "    if (`$a -eq $i) { return $i }" + [Environment]::NewLine }
+    $deep += '}'
+    Set-Content -LiteralPath (Join-Path $src 'Deep.ps1') $deep -Encoding utf8
+
+    # The CONTROL. Asserts nothing about this module -- it asks whether the requested Pester
+    # can execute a test at all on this PowerShell. Without it, a Pester that is broken in
+    # the host (5.8.0 fails every test on PowerShell 7.6.x, with an EMPTY error record)
+    # looks exactly like a PSComplexity incompatibility, and the gate accuses the wrong code.
+    Set-Content -LiteralPath (Join-Path $Root 'Control.Tests.ps1') @'
+Describe 'control -- can this Pester run anything at all' {
+    It 'evaluates a trivial assertion' { (1 + 1) | Should -Be 2 }
+}
+'@ -Encoding utf8
+
+    Set-Content -LiteralPath (Join-Path $Root 'Consumer.Tests.ps1') @'
+Describe 'a consumer gates on complexity from inside Pester' {
+    It 'passes a unit within the ceilings' {
+        Test-PSComplexity -Path $env:PSCX_COMPAT_SRC -Recurse |
+            Should -Be $true
+    }
+    It 'fails a unit over the ceilings' {
+        Test-PSComplexity -Path $env:PSCX_COMPAT_SRC -Recurse -MaxCyclomatic 3 -MaxCognitive 3 -WarningAction SilentlyContinue |
+            Should -Be $false
+    }
+    It 'refuses a path it measured nothing under' {
+        { Test-PSComplexity -Path (Join-Path $env:PSCX_COMPAT_SRC 'nothing-here') -Recurse } |
+            Should -Throw
+    }
+}
+'@ -Encoding utf8
+
+    return $src
+}
+
+function Invoke-PSCxCompatSuite {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    $cfg = New-PesterConfiguration
+    $cfg.Run.Path = $Path
+    $cfg.Run.PassThru = $true
+    $cfg.Output.Verbosity = 'None'
+    return Invoke-Pester -Configuration $cfg
+}
+
+if ($Child) {
+    Import-Module Pester -RequiredVersion $PesterVersion -Force
+    Import-Module (Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'PSComplexity.psd1') -Force
+
+    $control = Invoke-PSCxCompatSuite -Path (Join-Path $FixtureRoot 'Control.Tests.ps1')
+    if ($control.FailedCount -gt 0) {
+        Write-Output "ENVIRONMENT: Pester $PesterVersion cannot run a trivial test on PowerShell $($PSVersionTable.PSVersion)."
+        Write-Output 'This is not a PSComplexity failure. The control assertion (1 + 1 = 2) failed.'
+        exit 2
+    }
+
+    $consumer = Invoke-PSCxCompatSuite -Path (Join-Path $FixtureRoot 'Consumer.Tests.ps1')
+    Write-Output "Pester ${PesterVersion}: control passed, consumer $($consumer.PassedCount) passed / $($consumer.FailedCount) failed."
+    foreach ($f in $consumer.Failed) { Write-Output "  FAILED: $($f.Name)" }
+    exit ([int]($consumer.FailedCount -gt 0))
+}
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) "pscx-compat-$([System.Guid]::NewGuid().ToString('N'))"
+try {
+    $srcDir = Build-PSCxCompatFixture -Root $root
+    $env:PSCX_COMPAT_SRC = $srcDir
+
+    Write-Output "Proving a Pester $PesterVersion consumer can gate on this module (child process)."
+    & (Get-Process -Id $PID).Path -NoProfile -File $PSCommandPath `
+        -PesterVersion $PesterVersion -FixtureRoot $root -Child
+    $code = $LASTEXITCODE
+
+    if ($code -eq 2) { throw "Pester $PesterVersion is unusable on this PowerShell; the gate could not run." }
+    if ($code -ne 0) { throw "PSComplexity does not work correctly under Pester $PesterVersion." }
+    Write-Output 'Pester compatibility gate passed.'
+}
+finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item Env:\PSCX_COMPAT_SRC -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Closes #10.

Two different promises, and only one was covered. The **estate** must run on the Pester this project develops against; the **module** must keep working for a consumer whose repo is on Pester 5. Conflating those is what cost the sibling repo its issue #16.

## The estate half is overdue, not optional

Verified by running:

| Pester | this suite | trivial `(1 + 1) \| Should -Be 2` |
|---|---|---|
| 5.8.0 | **0 pass / 69 fail** | **fails** |
| 5.7.1 | — | passes |
| 6.1.0 | 69 pass / 0 fail | passes |

So it is not this suite — **Pester 5.8.0 cannot run any test on PowerShell 7.6.5**, and the error record it produces carries *no exception*, which is why nothing ever surfaced a cause. CI stayed green only because the runner image ships an older PowerShell.

Issue #10 recorded "62 pass, 0 fail" under 5.8.0. That was true when written and is no longer true.

**The pin was decorative.** It chose what got *installed*; `Invoke-Pester` then autoloaded the newest installed anyway. Every step now does `Import-Module Pester -RequiredVersion 6.1.0` first.

## The consumer half gets a gate, not a claim

New: `tools/Test-PSCxPesterCompatibility.ps1`. Committed rather than inlined, for the reason the analyzer gate already argues — a gate that exists only inside a workflow cannot be run by hand, so by hand and in CI cannot be compared.

Two design points are load-bearing:

**A control assertion runs first**, and asserts nothing about this module — only that the requested Pester can execute a test at all. Without it a broken Pester is indistinguishable from a module incompatibility, and the gate accuses the wrong code. It exits `2` for that case and says so in words:

```
ENVIRONMENT: Pester 5.8.0 cannot run a trivial test on PowerShell 7.6.5.
This is not a PSComplexity failure. The control assertion (1 + 1 = 2) failed.
```

**The fixture carries all three consumer outcomes in one run** — a unit under the ceilings, one over them, and a path that measures nothing. A fixture that only passes cannot tell a working gate from one returning `$true` unconditionally, which is the exact defect this module shipped with until #15.

It runs in a **child process** (Pester loads assemblies; assemblies are per-process; the calling step has already imported a different Pester), and re-invokes *itself* with `-Child` rather than spawning a here-string, so the analyzer and the parser see every line that runs.

## PSMutant 0.1.0 → 0.3.1

Two majors of fixes, including the one where a wrong config type silently emptied the per-mutant timeout and every mutant was then scored Killed. Verified against the published 0.3.1 before pinning: **100%, 54/54**, unchanged.

## Gates

69 tests under 6.1.0. Whole-repo lint clean with **no severity filter** — `code-scanning.yml` scans `.` recursively, so `tools/` sits inside a required check; the four `Write-Host` findings my first draft produced are fixed rather than muted, since `src/` currently benefits from that rule. Compatibility gate green under 5.7.1 and 6.1.0, and correctly reporting `ENVIRONMENT` under 5.8.0.
