### PR TITLE
ci: give every workflow a concurrency group, a timeout and least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A superseded run answers a question nobody is asking any more. Pushes to main are NOT
+# cancelled -- that history is the record of what main was green at.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Least privilege. The default token is write-scoped, and this job installs four modules
+# from the gallery and then executes them.
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -17,6 +28,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # A wedged runner otherwise holds a REQUIRED check pending for the six-hour default,
+    # blocking every merge behind it. The full matrix runs in about two minutes.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -40,6 +54,16 @@ jobs:
           $pins.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" } |
             Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "pins: $(($required | ForEach-Object { "$_=$($pins[$_])" }) -join '  ')"
+
+      # Keyed on the pinned versions, so a bump invalidates it rather than serving the
+      # previous ones. Windows and Linux keep separate caches: the module path differs.
+      - name: Cache pinned PowerShell modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.local/share/powershell/Modules
+            ~/Documents/PowerShell/Modules
+          key: psmodules-${{ runner.os }}-pester${{ env.PESTER_VERSION }}-${{ env.PESTER_COMPAT_VERSION }}-pssa${{ env.PSSA_VERSION }}-psmut${{ env.PSMUTANT_VERSION }}
 
       - name: Install pinned modules
         shell: pwsh

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -19,6 +19,9 @@ jobs:
   analyze:
     name: Analyze (PSScriptAnalyzer)
     runs-on: ubuntu-latest
+    # This is a REQUIRED check, so a wedged runner blocks merges until the six-hour default
+    # expires. The job takes well under a minute.
+    timeout-minutes: 15
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,21 @@ on:
         type: boolean
         default: true
 
+# NEVER cancel-in-progress here, unlike the other two. A superseded CI run is waste; a
+# half-finished publish is a gallery version that cannot be withdrawn. The group serialises
+# releases instead, so a second tag waits rather than racing the first.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+# Least privilege on the one job that holds the gallery key.
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ A run that starts failing after this upgrade is the honest one.
   finding failed nothing and blocked everything.
 - Pinned versions move to `.github/pins.env`, loaded and asserted by each workflow.
   `ConvertToSARIF` had no version pin at all.
+- Every workflow now declares a `concurrency` group, a `timeout-minutes` and a
+  least-privilege `permissions` block, and pinned modules are cached. `publish.yml`
+  deliberately does **not** cancel in progress: a half-finished publish is a gallery
+  version that cannot be withdrawn.
 - A coverage gate: `tools/Measure-PSCxCoverage.ps1`, enforced at 100% in CI. The figure was
   claimed in two places and measured by nobody, and the command count quoted in this file
   had been wrong for two releases.


### PR DESCRIPTION
Closes #25. Closes #31.

Three settings, and the reason each is not paperwork:

## Timeouts

**No workflow had one**, so the default is six hours. Both `ci.yml` and `code-scanning.yml` are **required** checks — a single wedged runner holds every merge in the repository until that expires. The full matrix takes about two minutes; the limits are 20, 15 and 25.

## Permissions

`ci.yml` and `publish.yml` ran with the repository default, which is a **write-scoped token**, while installing four modules from the gallery and executing them. Both are now `contents: read`. `publish.yml` matters most — it's the job holding the gallery key.

## Concurrency

`ci.yml` had none, so three pushes in quick succession meant three full chains where only the last result is ever read. Pull requests now cancel; pushes to `main` do **not**, because that history is the record of what `main` was green at.

**`publish.yml` is the one to think about rather than copy.** It must *never* cancel: a superseded CI run is waste, but a half-finished publish is a gallery version that cannot be withdrawn. Its group serialises releases instead, so a second tag waits rather than racing the first.

| | group | cancel-in-progress | timeout | permissions |
|---|---|---|---|---|
| `ci.yml` | `ci-${{ github.ref }}` | PRs only | 20 | `contents: read` |
| `code-scanning.yml` | `code-scanning-${{ github.ref }}` | PRs only | 15 | `+ security-events: write` |
| `publish.yml` | `publish` | **never** | 25 | `contents: read` |

## Also

The module cache #25 asks for, keyed on the pinned versions so a bump invalidates it rather than serving the previous ones, with separate paths for Windows and Linux because the module directory differs.

## Less was missing than the issue claimed

`code-scanning.yml` already had a concurrency group and a `security-events` permission. Only its timeout was absent. Recorded because the issue overstated the gap.

## Gates

All three workflows parse and carry all three settings · analyzer clean at every severity · coverage 100% over 216 commands · release gate consistent.
