### PR TITLE
test: assert the exact answer, and widen the mutation gate to see structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ All notable changes to PSComplexity are documented here. Format follows
   note. Verified that the setting actually fires, in both directions.
 - The fixture inside `tools/Test-PSCxPesterCompatibility.ps1` deliberately keeps the classic
   syntax: it executes under Pester 5, where the `Should-*` commands do not exist.
+- **The self-mutation gate now runs the three opt-in operators PSMutant runs on itself** --
+  `ConditionalBoundary`, `ConditionForcing` and `ReturnValue`. The mutant count goes from 54
+  to 122, and the previous 100% turns out to have covered less than half of what is
+  reachable. Six survivors appeared immediately, every one of them structural logic the
+  expression-only set could not see.
+- Assertions over collections are exact counts rather than "at least one". Verified against a
+  deliberately injected duplicate-row defect: six tests catch it that all passed before.
 
 ## [0.2.0] - 2026-08-19
 ### Added

--- a/psmutant.self.config.json
+++ b/psmutant.self.config.json
@@ -14,7 +14,8 @@
     "src/Measure-PSComplexity.ps1": ["tests/Measure.Tests.ps1"]
   },
   "coveredLinesOnly": true,
-  "operators": ["BinaryOperator", "BooleanLiteral", "NumberLiteral", "NegationRemoval"],
+  "_operators_comment": "The three opt-in operators PSMutant itself runs. Without them the gate sees only expressions, so structural logic -- a guard, an early return, a fencepost -- scores a vacuous 100%. StringLiteral stays off: high volume, low signal.",
+  "operators": ["BinaryOperator", "BooleanLiteral", "NumberLiteral", "NegationRemoval", "ConditionalBoundary", "ConditionForcing", "ReturnValue"],
   "thresholds": { "high": 90, "low": 75, "break": 100 },
   "reportPath": "reports/ps-mutation-self.json"
 }

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -109,10 +109,8 @@ function Test-PSCxSelfInvocation {
     if ($expr -is [System.Management.Automation.Language.VariableExpressionAst]) {
         return $expr.VariablePath.UserPath -eq 'this'
     }
-    if ($expr -is [System.Management.Automation.Language.TypeExpressionAst]) {
-        return $expr.TypeName.Name -eq $Method.Parent.Name
-    }
-    return $false
+    return ($expr -is [System.Management.Automation.Language.TypeExpressionAst]) -and
+        ($expr.TypeName.Name -eq $Method.Parent.Name)
 }
 
 function Get-PSCxCogMethodRecursionRow {

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -28,6 +28,10 @@ function Get-Fib { param($n) if ($n -le 1) { return $n }; return (Get-Fib ($n - 
     @{ name = 'a -and b -and c is one run'; expected = 2; code = 'function T { param($a,$b,$c) if ($a -and $b -and $c) { 1 } }' }
     @{ name = 'a -and b -or c is two runs'; expected = 3; code = 'function T { param($a,$b,$c) if ($a -and $b -or $c) { 1 } }' }
     @{ name = 'nested if (structural + nesting)'; expected = 3; code = 'function T { param($a,$b) if ($a) { if ($b) { 1 } } }' }
+    # Paired deliberately: only the LABELLED jump adds a point. A fixture with just the
+    # labelled case passes equally well against a rule that counts every break.
+    @{ name = 'bare break adds nothing beyond its loop'; expected = 1; code = 'function T { foreach ($i in 1..3) { break } }' }
+    @{ name = 'labelled break adds one'; expected = 2; code = 'function T { :outer foreach ($i in 1..3) { break outer } }' }
     @{ name = 'else and elseif each add 1, no nesting bonus'; expected = 3; code = 'function T { param($a) if ($a -eq 1) { 1 } elseif ($a -eq 2) { 2 } else { 3 } }' }
     @{ name = 'labelled break'; expected = 4; code = 'function T { param($n) :L for ($i = 0; $i -lt $n; $i++) { if ($i -eq 3) { break L } } }' }
     @{ name = 'do-until loop'; expected = 1; code = 'function T { param($n) $i = 0; do { $i++ } until ($i -ge $n) }' }
@@ -100,6 +104,22 @@ class C { static [int] Helper($o) { if ($o) { return [D]::Helper(1) } return 0 }
         # this object -- (...).Walk() is a call on whatever that expression returned.
         $code = 'class C { [int] Walk($o) { if ($o) { return (Get-Item .).Walk(1) } return 0 } }'
         Get-UnitCognitive -Code $code -Unit 'C.Walk' | Should-Be 1
+    }
+
+    It 'does not treat a plain function as the enclosing method' {
+        # The enclosing-method lookup must return $null for a FUNCTION boundary. If it
+        # returns the function instead, `$this.Walk()` inside a function named Walk is
+        # read as method recursion and scores 1 where it should score 0.
+        $code = 'function Walk { $this.Walk() }'
+        Get-UnitCognitive -Code $code -Unit 'Walk' | Should-Be 0
+    }
+
+    It 'ignores a DYNAMIC member name outside any class' {
+        # $this.$m() has no literal member name, so the name comparison below the guard
+        # cannot reject it -- only the "no enclosing method" guard can. Without that
+        # guard this scores 1.
+        $code = 'function Outer { $this.$m() }'
+        Get-UnitCognitive -Code $code -Unit 'Outer' | Should-Be 0
     }
 
     It 'ignores a member invocation outside any class' {

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Measure-PSComplexity' {
     It 'reports a record per unit including the script body' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1')
         ($recs | Where-Object Unit -eq 'Get-A').Cyclomatic | Should-Be 2
-        @($recs | Where-Object Unit -eq '<script-body>').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq '<script-body>').Count | Should-Be 1
     }
     It 'reports Cyclomatic 1 / Cognitive 0 for a decision-free unit' {
         $flat = Join-Path $script:work 'flat.ps1'
@@ -29,14 +29,14 @@ Describe 'Measure-PSComplexity' {
     }
     It 'recurses a directory and finds nested files' {
         $recs = Measure-PSComplexity -Path $script:work -Recurse
-        @($recs | Where-Object Unit -eq 'Get-B').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-B').Count | Should-Be 1
     }
     It 'measures a flat directory without -Recurse, and only that directory' {
         # Two assertions, and the FIRST one is the test. Asserting only that the nested
         # unit is absent passes just as well when discovery found nothing at all, which
         # is what it used to do -- so the gate returned $true over breaching code.
         $recs = Measure-PSComplexity -Path $script:work
-        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-Be 1
         @($recs | Where-Object Unit -eq 'Get-B').Count | Should-Be 0
     }
     It 'gives a directory the same units with and without -Recurse when nothing is nested' {
@@ -48,7 +48,7 @@ Describe 'Measure-PSComplexity' {
 
         $shallow = @(Measure-PSComplexity -Path $flatDir)
         $deep    = @(Measure-PSComplexity -Path $flatDir -Recurse)
-        $shallow.Count | Should-BeGreaterThan 0
+        $shallow.Count | Should-Be 2   # Get-C and the script body
         $shallow.Count | Should-Be $deep.Count
     }
     It 'measures a directory whose name contains wildcard characters' {
@@ -59,21 +59,33 @@ Describe 'Measure-PSComplexity' {
         Set-Content -LiteralPath (Join-Path $odd 'd.ps1') 'function Get-D { if ($q) { 1 } }' -Encoding utf8
 
         $recs = @(Measure-PSComplexity -Path $odd -Recurse)
-        @($recs | Where-Object Unit -eq 'Get-D').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-D').Count | Should-Be 1
     }
     It 'still accepts a wildcard path that matches nothing literally' {
         # Resolving an existing path literally must not cost wildcard support: a pattern
         # names no file on disk, so it has to keep falling through to -Path.
         $recs = @(Measure-PSComplexity -Path (Join-Path $script:work '*.ps1'))
-        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-Be 1
     }
+    It 'measures a file named explicitly whatever its extension, but not one it discovered' {
+        # Two halves of one contract, and both are needed. The extension filter belongs to
+        # DISCOVERY: name a file and you get it measured; hand over a directory and only
+        # PowerShell files come back. Drop the leaf check and the explicit half returns
+        # nothing, silently, for the file the caller pointed straight at.
+        $odd = Join-Path $script:work 'named.psx'
+        Set-Content -LiteralPath $odd 'function Get-Odd { if ($a) { 1 } }' -Encoding utf8
+
+        @(Measure-PSComplexity -Path $odd | Where-Object Unit -eq 'Get-Odd').Count | Should-Be 1
+        @(Measure-PSComplexity -Path $script:work -Recurse | Where-Object Unit -eq 'Get-Odd').Count | Should-Be 0
+    }
+
     It 'skips an unparseable file with a warning' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'broken.ps1') -WarningAction SilentlyContinue
         @($recs).Count | Should-Be 0
     }
     It 'accepts pipeline input' {
         $recs = (Join-Path $script:work 'a.ps1') | Measure-PSComplexity
-        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-Be 1
     }
 }
 
@@ -85,7 +97,7 @@ Describe 'Test-PSComplexity' {
         $wv = $null
         $result = Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') -MaxCyclomatic 1 -WarningVariable wv -WarningAction SilentlyContinue
         $result | Should-BeFalse
-        @($wv).Count | Should-BeGreaterThan 0
+        @($wv).Count | Should-Be 1   # Get-A breaches; the script body does not
     }
     It 'honours the cognitive ceiling independently' {
         # Get-B has cognitive 3 (foreach + nested if); ceiling 2 should trip it.
@@ -122,7 +134,7 @@ Describe 'Test-PSComplexity' {
         try { Test-PSComplexity -Path $empty -Recurse } catch { $withRecurse = $_.Exception.Message }
 
         { Test-PSComplexity -Path $empty } | Should-Throw -ExceptionMessage '*-Recurse*'
-        $withRecurse | Should-NotBeNull
+        $withRecurse | Should-BeLikeString '*Measured no units*'
         $withRecurse | Should-NotBeLikeString '*-Recurse*'
     }
     It 'still passes over a real file that is within the ceilings' {
@@ -153,7 +165,7 @@ Describe 'Measure-PSComplexity - script-level code outside any function' {
         $p = Join-Path $script:work 'toplevel-if.ps1'
         Set-Content $p 'if ($env:CI) { "ci" } else { "local" }' -Encoding utf8
         $body = Measure-PSComplexity -Path $p | Where-Object Unit -eq '<script-body>'
-        @($body).Count   | Should-BeGreaterThan 0
+        @($body).Count   | Should-Be 1
         $body.Cyclomatic | Should-Be 2   # baseline 1 + the if
         $body.Cognitive  | Should-Be 2   # +1 the if, +1 the else branch
     }
@@ -236,7 +248,7 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         $wv = $null
         $recs = Measure-PSComplexity -Path $script:work -Recurse -WarningVariable wv -WarningAction SilentlyContinue
         # The real file inside it is still measured...
-        @($recs | Where-Object Unit -like 'Get-Inner*').Count | Should-BeGreaterThan 0
+        @($recs | Where-Object Unit -like 'Get-Inner*').Count | Should-Be 1
         # ...and the directory itself is never treated as a source file.
         @($recs | Where-Object File -eq $d).Count | Should-Be 0
         ($wv -join ' ') | Should-NotBeLikeString "*weird.ps1'*"

--- a/tests/SelfComplexity.Tests.ps1
+++ b/tests/SelfComplexity.Tests.ps1
@@ -9,6 +9,8 @@ BeforeAll {
 
 Describe 'Self complexity gate' {
     It 'measured its own units' {
+        # Deliberately NOT an exact count: this asserts that the gate below judged something,
+        # and a literal here would fail on every unrelated edit to src/ while proving no more.
         $script:units.Count | Should-BeGreaterThan 0
     }
     It 'has no unit over cyclomatic 15' {


### PR DESCRIPTION
Closes #13.

Two halves of one thing: the tests did not say what they meant, and the gate that judges the tests could not see most of the code.

## Tightening

Eleven assertions moved from "at least one" to the exact number — every value **measured from the fixture**, not reasoned about.

The proof they buy something isn't the diff. Injecting the duplicate-row defect #45 describes (emit every discovered file twice) fails **six tests that all passed** under the old form:

```
AGAINST THE DUPLICATE-ROW DEFECT: passed=63 failed=6
  CAUGHT: recurses a directory and finds nested files
  CAUGHT: measures a flat directory without -Recurse, and only that directory
  CAUGHT: gives a directory the same units with and without -Recurse ...
  CAUGHT: measures a directory whose name contains wildcard characters
  CAUGHT: still accepts a wildcard path that matches nothing literally
  CAUGHT: ignores a DIRECTORY whose name ends in .ps1
```

The strongest single change is the `-Recurse` hint test, which previously accepted *any* exception as long as it didn't mention `-Recurse`. It now requires the message that proves it threw for the right reason.

**One assertion deliberately stays loose**, with the reason beside it: `SelfComplexity`'s "measured its own units" asserts the gate judged *something*. A literal there would fail on every unrelated edit to `src/` and prove no more.

## Widening

The config gains `ConditionalBoundary`, `ConditionForcing` and `ReturnValue` — the three PSMutant runs on itself. `StringLiteral` stays off: high volume, low signal.

| | mutants | score |
|---|---|---|
| before | 54 | 100% |
| after widening | **125** | **95.2%** |
| after this PR | 122 | **100%** |

That is the issue in one table. An expression-only operator set cannot see a guard, an early return or a fencepost, so structural logic scored a vacuous 100%.

**Four survivors became tests**, each verified against the fixture first:

- a plain function is **not** a method boundary — `$this.Walk()` inside a function named `Walk` scores 0 rather than being read as method recursion
- a bare `break` adds nothing where a labelled one adds 1. **Paired deliberately** — the labelled case alone passes against a rule that counts every jump
- `$this.$m()` outside a class scores 0. A *dynamic* member name is the only shape where the name comparison below the guard cannot reject the node, so the guard is the only thing that can
- naming a file explicitly measures it **whatever its extension**, while the same file reached by directory scan does not

That last one was a real contract nobody had written down: the extension filter belongs to **discovery**, not to explicit naming.

## Two survivors fixed by restructuring, not by declaring them equivalent

The `-is [TypeExpressionAst]` guard and the `return $false` under it were unobservable — forcing the guard true *still* returns false, because a non-type expression has no `TypeName`. No test could ever have pinned them.

```powershell
return ($expr -is [System.Management.Automation.Language.TypeExpressionAst]) -and
    ($expr.TypeName.Name -eq $Method.Parent.Name)
```

Behaviour-identical (`-and` short-circuits exactly where the guard used to fall through), and the result **is** killable — the cross-class static test that already existed kills `-and -> -or`.

Checked rather than assumed, because trading unkillable mutants for an *unmutated* line would be a loss dressed as a win. The restructured region carries five mutants, all killed.

## Gates

74 tests (was 69) · self-mutation **100%, 122/122** · lint clean with no severity filter · complexity 3/2 for the restructured function · compatibility gate green under 5.7.1.
