### PR TITLE
ci: measure the coverage this repo has been claiming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,13 @@ jobs:
           $r = Invoke-Pester -Configuration $cfg
           if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed" }
 
+      # A committed script, not a snippet here, so measuring by hand and measuring in CI
+      # cannot drift. The figure in CLAUDE.md was a claim nothing checked, and the one in
+      # CHANGELOG.md had been wrong for two releases.
+      - name: Coverage gate (100%)
+        shell: pwsh
+        run: ./tools/Measure-PSCxCoverage.ps1
+
       # Self-assess: mutation-test our own metric logic with our sibling module PSMutant,
       # gating on the score. (Linux only -- test quality is platform-independent.)
       - name: Self-assess (PSMutant mutation testing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ A run that starts failing after this upgrade is the honest one.
   logic against its reference-score suite, gated on the mutation score (~90%). The two
   Fortigi modules dogfood each other -- PSComplexity gates PSMutant's complexity, and
   PSMutant gates PSComplexity's test quality.
-- The self-mutation gate is now set at **100%**: coverage is 100% (167/167 commands) and
+- The self-mutation gate is now set at **100%**: coverage is 100% and
   every one of the 41 mutants is killed, with no mutant declared equivalent. From here a
   new survivor fails the build.
 
@@ -73,6 +73,9 @@ A run that starts failing after this upgrade is the honest one.
   finding failed nothing and blocked everything.
 - Pinned versions move to `.github/pins.env`, loaded and asserted by each workflow.
   `ConvertToSARIF` had no version pin at all.
+- A coverage gate: `tools/Measure-PSCxCoverage.ps1`, enforced at 100% in CI. The figure was
+  claimed in two places and measured by nobody, and the command count quoted in this file
+  had been wrong for two releases.
 - The suite is fully on the Pester 6 `Should-*` assertions, and `Should.DisableV5 = $true` is
   set in both workflows so the classic `Should -Be` form is an **error** rather than a style
   note. Verified that the setting actually fires, in both directions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,20 +34,21 @@ CI (`.github/workflows/ci.yml`) runs:
 | Complexity | **its own** `Test-PSComplexity` against `src/`, 15 / 15 per unit |
 | Self-mutation | PSMutant against `psmutant.self.config.json`, break = 100 |
 
-Measuring coverage here is straightforward — whole-directory works, and both Pester
-versions agree at 100% (they disagree on the analysed-command *denominator*, 201 vs 204,
-which is worth remembering when quoting a figure):
+Coverage is measured by one committed script, and it is enforced:
 
 ```powershell
-$c = New-PesterConfiguration
-$c.Run.Path = 'tests'; $c.Run.PassThru = $true
-$c.CodeCoverage.Enabled = $true; $c.CodeCoverage.Path = 'src'
-(Invoke-Pester -Configuration $c).CodeCoverage.CoveragePercent
+./tools/Measure-PSCxCoverage.ps1        # fails below 100%
 ```
 
-That simplicity is not luck: nothing here starts a nested Pester run. The sibling repo
-PSMutant does, and its coverage is unmeasurable in places as a result. If you ever add
-something that runs Pester from inside a test, expect the same problem.
+It is a script rather than a recipe in this file because a recipe cannot be run by CI: the
+figures here were a claim nobody checked, and the count quoted in `CHANGELOG.md` had been
+wrong for two releases. Do not quote a command count in prose — the script prints it.
+
+`UseBreakpoints` is set as a **hedge, not a fix**. In PSMutant it is load-bearing, because a
+nested Pester run tears down Pester 6's Profiler tracer and every file discovered afterwards
+reports a plausible near-zero. Measured here both ways on the same suite, the two agree
+exactly, because nothing in `tests/` starts a nested run. The setting costs a little speed
+and means a future test that does start one cannot quietly halve the number.
 
 **Pester version split**: CI pins 5.8.0, development happens on 6.1.0. This suite passes
 under both. Tracked in **#10**.

--- a/tools/Measure-PSCxCoverage.ps1
+++ b/tools/Measure-PSCxCoverage.ps1
@@ -1,0 +1,65 @@
+# Measure line coverage over src/ and fail below the required figure.
+#
+# A committed script rather than a few lines inside ci.yml, so that measuring by hand and
+# measuring in CI cannot drift. This project's coverage figure was folklore for exactly that
+# reason: CLAUDE.md claimed 100% and nothing measured it, while CHANGELOG.md quoted a command
+# count that had been wrong for two releases.
+#
+# UseBreakpoints is set as a HEDGE, not a fix. In the sibling repo it is load-bearing --
+# Pester 6 moved coverage to the Profiler tracer, and a nested Pester run tears that tracer
+# down, so every file discovered afterwards reports a plausible near-zero. Measured here both
+# ways on the same suite, the two agree exactly, because nothing in tests/ starts a nested
+# run. The setting costs a little speed and means a future test that does start one cannot
+# quietly halve the number.
+[CmdletBinding()]
+param(
+    # Percentage the run must reach. 100 because this module gates other people's code on a
+    # number, so its own numbers are the product.
+    [double]$Minimum = 100
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+
+$cfg = New-PesterConfiguration
+$cfg.Run.Path = Join-Path $root 'tests'
+$cfg.Run.PassThru = $true
+$cfg.Output.Verbosity = 'None'
+# Match the gates: the classic `Should -Be` form is an error here too, so coverage cannot be
+# measured over a suite that would fail the lint of its own assertions.
+$cfg.Should.DisableV5 = $true
+$cfg.CodeCoverage.Enabled = $true
+$cfg.CodeCoverage.UseBreakpoints = $true
+$cfg.CodeCoverage.Path = (Get-ChildItem (Join-Path $root 'src') -Filter *.ps1).FullName
+# Steer the XML to temp: Pester's default would drop a coverage.xml in the working tree on
+# every local run.
+$cfg.CodeCoverage.OutputPath = Join-Path ([System.IO.Path]::GetTempPath()) "pscx-coverage-$PID.xml"
+
+$result = Invoke-Pester -Configuration $cfg
+if ($result.FailedCount -gt 0) {
+    throw "$($result.FailedCount) test(s) failed; coverage over a red suite means nothing."
+}
+
+$covered = $result.CodeCoverage.CommandsExecuted
+$missed = $result.CodeCoverage.CommandsMissed
+$total = @($covered).Count + @($missed).Count
+
+# Refuse to report on nothing. An empty src/, or a Path that resolved to no files, would
+# otherwise divide by zero or report a clean 0/0 -- the same shape of failure this module
+# shipped with, where a gate that measured nothing reported success.
+if ($total -eq 0) { throw 'No commands were analysed: src/ resolved to no measurable files.' }
+
+@($covered) + @($missed) | Group-Object { Split-Path $_.File -Leaf } | Sort-Object Name |
+    ForEach-Object {
+        $hit = @($_.Group | Where-Object { $_.HitCount -gt 0 }).Count
+        Write-Output ('  {0,-30} {1,4}/{2,-5} {3,6:N1}%' -f $_.Name, $hit, $_.Count, (100 * $hit / $_.Count))
+    }
+@($missed) | Sort-Object File, Line | ForEach-Object {
+    Write-Output ('  UNCOVERED {0}:{1}  {2}' -f (Split-Path $_.File -Leaf), $_.Line, $_.Command)
+}
+
+$percent = 100 * @($covered).Count / $total
+Write-Output ("Coverage: {0:N2}% over {1} commands in src/" -f $percent, $total)
+if ($percent -lt $Minimum) {
+    throw ("Coverage {0:N2}% is below the required {1}%." -f $percent, $Minimum)
+}


### PR DESCRIPTION
Closes #27.

`CLAUDE.md` said *"100% line coverage"* and nothing measured it. `CHANGELOG.md` quoted *"167/167 commands"*, which had been wrong for two releases. Both were folklore, in a repo whose entire purpose is telling other people their numbers are not.

**The claim turns out to be true** — 100% over 216 commands, every file at 100%:

```
  Ast.ps1                          46/46     100,0%
  Cognitive.ps1                    81/81     100,0%
  Cyclomatic.ps1                   35/35     100,0%
  Measure-PSComplexity.ps1         54/54     100,0%
Coverage: 100,00% over 216 commands in src/
```

That is the good outcome and the least interesting part. What matters is that it is now measured by a committed script rather than asserted in prose, so by hand and in CI are the same run.

## Proved able to fail, in both arms

A coverage gate that cannot fail is exactly what is being replaced, so this was checked rather than assumed.

**Threshold arm** — raising the minimum above the actual figure throws.

**Measurement arm** — adding a function nothing calls:

```
  UNCOVERED Ast.ps1:159  if ($Node) { return 'yes' }
  UNCOVERED Ast.ps1:159  return 'yes'
  UNCOVERED Ast.ps1:160  return 'no'
Coverage: 98,63% over 219 commands in src/
Coverage 98,63% is below the required 100%.
```

It also **refuses to report on nothing** — an empty `src/`, or a path resolving to no files, would otherwise divide by zero or report a clean `0/0`, the same shape as the defect this module shipped with. And it refuses to report coverage over a **red suite**, since a percentage of a failing run describes nothing.

## `UseBreakpoints` is a hedge here, not a fix

In PSMutant it is load-bearing: a nested Pester run tears down Pester 6's Profiler tracer, and every file discovered afterwards reports a plausible near-zero. Measured here **both ways on the same suite, the two agree exactly**, because nothing in `tests/` starts a nested run.

So the comment says *hedge*. Importing a justification that does not apply is how a comment becomes decoration.

## Documentation

`CLAUDE.md` loses the prose recipe — a recipe cannot be run by CI, which is how the figures went wrong — and gains the one-line command plus an instruction not to quote a command count in prose. The script prints it.

## Gates

100 tests · coverage 100% over 216 commands · lint clean at every severity over the full path set · release gate consistent · complexity and Pester 5 compatibility gates green.
