### PR TITLE
ci: one analyzer script, one pins file, called by every gate

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -1,0 +1,28 @@
+# Single source of truth for the pinned dependencies every workflow installs.
+#
+# The versions used to be written out inline in three workflows, so they could drift apart
+# without anything noticing: the lint gate and the required code-scanning check could analyse
+# with different analyzers, and ConvertToSARIF was not pinned at all.
+#
+# Each workflow loads this file into $GITHUB_ENV immediately after checkout, then asserts
+# every key arrived. Format is KEY=value, one per line; no quoting, no expansion.
+#
+# NOT covered here: `uses:` action SHAs. A workflow's `uses:` cannot reference a variable, so
+# those stay written out in each file and have to be kept in step by hand. They are all
+# SHA-pinned with the version in a trailing comment.
+
+# The version the test estate is written against. Bump with CLAUDE.md.
+PESTER_VERSION=6.1.0
+
+# Deliberately NOT the version above: the compatibility gate proves a consumer on an older
+# Pester can still gate on this module, which needs a second one installed.
+PESTER_COMPAT_VERSION=5.7.1
+
+PSSA_VERSION=1.25.0
+PSMUTANT_VERSION=0.3.1
+CONVERTTOSARIF_VERSION=1.0.0
+
+# What PSScriptAnalyzer looks at. Shared so the lint gate and the code-scanning check cannot
+# disagree about scope: a finding in one and not the other is the least diagnosable kind of
+# red build, and code scanning is a required check.
+PSSA_PATHS=./src ./tests ./tools ./PSComplexity.psm1 ./PSComplexity.psd1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,46 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install pinned Pester + PSScriptAnalyzer
+      - name: Load pinned versions
         shell: pwsh
         run: |
-          Install-Module Pester -RequiredVersion 6.1.0 -Force -Scope CurrentUser
-          # The OLD Pester the compatibility gate proves consumers against. It must match the
-          # -PesterVersion passed below; both belong in a shared pins file (#26).
-          Install-Module Pester -RequiredVersion 5.7.1 -Force -Scope CurrentUser
-          Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
+          $required = 'PESTER_VERSION', 'PESTER_COMPAT_VERSION', 'PSSA_VERSION',
+                      'PSMUTANT_VERSION', 'CONVERTTOSARIF_VERSION', 'PSSA_PATHS'
+          $pins = @{}
+          foreach ($line in Get-Content .github/pins.env) {
+            $t = $line.Trim()
+            if (-not $t -or $t.StartsWith('#')) { continue }
+            $k, $v = $t -split '=', 2
+            $pins[$k.Trim()] = $v.Trim()
+          }
+          # Asserted, not assumed: a missing key would otherwise install "latest" or analyse
+          # nothing, and both look like a clean run.
+          foreach ($k in $required) {
+            if (-not $pins.ContainsKey($k) -or -not $pins[$k]) { throw ".github/pins.env is missing a value for $k" }
+          }
+          $pins.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" } |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "pins: $(($required | ForEach-Object { "$_=$($pins[$_])" }) -join '  ')"
+
+      - name: Install pinned modules
+        shell: pwsh
+        run: |
+          # Install only what is missing, then assert. An unconditional -Force collides with
+          # what the runner image already ships: the install warns "currently in use", carries
+          # on, and the tool then fails somewhere else entirely.
+          $wanted = @(
+            @{ Name = 'Pester';           Version = $env:PESTER_VERSION }
+            @{ Name = 'Pester';           Version = $env:PESTER_COMPAT_VERSION }
+            @{ Name = 'PSScriptAnalyzer'; Version = $env:PSSA_VERSION }
+          )
+          foreach ($w in $wanted) {
+            if (-not (Get-Module $w.Name -ListAvailable | Where-Object Version -eq $w.Version)) {
+              Install-Module $w.Name -RequiredVersion $w.Version -Force -Scope CurrentUser
+            }
+            if (-not (Get-Module $w.Name -ListAvailable | Where-Object Version -eq $w.Version)) {
+              throw "$($w.Name) $($w.Version) is not available after install"
+            }
+          }
 
       - name: Module manifest is valid + imports
         shell: pwsh
