### PR TITLE
refactor: migrate the suite to Pester 6 assertions and make the v5 form an error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'
           $cfg.Run.PassThru = $true
+          # The classic `Should -Be` form is an ERROR, not a style note. Pester 6 keeps it
+          # working, so without this the suite drifts back into a mix one test at a time.
+          $cfg.Should.DisableV5 = $true
           $cfg.Output.Verbosity = 'Detailed'
           $r = Invoke-Pester -Configuration $cfg
           if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
           Import-Module Pester -RequiredVersion 6.1.0 -Force
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'; $cfg.Run.PassThru = $true; $cfg.Output.Verbosity = 'Normal'
+          # Match ci.yml: the classic `Should -Be` form is an error, not a style note.
+          $cfg.Should.DisableV5 = $true
           $r = Invoke-Pester -Configuration $cfg
           if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed -- not publishing" }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ All notable changes to PSComplexity are documented here. Format follows
   this module. The module has no Pester dependency, so the promise is cheap to keep and was
   previously not checked at all.
 - The mutation-gate step moves from PSMutant 0.1.0 to 0.3.1.
+- The suite is fully on the Pester 6 `Should-*` assertions, and `Should.DisableV5 = $true` is
+  set in both workflows so the classic `Should -Be` form is an **error** rather than a style
+  note. Verified that the setting actually fires, in both directions.
+- The fixture inside `tools/Test-PSCxPesterCompatibility.ps1` deliberately keeps the classic
+  syntax: it executes under Pester 5, where the `Should-*` commands do not exist.
 
 ## [0.2.0] - 2026-08-19
 ### Added

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -50,7 +50,7 @@ BeforeAll {
 
 Describe 'Cognitive complexity - reference scores' {
     It 'cognitive of <name> = <expected>' -ForEach $script:CognitiveCases {
-        Get-CognitiveOf -Code $code | Should -Be $expected
+        Get-CognitiveOf -Code $code | Should-Be $expected
     }
 }
 
@@ -70,43 +70,43 @@ Describe 'Cognitive complexity - class members' {
         # collector never sees this. Without the member-invocation rule the if is
         # the only increment and the score is 1.
         $code = 'class C { [int] Walk($o) { if ($o) { return $this.Walk($o.Next) } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 2
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 2
     }
 
     It 'counts a static method calling itself through the class name' {
         $code = 'class C { static [int] Helper($o) { if ($o) { return [C]::Helper($o.Next) } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should -Be 2
+        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should-Be 2
     }
 
     It 'does not count a call to the SAME method name on another object' {
         # $other.Walk() is a different object's method. Only the if counts.
         $code = 'class C { [int] Walk($o) { if ($o) { return $o.Walk(1) } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 1
     }
 
     It 'does not count a call to a DIFFERENT method on $this' {
         $code = 'class C { [int] Walk($o) { if ($o) { return $this.Other(1) } return 0 } [int] Other($x) { return 1 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 1
     }
 
     It 'does not count a same-named static method on a DIFFERENT class' {
         $code = 'class D { static [int] Helper($x) { return 1 } }
 class C { static [int] Helper($o) { if ($o) { return [D]::Helper(1) } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should -Be 1
+        Get-UnitCognitive -Code $code -Unit 'C.Helper' | Should-Be 1
     }
 
     It 'does not count a same-named call on the result of an expression' {
         # The target is neither $this nor a type name, so it cannot be known to be
         # this object -- (...).Walk() is a call on whatever that expression returned.
         $code = 'class C { [int] Walk($o) { if ($o) { return (Get-Item .).Walk(1) } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 1
     }
 
     It 'ignores a member invocation outside any class' {
         # Guards the "no enclosing method" path: without it the rule dereferences
         # $null looking for a method name.
         $code = '$o = Get-Item .; $o.Refresh()'
-        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should -Be 0
+        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should-Be 0
     }
 
     It 'does not treat a bare command matching the method name as recursion' {
@@ -114,25 +114,25 @@ class C { static [int] Helper($o) { if ($o) { return [D]::Helper(1) } return 0 }
         # The method body is itself a FunctionDefinitionAst named Walk, so reading
         # the enclosing FUNCTION name here would score a phantom recursive call.
         $code = 'class C { [int] Walk($o) { if ($o) { Walk } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should -Be 1
+        Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 1
     }
 
     It 'still counts recursion for a plain function of the same shape' {
         $code = 'function Walk { param($o) if ($o) { return (Walk $o.Next) } return 0 }'
-        Get-UnitCognitive -Code $code -Unit 'Walk' | Should -Be 2
+        Get-UnitCognitive -Code $code -Unit 'Walk' | Should-Be 2
     }
 
     It 'measures nesting inside a method from the method boundary, not the class' {
         # if(+1) > if(+2) > foreach(+3) > if(+4) = 10, exactly as the same body
         # scores in a plain function.
         $code = 'class C { [int] Process($o) { if ($o.A) { if ($o.B) { foreach ($x in $o.C) { if ($x) { return 1 } } } } return 0 } }'
-        Get-UnitCognitive -Code $code -Unit 'C.Process' | Should -Be 10
+        Get-UnitCognitive -Code $code -Unit 'C.Process' | Should-Be 10
     }
 
     It 'attributes a property initialiser to the property, not the script body' {
         $code = 'class C { [int] $Threshold = $(if ($env:X) { 5 } else { 1 }) }'
-        Get-UnitCognitive -Code $code -Unit 'C.Threshold'  | Should -Be 2
-        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should -Be 0
+        Get-UnitCognitive -Code $code -Unit 'C.Threshold'  | Should-Be 2
+        Get-UnitCognitive -Code $code -Unit '<script-body>' | Should-Be 0
     }
 }
 
@@ -140,11 +140,11 @@ Describe 'Test-PSCxLogicalRunStart' {
     It 'flags the outer node of a same-operator chain as the single run start' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput('$a -and $b -and $c', [ref]$null, [ref]$null)
         $bins = $ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)
-        @($bins | Where-Object { Test-PSCxLogicalRunStart -Node $_ }).Count | Should -Be 1
+        @($bins | Where-Object { Test-PSCxLogicalRunStart -Node $_ }).Count | Should-Be 1
     }
     It 'is false for a non-logical operator' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput('$a + $b', [ref]$null, [ref]$null)
         $bin = $ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)[0]
-        Test-PSCxLogicalRunStart -Node $bin | Should -BeFalse
+        Test-PSCxLogicalRunStart -Node $bin | Should-BeFalse
     }
 }

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -28,6 +28,6 @@ BeforeAll {
 
 Describe 'Cyclomatic complexity - reference scores' {
     It 'cyclomatic of <name>' -ForEach $script:CyclomaticCases {
-        Get-CyclomaticOf -Code $code | Should -Be $expected
+        Get-CyclomaticOf -Code $code | Should-Be $expected
     }
 }

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -17,27 +17,27 @@ AfterAll { Remove-Item $script:work -Recurse -Force -ErrorAction SilentlyContinu
 Describe 'Measure-PSComplexity' {
     It 'reports a record per unit including the script body' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1')
-        ($recs | Where-Object Unit -eq 'Get-A').Cyclomatic | Should -Be 2
-        ($recs | Where-Object Unit -eq '<script-body>') | Should -Not -BeNullOrEmpty
+        ($recs | Where-Object Unit -eq 'Get-A').Cyclomatic | Should-Be 2
+        @($recs | Where-Object Unit -eq '<script-body>').Count | Should-BeGreaterThan 0
     }
     It 'reports Cyclomatic 1 / Cognitive 0 for a decision-free unit' {
         $flat = Join-Path $script:work 'flat.ps1'
         Set-Content $flat 'function Get-Flat { param($x) $x }' -Encoding utf8
         $r = Measure-PSComplexity -Path $flat | Where-Object Unit -eq 'Get-Flat'
-        $r.Cyclomatic | Should -Be 1
-        $r.Cognitive  | Should -Be 0
+        $r.Cyclomatic | Should-Be 1
+        $r.Cognitive  | Should-Be 0
     }
     It 'recurses a directory and finds nested files' {
         $recs = Measure-PSComplexity -Path $script:work -Recurse
-        ($recs | Where-Object Unit -eq 'Get-B') | Should -Not -BeNullOrEmpty
+        @($recs | Where-Object Unit -eq 'Get-B').Count | Should-BeGreaterThan 0
     }
     It 'measures a flat directory without -Recurse, and only that directory' {
         # Two assertions, and the FIRST one is the test. Asserting only that the nested
         # unit is absent passes just as well when discovery found nothing at all, which
         # is what it used to do -- so the gate returned $true over breaching code.
         $recs = Measure-PSComplexity -Path $script:work
-        ($recs | Where-Object Unit -eq 'Get-A') | Should -Not -BeNullOrEmpty
-        ($recs | Where-Object Unit -eq 'Get-B') | Should -BeNullOrEmpty
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-B').Count | Should-Be 0
     }
     It 'gives a directory the same units with and without -Recurse when nothing is nested' {
         # The flat and recursive forms must agree on a flat folder. They did not: one
@@ -48,8 +48,8 @@ Describe 'Measure-PSComplexity' {
 
         $shallow = @(Measure-PSComplexity -Path $flatDir)
         $deep    = @(Measure-PSComplexity -Path $flatDir -Recurse)
-        $shallow.Count | Should -BeGreaterThan 0
-        $shallow.Count | Should -Be $deep.Count
+        $shallow.Count | Should-BeGreaterThan 0
+        $shallow.Count | Should-Be $deep.Count
     }
     It 'measures a directory whose name contains wildcard characters' {
         # -Path glob-parses '[': a real directory called 'my[1]proj' matched nothing, so
@@ -59,37 +59,37 @@ Describe 'Measure-PSComplexity' {
         Set-Content -LiteralPath (Join-Path $odd 'd.ps1') 'function Get-D { if ($q) { 1 } }' -Encoding utf8
 
         $recs = @(Measure-PSComplexity -Path $odd -Recurse)
-        ($recs | Where-Object Unit -eq 'Get-D') | Should -Not -BeNullOrEmpty
+        @($recs | Where-Object Unit -eq 'Get-D').Count | Should-BeGreaterThan 0
     }
     It 'still accepts a wildcard path that matches nothing literally' {
         # Resolving an existing path literally must not cost wildcard support: a pattern
         # names no file on disk, so it has to keep falling through to -Path.
         $recs = @(Measure-PSComplexity -Path (Join-Path $script:work '*.ps1'))
-        ($recs | Where-Object Unit -eq 'Get-A') | Should -Not -BeNullOrEmpty
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
     }
     It 'skips an unparseable file with a warning' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'broken.ps1') -WarningAction SilentlyContinue
-        @($recs).Count | Should -Be 0
+        @($recs).Count | Should-Be 0
     }
     It 'accepts pipeline input' {
         $recs = (Join-Path $script:work 'a.ps1') | Measure-PSComplexity
-        ($recs | Where-Object Unit -eq 'Get-A') | Should -Not -BeNullOrEmpty
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
     }
 }
 
 Describe 'Test-PSComplexity' {
     It 'returns $true when everything is within the ceilings' {
-        Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') | Should -BeTrue
+        Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') | Should-BeTrue
     }
     It 'returns $false and warns when a unit exceeds a ceiling' {
         $wv = $null
         $result = Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') -MaxCyclomatic 1 -WarningVariable wv -WarningAction SilentlyContinue
-        $result | Should -BeFalse
-        @($wv).Count | Should -BeGreaterThan 0
+        $result | Should-BeFalse
+        @($wv).Count | Should-BeGreaterThan 0
     }
     It 'honours the cognitive ceiling independently' {
         # Get-B has cognitive 3 (foreach + nested if); ceiling 2 should trip it.
-        Test-PSComplexity -Path $script:work -Recurse -MaxCognitive 2 -WarningAction SilentlyContinue | Should -BeFalse
+        Test-PSComplexity -Path $script:work -Recurse -MaxCognitive 2 -WarningAction SilentlyContinue | Should-BeFalse
     }
     It 'throws rather than passing when it measured nothing' {
         # A directory with no PowerShell in it. Returning $true here is the same answer
@@ -99,7 +99,7 @@ Describe 'Test-PSComplexity' {
         New-Item -ItemType Directory -Path $empty -Force | Out-Null
         Set-Content (Join-Path $empty 'notes.txt') 'not powershell' -Encoding utf8
 
-        { Test-PSComplexity -Path $empty -Recurse } | Should -Throw -ExpectedMessage '*Measured no units*'
+        { Test-PSComplexity -Path $empty -Recurse } | Should-Throw -ExceptionMessage '*Measured no units*'
     }
     It 'names the path it measured nothing under' {
         # The message has to say WHERE. A gate that fails without naming the path sends
@@ -108,7 +108,7 @@ Describe 'Test-PSComplexity' {
         New-Item -ItemType Directory -Path $empty -Force | Out-Null
 
         { Test-PSComplexity -Path $empty -Recurse } |
-            Should -Throw -ExpectedMessage "*$([System.IO.Path]::GetFileName($empty))*"
+            Should-Throw -ExceptionMessage "*$([System.IO.Path]::GetFileName($empty))*"
     }
     It 'suggests -Recurse only when -Recurse was not given' {
         # Two calls, because a hint that always appears is not a hint. Suggesting
@@ -121,14 +121,14 @@ Describe 'Test-PSComplexity' {
         $withRecurse = $null
         try { Test-PSComplexity -Path $empty -Recurse } catch { $withRecurse = $_.Exception.Message }
 
-        { Test-PSComplexity -Path $empty } | Should -Throw -ExpectedMessage '*-Recurse*'
-        $withRecurse | Should -Not -BeNullOrEmpty
-        $withRecurse | Should -Not -BeLike '*-Recurse*'
+        { Test-PSComplexity -Path $empty } | Should-Throw -ExceptionMessage '*-Recurse*'
+        $withRecurse | Should-NotBeNull
+        $withRecurse | Should-NotBeLikeString '*-Recurse*'
     }
     It 'still passes over a real file that is within the ceilings' {
         # Paired with the refusal above: the empty case must fail and a measured, clean
         # case must still succeed, or "throws on empty" is satisfied by throwing always.
-        Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') | Should -BeTrue
+        Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') | Should-BeTrue
     }
 }
 
@@ -153,9 +153,9 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         $p = Join-Path $script:work 'toplevel-if.ps1'
         Set-Content $p 'if ($env:CI) { "ci" } else { "local" }' -Encoding utf8
         $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
-        $body            | Should -Not -BeNullOrEmpty
-        $body.Cyclomatic | Should -Be 2   # baseline 1 + the if
-        $body.Cognitive  | Should -Be 2   # +1 the if, +1 the else branch
+        @($body).Count   | Should-BeGreaterThan 0
+        $body.Cyclomatic | Should-Be 2   # baseline 1 + the if
+        $body.Cognitive  | Should-Be 2   # +1 the if, +1 the else branch
     }
 
     It 'nests top-level decisions the same way it nests them inside a function' {
@@ -165,8 +165,8 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         $p = Join-Path $script:work 'toplevel-nested.ps1'
         Set-Content $p 'if ($a) { if ($b) { "x" } }' -Encoding utf8
         $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
-        $body.Cyclomatic | Should -Be 3
-        $body.Cognitive  | Should -Be 3
+        $body.Cyclomatic | Should-Be 3
+        $body.Cognitive  | Should-Be 3
     }
 
     It 'does not count a top-level call as recursion' {
@@ -177,7 +177,7 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         $p = Join-Path $script:work 'toplevel-call.ps1'
         Set-Content $p 'Get-Date' -Encoding utf8
         $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
-        $body.Cognitive | Should -Be 0
+        $body.Cognitive | Should-Be 0
     }
 
     It 'still detects recursion inside a function in the same file' {
@@ -186,8 +186,8 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         $p = Join-Path $script:work 'toplevel-plus-recursion.ps1'
         Set-Content $p "Get-Date`nfunction Get-Loop { Get-Loop }" -Encoding utf8
         $recs = Measure-PSComplexity -Path $p
-        ($recs | Where-Object Unit -like 'Get-Loop*').Cognitive | Should -Be 1
-        ($recs | Where-Object Unit -eq '<script-body>').Cognitive | Should -Be 0
+        ($recs | Where-Object Unit -like 'Get-Loop*').Cognitive | Should-Be 1
+        ($recs | Where-Object Unit -eq '<script-body>').Cognitive | Should-Be 0
     }
 }
 
@@ -199,7 +199,7 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         # stayed correct while the record pointed at the wrong place.
         $p = Join-Path $script:work 'body-line.ps1'
         Set-Content $p "if (`$a) { 1 }" -Encoding utf8
-        (Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>').Line | Should -Be 1
+        (Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>').Line | Should-Be 1
     }
 
     It 'counts a ternary as exactly one cyclomatic decision' {
@@ -207,7 +207,7 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         # every unit using one, and no cyclomatic test used a ternary at all.
         $p = Join-Path $script:work 'ternary-cyc.ps1'
         Set-Content $p 'function Get-T { param($x) $x ? 1 : 2 }' -Encoding utf8
-        (Measure-PSComplexity -Path $p | Where-Object Unit -like 'Get-T*').Cyclomatic | Should -Be 2
+        (Measure-PSComplexity -Path $p | Where-Object Unit -like 'Get-T*').Cyclomatic | Should-Be 2
     }
 
     It 'names the FIRST parse error in the skip warning' {
@@ -218,7 +218,7 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         $p = Join-Path $script:work 'one-error.ps1'
         Set-Content $p 'if ($a) {' -Encoding utf8
         Measure-PSComplexity -Path $p -WarningVariable w -WarningAction SilentlyContinue | Out-Null
-        ($w -join ' ') | Should -BeLike "*Missing closing '}'*"
+        ($w -join ' ') | Should-BeLikeString "*Missing closing '}'*"
     }
 
     It 'ignores a DIRECTORY whose name ends in .ps1' {
@@ -236,10 +236,10 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         $wv = $null
         $recs = Measure-PSComplexity -Path $script:work -Recurse -WarningVariable wv -WarningAction SilentlyContinue
         # The real file inside it is still measured...
-        ($recs | Where-Object Unit -like 'Get-Inner*') | Should -Not -BeNullOrEmpty
+        @($recs | Where-Object Unit -like 'Get-Inner*').Count | Should-BeGreaterThan 0
         # ...and the directory itself is never treated as a source file.
-        @($recs | Where-Object File -eq $d).Count | Should -Be 0
-        ($wv -join ' ') | Should -Not -BeLike "*weird.ps1'*"
+        @($recs | Where-Object File -eq $d).Count | Should-Be 0
+        ($wv -join ' ') | Should-NotBeLikeString "*weird.ps1'*"
     }
 }
 
@@ -269,44 +269,47 @@ function Process { if (1) { } }
         # A method body is itself a FunctionDefinitionAst, so an unqualified 'Process'
         # is what you get without treating the member as the unit -- and then three
         # different units in this file all answer to that one name.
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cyclomatic | Should -Be 5
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cognitive  | Should -Be 10
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cyclomatic | Should-Be 5
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Cognitive  | Should-Be 10
     }
 
     It 'reports each method exactly once' {
-        @($script:clsRecs | Where-Object Unit -eq 'Order.Process') | Should -HaveCount 1
+        @($script:clsRecs | Where-Object Unit -eq 'Order.Process') | Should-BeCollection -Count 1
     }
 
     It 'keeps same-named methods on different classes apart, and apart from a function' {
         $names = @($script:clsRecs | Where-Object { $_.Unit -like '*Process*' } | ForEach-Object Unit | Sort-Object)
-        $names | Should -Be @('Invoice.Process', 'Order.Process', 'Process')
+        # Joined rather than Should-BeCollection: that one ignores order and has no switch to
+        # make it strict, so it passes against any permutation -- and the sort above exists
+        # precisely so this comparison is deterministic.
+        ($names -join ',') | Should-Be 'Invoice.Process,Order.Process,Process'
     }
 
     It 'names a constructor after its class' {
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Order').Cyclomatic | Should -Be 2
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Order').Cyclomatic | Should-Be 2
     }
 
     It 'reports a static method' {
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Helper').Cyclomatic | Should -Be 1
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Helper').Cyclomatic | Should-Be 1
     }
 
     It 'makes an initialised property its own unit and leaves the script body alone' {
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Threshold').Cyclomatic | Should -Be 2
-        ($script:clsRecs | Where-Object Unit -eq '<script-body>').Cyclomatic  | Should -Be 1
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Threshold').Cyclomatic | Should-Be 2
+        ($script:clsRecs | Where-Object Unit -eq '<script-body>').Cyclomatic  | Should-Be 1
     }
 
     It 'does not create a unit for a property with no initialiser' {
         # No initialiser means no code, so there is nothing to measure or gate.
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Plain') | Should -BeNullOrEmpty
+        @($script:clsRecs | Where-Object Unit -eq 'Order.Plain').Count | Should-Be 0
     }
 
     It 'reports the line of the member, not of the class' {
-        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Line | Should -Be 5
+        ($script:clsRecs | Where-Object Unit -eq 'Order.Process').Line | Should-Be 5
     }
 
     It 'lets the gate fail a single over-complex method' {
         # The point of the whole change: a per-unit ceiling can now name the method.
-        Test-PSComplexity -Path $script:clsFile -MaxCognitive 9 -WarningAction SilentlyContinue | Should -BeFalse
-        Test-PSComplexity -Path $script:clsFile -MaxCognitive 10 -WarningAction SilentlyContinue | Should -BeTrue
+        Test-PSComplexity -Path $script:clsFile -MaxCognitive 9 -WarningAction SilentlyContinue | Should-BeFalse
+        Test-PSComplexity -Path $script:clsFile -MaxCognitive 10 -WarningAction SilentlyContinue | Should-BeTrue
     }
 }

