### PR TITLE
ci: pin line endings so a checkout cannot change what a gate compares

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Git rewrites line endings on checkout, and a release gate here compares stored text against
+# text extracted from CHANGELOG.md. Under the default core.autocrlf the same commit reads LF
+# on a Linux runner and CRLF on a Windows machine, so an exact comparison answers a question
+# about the working copy rather than about the release. That bit the sibling repo: CI green,
+# gate red on every maintainer machine.
+#
+# This repo is not exposed to that today only because Get-PSCxConsumerNotes collapses the
+# block to a single line. eol=lf removes the cause rather than relying on that.
+#
+# The repository blobs were already LF, so this changes working copies rather than history.
+* text=auto eol=lf
+
+# Nothing binary is tracked today. Add entries here rather than relying on detection if that
+# changes: a file mis-detected as text is silently corrupted by normalisation.

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -54,6 +54,13 @@ function Get-PSCxConsumerNotes {
 
     # Collapse to one line: the manifest field is a single string, and a newline in it does
     # not survive being read back off the gallery page.
+    #
+    # It also keeps the release gate platform-independent, which is not obvious and is worth
+    # knowing before someone preserves the newlines here. Git rewrites line endings inside a
+    # stored string on checkout, so a multi-line value reads LF on a Linux runner and CRLF on
+    # a Windows one and an exact comparison then reports on the checkout rather than the
+    # release. That bit the sibling repo -- CI green, gate red on every maintainer machine.
+    # .gitattributes pins eol=lf so the cause is gone either way.
     $text = ($body -join ' ') -replace '\s+', ' '
     return $text.Trim()
 }


### PR DESCRIPTION
Git rewrites line endings on checkout. Where a stored string carries newlines as content — and a release gate compares that string against text extracted from `CHANGELOG.md` — the default `core.autocrlf` makes the same commit read LF on a Linux runner and CRLF on a Windows machine.

That happened in the sibling repo (Fortigi/PSMutant#120): **CI green, gate red on every maintainer machine**, which is the worse direction because the green is the one people trust.

## This repo is not exposed, and the reason is worth knowing

`Get-PSCxConsumerNotes` collapses the block to a **single line**, so no newline is ever stored. Verified rather than assumed — the gate passes on a CRLF working tree, and the stored notes contain no newline.

That immunity is accidental from a reader's point of view, so a comment now says so **at the collapse**. Someone preserving the newlines there would reopen the hole without touching the gate.

## What this changes

`* text=auto eol=lf`, so every checkout gets LF on every platform and the cause is gone. The repository blobs were already LF, so this changes working copies rather than history — `git add --renormalize .` stages no content and `git status` is clean afterwards.

## What this deliberately does not add

A line-ending guard in the comparison. It could not fire today, and **a rule that cannot fire looks exactly like one that passes** — the thing this project exists to distrust. `.gitattributes` removes the cause; the comment stops the cause being reintroduced by accident.

## Gates

100 tests · coverage 100% over 216 commands · analyzer clean at every severity · release gate consistent.