@@ -40,20 +72,20 @@ jobs:
         shell: pwsh
         run: ./tools/Test-PSCxRelease.ps1
 
+      # One committed script, called by this gate and by code-scanning.yml. Spelled out in
+      # both, they disagreed about severity and scope, so an Information finding failed
+      # nothing and blocked everything.
       - name: Lint (PSScriptAnalyzer)
         shell: pwsh
         run: |
-          $f = @()
-          foreach ($p in './src', './tests', './PSComplexity.psm1', './PSComplexity.psd1') {
-            $f += Invoke-ScriptAnalyzer -Path $p -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error, Warning
-          }
-          if ($f) { $f | Format-Table RuleName, ScriptName, Line, Message -AutoSize; throw "$($f.Count) lint finding(s)" }
+          $f = ./tools/Invoke-PSCxAnalyzer.ps1
+          if ($f) { $f | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize; throw "$($f.Count) lint finding(s)" }
           Write-Host 'Lint clean.'
 
       - name: Tests (reference scores + self-complexity gate)
         shell: pwsh
         run: |
-          Import-Module Pester -RequiredVersion 6.1.0 -Force
+          Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
           Import-Module ./PSComplexity.psd1 -Force
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'
@@ -71,9 +103,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh
         run: |
-          Install-Module PSMutant -RequiredVersion 0.3.1 -Force -Scope CurrentUser
-          Import-Module Pester -RequiredVersion 6.1.0 -Force
-          Import-Module PSMutant -RequiredVersion 0.3.1 -Force
+          if (-not (Get-Module PSMutant -ListAvailable | Where-Object Version -eq $env:PSMUTANT_VERSION)) {
+            Install-Module PSMutant -RequiredVersion $env:PSMUTANT_VERSION -Force -Scope CurrentUser
+          }
+          Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
+          Import-Module PSMutant -RequiredVersion $env:PSMUTANT_VERSION -Force
           $r = Invoke-PSMutation -ConfigFile ./psmutant.self.config.json -SourceRoot . -Quiet
           Write-Host "Self mutation score: $($r.Score)% ($($r.Killed)/$($r.Total))"
           if ($r.ExitCode -ne 0) { throw "Mutation score $($r.Score)% is below the break threshold" }
@@ -83,4 +117,4 @@ jobs:
       # separates "this Pester cannot run here" from "this module is broken".
       - name: Pester compatibility (a Pester 5 consumer)
         shell: pwsh
-        run: ./tools/Test-PSCxPesterCompatibility.ps1 -PesterVersion 5.7.1
+        run: ./tools/Test-PSCxPesterCompatibility.ps1 -PesterVersion $env:PESTER_COMPAT_VERSION

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -25,14 +25,51 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Load pinned versions
+        shell: pwsh
+        run: |
+          $required = 'PSSA_VERSION', 'CONVERTTOSARIF_VERSION', 'PSSA_PATHS'
+          $pins = @{}
+          foreach ($line in Get-Content .github/pins.env) {
+            $t = $line.Trim()
+            if (-not $t -or $t.StartsWith('#')) { continue }
+            $k, $v = $t -split '=', 2
+            $pins[$k.Trim()] = $v.Trim()
+          }
+          # Asserted, not assumed: a missing key would install "latest" or analyse nothing,
+          # and both look exactly like a clean run.
+          foreach ($k in $required) {
+            if (-not $pins.ContainsKey($k) -or -not $pins[$k]) { throw ".github/pins.env is missing a value for $k" }
+          }
+          $pins.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" } |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Install pinned modules
+        shell: pwsh
+        run: |
+          # ConvertToSARIF had no version at all: this required check could change behaviour
+          # on someone else's release, with no commit here to explain it.
+          $wanted = @(
+            @{ Name = 'PSScriptAnalyzer'; Version = $env:PSSA_VERSION }
+            @{ Name = 'ConvertToSARIF';   Version = $env:CONVERTTOSARIF_VERSION }
+          )
+          foreach ($w in $wanted) {
+            if (-not (Get-Module $w.Name -ListAvailable | Where-Object Version -eq $w.Version)) {
+              Install-Module $w.Name -RequiredVersion $w.Version -Force -Scope CurrentUser
+            }
+            if (-not (Get-Module $w.Name -ListAvailable | Where-Object Version -eq $w.Version)) {
+              throw "$($w.Name) $($w.Version) is not available after install"
+            }
+          }
+
+      # The SAME script the failing lint gate runs. Spelled out separately, the two
+      # disagreed about severity and scope, so a finding could block a merge here while
+      # passing there -- and code scanning is a required check, so it blocked silently.
       - name: Run PSScriptAnalyzer -> SARIF
         shell: pwsh
         run: |