--- a/tests/SelfComplexity.Tests.ps1
+++ b/tests/SelfComplexity.Tests.ps1
@@ -9,16 +9,16 @@ BeforeAll {
 
 Describe 'Self complexity gate' {
     It 'measured its own units' {
-        $script:units.Count | Should -BeGreaterThan 0
+        $script:units.Count | Should-BeGreaterThan 0
     }
     It 'has no unit over cyclomatic 15' {
         $over = @($script:units | Where-Object Cyclomatic -gt 15)
         $detail = ($over | ForEach-Object { "$($_.Unit)=$($_.Cyclomatic)" }) -join ', '
-        $over.Count | Should -Be 0 -Because "over cyclomatic 15: $detail"
+        $over.Count | Should-Be 0 -Because "over cyclomatic 15: $detail"
     }
     It 'has no unit over cognitive 15' {
         $over = @($script:units | Where-Object Cognitive -gt 15)
         $detail = ($over | ForEach-Object { "$($_.Unit)=$($_.Cognitive)" }) -join ', '
-        $over.Count | Should -Be 0 -Because "over cognitive 15: $detail"
+        $over.Count | Should-Be 0 -Because "over cognitive 15: $detail"
     }
 }


### PR DESCRIPTION
Closes #55.

Pester 6 keeps the classic `Should -Be` form working, so #10 moved the *estate* to 6.1.0 without moving the *suite*. `Should.DisableV5 = $true` is now set in both workflows and all 68 assertions are converted — a half-migrated suite is the state where the traps below are most likely to be introduced.

**The conversion preserves semantics exactly.** Tightening a test is a separate change and does not belong inside a mechanical migration, so `-Not -BeNullOrEmpty` became a count comparison rather than the stronger "exactly one" it could have been.

## Three things had to be run, not assumed — two changed the result

**`Should-NotBeNull` is not the equivalent of `-Not -BeNullOrEmpty`, and the difference runs opposite to the obvious guess:**

```powershell
@() | Should-NotBeNull            # FAILS  <- correct
Should-NotBeNull -Actual @()      # PASSES <- an empty array is not $null
```

The *explicit* form is the vacuous one. Collection results are therefore asserted on `.Count`, which states the actual claim and cannot go quiet in either direction.

**`Should-Be` refuses a collection on the expected side**, which caught the one assertion comparing a sorted name list:

```
OperationStopped: You provided a collection to the -Expected parameter.
```

It is **joined** rather than switched to `Should-BeCollection` — that command ignores order and has no switch to make it strict, so it passes against any permutation, and the `Sort-Object` above it exists precisely so the comparison is deterministic.

**`DisableV5` itself was verified in both directions**, because a setting that cannot fire looks exactly like one that passes:

| | classic `Should -Be` |
|---|---|
| `DisableV5 = $true` | **errors** — "Pester Should -Be syntax is disabled" |
| `DisableV5 = $false` | passes |

## One thing that must NOT be migrated

The fixture inside `tools/Test-PSCxPesterCompatibility.ps1` keeps the classic syntax deliberately. It executes under **Pester 5**, where the `Should-*` commands do not exist, and it builds its own configuration in a child process that `DisableV5` cannot reach. "Finishing the migration" there would break the compatibility gate while every other test stayed green.

## Gates

| Check | Result |
|---|---|
| 69 tests, `DisableV5` on | pass |
| 69 tests, `DisableV5` off | pass |
| Whole-repo lint, no severity filter | clean |
| Compatibility gate under 5.7.1 | green |
| **Self-mutation** | **100%, 54/54 — unchanged** |

That last row is the one that matters. The mutant count and kill count are identical to before the conversion, so no assertion lost its ability to detect a fault in translation.