-          Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
-          Install-Module ConvertToSARIF -Force -Scope CurrentUser
-          Import-Module ConvertToSARIF
-          Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 |
-            ConvertTo-SARIF -FilePath results.sarif
+          Import-Module ConvertToSARIF -RequiredVersion $env:CONVERTTOSARIF_VERSION
+          ./tools/Invoke-PSCxAnalyzer.ps1 | ConvertTo-SARIF -FilePath results.sarif
 
       - name: Upload SARIF to code scanning
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,22 +23,39 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Load pinned versions
+        shell: pwsh
+        run: |
+          $required = 'PESTER_VERSION', 'PSSA_VERSION'
+          $pins = @{}
+          foreach ($line in Get-Content .github/pins.env) {
+            $t = $line.Trim()
+            if (-not $t -or $t.StartsWith('#')) { continue }
+            $k, $v = $t -split '=', 2
+            $pins[$k.Trim()] = $v.Trim()
+          }
+          foreach ($k in $required) {
+            if (-not $pins.ContainsKey($k) -or -not $pins[$k]) { throw ".github/pins.env is missing a value for $k" }
+          }
+          $pins.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" } |
+            Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Install pinned Pester + PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module Pester -RequiredVersion 6.1.0 -Force -Scope CurrentUser
-          Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
+          Install-Module Pester -RequiredVersion $env:PESTER_VERSION -Force -Scope CurrentUser
+          Install-Module PSScriptAnalyzer -RequiredVersion $env:PSSA_VERSION -Force -Scope CurrentUser
 
       - name: Full quality gate (lint + tests + self-complexity)
         shell: pwsh
         run: |
-          $f = @()
-          foreach ($p in './src', './tests', './PSComplexity.psm1', './PSComplexity.psd1') {
-            $f += Invoke-ScriptAnalyzer -Path $p -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error, Warning
-          }
-          if ($f) { $f | Format-Table -AutoSize; throw "$($f.Count) lint finding(s) -- not publishing" }
+          # The same committed script ci.yml and code-scanning.yml run. This was a THIRD
+          # inline copy, and it carried the severity filter too -- so the release path could
+          # publish over a finding the required check was already blocking on.
+          $f = ./tools/Invoke-PSCxAnalyzer.ps1
+          if ($f) { $f | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize; throw "$($f.Count) lint finding(s) -- not publishing" }
           Import-Module ./PSComplexity.psd1 -Force
-          Import-Module Pester -RequiredVersion 6.1.0 -Force
+          Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
           $cfg = New-PesterConfiguration
           $cfg.Run.Path = './tests'; $cfg.Run.PassThru = $true; $cfg.Output.Verbosity = 'Normal'
           # Match ci.yml: the classic `Should -Be` form is an error, not a style note.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ A run that starts failing after this upgrade is the honest one.
   this module. The module has no Pester dependency, so the promise is cheap to keep and was
   previously not checked at all.
 - The mutation-gate step moves from PSMutant 0.1.0 to 0.3.1.
+- One committed analyzer script, `tools/Invoke-PSCxAnalyzer.ps1`, is now what all three
+  gates run. They had three separate inline copies, and two of them filtered to Error and
+  Warning while the required code-scanning check did not -- so an Information-severity
+  finding failed nothing and blocked everything.
+- Pinned versions move to `.github/pins.env`, loaded and asserted by each workflow.
+  `ConvertToSARIF` had no version pin at all.
 - The suite is fully on the Pester 6 `Should-*` assertions, and `Should.DisableV5 = $true` is
   set in both workflows so the classic `Should -Be` form is an **error** rather than a style
   note. Verified that the setting actually fires, in both directions.

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -154,3 +154,66 @@ Describe 'Get-PSCxReleaseFault' {
         @(Get-PSCxReleaseFault @a).Count | Should-Be 2
     }
 }
+
+Describe 'Get-PSCxPinValue' {
+    BeforeAll {
+        $script:Pins = @(
+            '# a comment'
+            ''
+            'PSSA_VERSION=1.25.0'
+            'PSSA_PATHS=./src ./tests ./tools'
+            '#PSSA_VERSION=9.9.9'
+            'ODD=a=b'
+        )
+    }
+
+    It 'reads a simple value' {
+        Get-PSCxPinValue -Line $script:Pins -Name 'PSSA_VERSION' | Should-Be '1.25.0'
+    }
+    It 'keeps a value containing spaces, because PSSA_PATHS is a list' {
+        Get-PSCxPinValue -Line $script:Pins -Name 'PSSA_PATHS' | Should-Be './src ./tests ./tools'
+    }
+    It 'splits on the FIRST equals only' {
+        # A value may legitimately contain one. Splitting on all of them silently truncates.
+        Get-PSCxPinValue -Line $script:Pins -Name 'ODD' | Should-Be 'a=b'
+    }
+    It 'ignores a commented-out key rather than reading it' {
+        # Paired with the first test: the same key appears commented below, and reading it
+        # would pin the analyzer to a version nobody chose.
+        Get-PSCxPinValue -Line $script:Pins -Name 'PSSA_VERSION' | Should-Be '1.25.0'
+    }
+    It 'matches the key in full' {
+        # PSSA_VERSION must not answer for PSSA, or a prefix silently wins.
+        Get-PSCxPinValue -Line $script:Pins -Name 'PSSA' | Should-BeNull
+    }
+    It 'returns null for a key that is not there' {
+        # The caller turns this into an error. If it returned an empty string instead, the
+        # analyzer gate would scan nothing and pass.
+        Get-PSCxPinValue -Line $script:Pins -Name 'NOPE' | Should-BeNull
+    }
+    It 'survives a file of only blank lines and comments' {
+        Get-PSCxPinValue -Line @('', '# x', '   ') -Name 'ANY' | Should-BeNull
+    }
+}
+
+Describe 'the pins file itself' {
+    It 'declares every key the workflows require' {
+        # The workflows assert this at run time; asserting it here means a missing pin fails
+        # in the suite rather than five minutes into a job.
+        $pins = Get-Content (Join-Path (Split-Path -Parent $PSScriptRoot) '.github/pins.env')
+        foreach ($k in 'PESTER_VERSION', 'PESTER_COMPAT_VERSION', 'PSSA_VERSION',
+            'PSMUTANT_VERSION', 'CONVERTTOSARIF_VERSION', 'PSSA_PATHS') {
+            Get-PSCxPinValue -Line $pins -Name $k | Should-NotBeNull -Because "pins.env must define $k"
+        }
+    }
+    It 'names only paths that exist' {
+        # An entry naming a moved directory makes the analyzer refuse rather than scan less,
+        # but only because it checks; this catches it a step earlier.
+        $root = Split-Path -Parent $PSScriptRoot
+        $pins = Get-Content (Join-Path $root '.github/pins.env')
+        foreach ($p in (Get-PSCxPinValue -Line $pins -Name 'PSSA_PATHS') -split ' ') {
+            Test-Path (Join-Path $root $p) | Should-BeTrue -Because "PSSA_PATHS names $p"
+        }
+    }
+}
+

--- a/tools/Invoke-PSCxAnalyzer.ps1
+++ b/tools/Invoke-PSCxAnalyzer.ps1
@@ -1,0 +1,79 @@
+# Run PSScriptAnalyzer the one way this project runs it, and return the findings.
+#
+# Two gates analyse this repo: the lint step in ci.yml, which FAILS the build, and
+# code-scanning.yml, which uploads SARIF and is a REQUIRED check. They each spelled the
+# invocation out inline and disagreed about both scope and severity -- ci.yml passed
+# `-Severity Error, Warning` over four paths, code scanning passed no filter over everything.
+#
+# So an Information-severity finding was invisible to the gate that fails and visible to the
+# gate that blocks: it passed lint locally and in CI, then surfaced where nobody was looking
+# and held the merge. There is now one definition of how the analyzer is invoked, and both
+# gates call it, so the class cannot come back by someone editing one workflow.
+#
+# Paths and the analyzer version come from .github/pins.env, read directly when the
+# environment does not already carry them, so running this by hand is identical to running it
+# in CI with no setup step.
+[CmdletBinding()]
+param(
+    # Defaults to PSSA_PATHS. Override only to analyse a subset while iterating; the gates
+    # must always run the full set.
+    [string[]]$Path,
+
+    # Defaults to PSSA_VERSION. The exact version matters: rules and their inference change
+    # between releases, so an unpinned analyzer can report a finding CI does not, or miss one
+    # it does.
+    [string]$AnalyzerVersion
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path -Path $PSScriptRoot -ChildPath 'ReleaseDecisions.ps1')
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Get-PSCxPin {
+    # One pinned value, preferring what the environment already holds.
+    #
+    # The workflows load pins.env into $env: after checkout, so in CI this reads the
+    # environment. Run by hand there is no such step, and falling back to the file is what
+    # stops a local run using a different analyzer, or a different path list, than the gate.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Name)
+
+    $fromEnv = [Environment]::GetEnvironmentVariable($Name)
+    if ($fromEnv) { return $fromEnv }
+
+    $pins = Join-Path -Path $repoRoot -ChildPath '.github/pins.env'
+    $value = Get-PSCxPinValue -Line (Get-Content -LiteralPath $pins) -Name $Name
+    if (-not $value) { throw "$Name is set neither in the environment nor in $pins." }
+    return $value
+}
+
+if (-not $Path) { $Path = (Get-PSCxPin -Name 'PSSA_PATHS') -split ' ' | Where-Object { $_ } }
+if (-not $AnalyzerVersion) { $AnalyzerVersion = Get-PSCxPin -Name 'PSSA_VERSION' }
+
+# Refuse to analyse nothing. Without this an empty or misparsed PSSA_PATHS makes both gates
+# report clean over zero files -- a lint gate that cannot fail, which looks exactly like a
+# lint gate with nothing to say. The same failure the module itself shipped with.
+if (@($Path).Count -eq 0) { throw 'No paths to analyse: PSSA_PATHS resolved to nothing.' }
+foreach ($p in $Path) {
+    if (-not (Test-Path -Path (Join-Path -Path $repoRoot -ChildPath $p))) {
+        throw "PSSA_PATHS names '$p', which does not exist under $repoRoot."
+    }
+}
+
+Import-Module PSScriptAnalyzer -RequiredVersion $AnalyzerVersion
+
+$settings = Join-Path -Path $repoRoot -ChildPath 'PSScriptAnalyzerSettings.psd1'
+
+# NO -Severity. Rules are excluded by name in the settings file, with a reason, which is a
+# decision someone made; a severity filter mutes a whole band nobody decided about. One
+# invocation, every rule, both gates.
+#
+# -Path takes a single item, so the loop is required rather than stylistic: passing the array
+# fails with "Cannot convert 'System.Object[]' to the type 'System.String'".
+$findings = $Path | ForEach-Object { Invoke-ScriptAnalyzer -Path $_ -Recurse -Settings $settings }
+
+# @() so a single finding is still a collection and callers can count it. No comma-wrap:
+# callers pipe this, and `, $array` would enter the pipeline as one item.
+return [object[]]@($findings)

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -144,3 +144,32 @@ function Get-PSCxRewrittenManifest {
     return [regex]::Replace($ManifestText, $pattern, { param($m) $m.Groups[1].Value + $literal }, 1)
 }
 
+
+function Get-PSCxPinValue {
+    # The value of one key in .github/pins.env, or $null when it is not there.
+    #
+    # A decision rather than plumbing, and the reason it is tested: the analyzer gate derives
+    # the paths it scans from PSSA_PATHS. A parser that quietly returns nothing makes that
+    # gate scan NOTHING and pass -- green, fast, and blind.
+    #
+    # Split on the FIRST '=' only. Values legitimately contain both '=' and spaces, since
+    # PSSA_PATHS is a space-separated list. Comment and blank lines are ignored, and the key
+    # must match in full so PSSA_VERSION does not answer for PSSA_VERSION_EXTRA.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        # AllowEmptyString as well as AllowEmptyCollection: pins.env has blank lines, and a
+        # Mandatory [string[]] otherwise refuses the whole file over one of them.
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$Line,
+        [Parameter(Mandatory)] [string]$Name
+    )
+    foreach ($l in $Line) {
+        $trimmed = $l.Trim()
+        if ($trimmed.StartsWith('#')) { continue }
+        $split = $trimmed.IndexOf('=')
+        if ($split -lt 1) { continue }
+        if ($trimmed.Substring(0, $split) -ne $Name) { continue }
+        return $trimmed.Substring($split + 1).Trim()
+    }
+    return $null
+}


### PR DESCRIPTION
Closes #19. Closes #26.

**Three** copies of the analyzer invocation existed, and they disagreed:

| Workflow | Severity | Scope |
|---|---|---|
| `ci.yml` (fails the build) | `-Severity Error, Warning` | 4 paths |
| `publish.yml` (blocks the release) | `-Severity Error, Warning` | 4 paths |
| `code-scanning.yml` (**required check**) | *(no filter)* | `.` |

So an Information-severity finding was **invisible where it would fail and visible where it would block**. It passed lint locally and in CI, then surfaced as a code scanning alert holding the merge, with no failing gate to explain why.

PSMutant hit exactly this twice in one PR (#76). I hit it twice in *this* session — every finding on the new `tools/` scripts landed in that band.

Dropping the filter fixes the instance. **One script all three gates call** is what stops the class, and it is the same argument that puts every other gate in `tools/`: an invocation spelled out in three places will eventually disagree with itself.

## It refuses to analyse nothing

The failure that looks exactly like success — an empty or misparsed `PSSA_PATHS` would have all three gates report clean over zero files. Both arms proved by running:

```
refused: No paths to analyse: PSSA_PATHS resolved to nothing.
refused: PSSA_PATHS names './does-not-exist', which does not exist under ...
```

## Pins move to `.github/pins.env`

Loaded into the environment by each workflow and asserted key by key. **`ConvertToSARIF` had no version pin at all**, so a required check could change behaviour on someone else's release with no commit here to explain it.

Modules are installed only when absent, then asserted present. An unconditional `-Force` collides with what the runner image ships: the install warns "currently in use", carries on, and the tool fails later somewhere unrelated.

`uses:` action SHAs deliberately stay inline — a workflow's `uses:` cannot reference a variable. `pins.env` says so rather than leaving the next reader to wonder.

## Nine tests

`Get-PSCxPinValue` is a **decision, not plumbing**: a parser that quietly returns nothing makes the analyzer scan nothing and pass. Pinned for first-equals-only splitting, full-key matching (so `PSSA` cannot answer for `PSSA_VERSION`), commented-out keys, and values containing spaces.

Two more assert the pins file itself declares every key the workflows require and names only paths that exist — failing in the suite rather than five minutes into a job.

## Gates

100 tests · analyzer clean over the full path set **at every severity** · release gate consistent · complexity and Pester 5 compatibility gates green.
