### PR TITLE
ci: require the merge gate to have passed, and load the package before shipping it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,11 @@ jobs:
           Install-Module Pester -RequiredVersion $env:PESTER_VERSION -Force -Scope CurrentUser
           Install-Module PSScriptAnalyzer -RequiredVersion $env:PSSA_VERSION -Force -Scope CurrentUser
 
-      - name: Full quality gate (lint + tests + self-complexity)
+      # NOT the full quality set, and it used to say it was. This runs lint and the tests;
+      # the merge gate additionally runs coverage, self-mutation, the Pester 5 compatibility
+      # guard and the whole chain on Windows. That is why the CI-conclusion check below
+      # exists -- this step is a fast fail, not the gate.
+      - name: Quick gate (lint + tests)
         shell: pwsh
         run: |
           # The same committed script ci.yml and code-scanning.yml run. This was a THIRD
@@ -74,6 +78,40 @@ jobs:
           $cfg.Should.DisableV5 = $true
           $r = Invoke-Pester -Configuration $cfg
           if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed -- not publishing" }
+
+      # The publish gate is a SUBSET of the merge gate -- it does not run self-mutation, the
+      # Pester 5 compatibility guard, or anything on Windows. Re-running a subset here is both
+      # slower and weaker than asking whether the run that did all of it passed for this exact
+      # commit. It also means every gate ci.yml gains later is inherited without editing this
+      # file, which is what stops the two drifting apart again.
+      - name: Require CI to have passed for this commit
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dryRun) }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $sha = '${{ github.sha }}'
+          $deadline = (Get-Date).AddMinutes(15)
+          # Tagging straight after a merge is the normal flow, so wait for the in-flight run
+          # rather than refusing it.
+          while ($true) {
+            $all = @(gh api "repos/${{ github.repository }}/commits/$sha/check-runs" --paginate --jq '.check_runs[] | "\(.name)=\(.status)/\(.conclusion)"')
+            # BOTH matrix legs must have passed. Selecting one would publish a tag that was
+            # never proven on the other platform, which is most of why the matrix exists.
+            $legs = @(gh api "repos/${{ github.repository }}/commits/$sha/check-runs" --paginate --jq '.check_runs[] | select(.name | startswith("test (")) | "\(.status)/\(.conclusion)"')
+            if ($legs.Count -ge 2 -and @($legs | Where-Object { $_ -ne 'completed/success' }).Count -eq 0) {
+              Write-Host "CI passed for $sha on all $($legs.Count) legs"; break
+            }
+            # Refuse at once on a definitive failure rather than waiting out the timeout.
+            if (@($legs | Where-Object { $_ -like 'completed/*' -and $_ -ne 'completed/success' }).Count -gt 0) {
+              throw "CI did not pass for $sha - $($legs -join ', '). Not publishing."
+            }
+            if ((Get-Date) -gt $deadline) {
+              throw "CI has not reported success for $sha within 15 minutes (saw: $($all -join ', ')). Not publishing."
+            }
+            Write-Host "waiting for CI on $sha ... (saw: $($all -join ', '))"
+            Start-Sleep -Seconds 30
+          }
 
       - name: Release consistency (ModuleVersion, CHANGELOG, ReleaseNotes)
         shell: pwsh
@@ -113,6 +151,29 @@ jobs:
               "already=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
+      # Staged as its OWN step so there is a seam to test. It used to be assembled inside the
+      # publish step and pushed in the same breath, which made the artifact that becomes
+      # permanent the one artifact nothing ever executed.
+      - name: Stage the module
+        if: steps.exists.outputs.already != 'true'
+        shell: pwsh
+        run: |
+          $stage = Join-Path ([System.IO.Path]::GetTempPath()) 'PSComplexity'
+          if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
+          New-Item -ItemType Directory -Path $stage -Force | Out-Null
+          # Publish-Module requires the folder to be named exactly like the module.
+          Copy-Item ./PSComplexity.psd1, ./PSComplexity.psm1, ./src, ./LICENSE, ./README.md -Destination $stage -Recurse -Force
+          "STAGE_DIR=$stage" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Get-ChildItem $stage | ForEach-Object { Write-Host "  staged: $($_.Name)" }
+
+      # Load the artifact that is about to become permanent and make it do its job: measure a
+      # fixture, pass a generous ceiling, FAIL a strict one, and refuse a path it measured
+      # nothing under. A gallery version cannot be withdrawn.
+      - name: Smoke-test the staged package
+        if: steps.exists.outputs.already != 'true'
+        shell: pwsh
+        run: ./tools/Test-PSCxPackage.ps1 -Path $env:STAGE_DIR
+
       - name: Publish to PSGallery
         if: steps.exists.outputs.already != 'true'
         shell: pwsh
@@ -121,10 +182,7 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dryRun }}
         run: |
           if (-not $env:PSGALLERY_API_KEY) { throw 'PSGALLERY_API_KEY secret is not set' }
-          $stage = Join-Path ([System.IO.Path]::GetTempPath()) 'PSComplexity'
-          if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
-          New-Item -ItemType Directory -Path $stage -Force | Out-Null
-          Copy-Item ./PSComplexity.psd1, ./PSComplexity.psm1, ./src, ./LICENSE, ./README.md -Destination $stage -Recurse -Force
+          $stage = $env:STAGE_DIR
 
           if ($env:DRY_RUN -eq 'true') {
               Write-Host '### DRY RUN -- Publish-Module -WhatIf ###' -ForegroundColor Yellow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ A run that starts failing after this upgrade is the honest one.
   least-privilege `permissions` block, and pinned modules are cached. `publish.yml`
   deliberately does **not** cancel in progress: a half-finished publish is a gallery
   version that cannot be withdrawn.
+- The publish path now requires the merge gate to have passed for the exact commit being
+  released, on **both** matrix legs, and loads the staged package before pushing it:
+  `tools/Test-PSCxPackage.ps1` imports it in a fresh process, measures a fixture, requires
+  the gate to fail a strict ceiling, and requires it to refuse a path it measured nothing
+  under.
 - A coverage gate: `tools/Measure-PSCxCoverage.ps1`, enforced at 100% in CI. The figure was
   claimed in two places and measured by nobody, and the command count quoted in this file
   had been wrong for two releases.

--- a/tools/Test-PSCxPackage.ps1
+++ b/tools/Test-PSCxPackage.ps1
@@ -1,0 +1,99 @@
+# Smoke-test a STAGED package before it becomes permanent.
+#
+# A gallery version cannot be withdrawn, only unlisted, and the staged folder was the one
+# artifact nothing ever executed: it was assembled inside the publish step and pushed in the
+# same breath, so nothing imported it, resolved its exports, or ran a single measurement
+# against it.
+#
+# Four things are checked, and the fourth is the point:
+#   1. the manifest is present and parses
+#   2. every shipped src file is actually dot-sourced by the .psm1
+#   3. the package imports in a FRESH process and both commands resolve
+#   4. a real measurement over a throwaway fixture is correct AND still able to FAIL
+[CmdletBinding()]
+param([Parameter(Mandatory)] [string]$Path)
+
+$ErrorActionPreference = 'Stop'
+$stage = (Resolve-Path -LiteralPath $Path).Path
+
+# --- 1. the manifest ---------------------------------------------------------------------
+$manifestPath = Join-Path $stage 'PSComplexity.psd1'
+if (-not (Test-Path -LiteralPath $manifestPath)) { throw "No PSComplexity.psd1 in the staged package at $stage" }
+$manifest = Import-PowerShellDataFile -LiteralPath $manifestPath
+Write-Output "  manifest: $($manifest.ModuleVersion)"
+
+# --- 2. every shipped source file is loaded ----------------------------------------------
+# Copy-Item ./src -Recurse ships every file; the .psm1 dot-sources an EXPLICIT list. A file
+# in the first and not the second imports cleanly and is silently missing its functions,
+# which cannot be fixed once published.
+$psm1 = Get-Content -LiteralPath (Join-Path $stage 'PSComplexity.psm1') -Raw
+$orphans = Get-ChildItem -LiteralPath (Join-Path $stage 'src') -Filter *.ps1 |
+    Where-Object { $psm1 -notmatch [regex]::Escape($_.Name) } |
+    ForEach-Object { $_.Name }
+if ($orphans) {
+    throw ("These files ship in the package but are never dot-sourced by PSComplexity.psm1: " +
+        ($orphans -join ', '))
+}
+Write-Output "  all $((Get-ChildItem -LiteralPath (Join-Path $stage 'src') -Filter *.ps1).Count) shipped src files are dot-sourced"
+
+# --- 3 and 4. import in a FRESH process and measure for real ------------------------------
+# A fresh process, because importing here is indistinguishable from the repo copy already
+# loaded in this session -- and "it worked on my machine, where the real one was loaded" is
+# precisely how a broken package ships.
+$fixture = Join-Path ([System.IO.Path]::GetTempPath()) "pscx-pkg-$([System.Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+try {
+    Set-Content -LiteralPath (Join-Path $fixture 'Sample.ps1') `
+        'function Get-Sample { param($x) if ($x) { 1 } else { 2 } }' -Encoding utf8
+
+    $child = {
+        param($ManifestPath, $Fixture)
+        $ErrorActionPreference = 'Stop'
+        Import-Module $ManifestPath -Force
+
+        foreach ($name in 'Measure-PSComplexity', 'Test-PSComplexity') {
+            if (-not (Get-Command $name -ErrorAction SilentlyContinue)) { throw "$name does not resolve from the package" }
+        }
+
+        # A flat directory with NO -Recurse. This exact call measured zero files before
+        # 0.2.1, so the package that ships must not be able to do it again.
+        $units = @(Measure-PSComplexity -Path $Fixture)
+        if ($units.Count -lt 2) { throw "Measured $($units.Count) units; expected the function and the script body" }
+        $sample = $units | Where-Object Unit -eq 'Get-Sample'
+        if ($sample.Cyclomatic -ne 2) { throw "Get-Sample cyclomatic is $($sample.Cyclomatic), expected 2" }
+
+        # The gate must PASS generous ceilings and FAIL strict ones. One outcome proves
+        # nothing: a gate wired to return $true always satisfies the first half.
+        if (-not (Test-PSComplexity -Path $Fixture)) { throw 'Gate failed code that is within the ceilings' }
+        if (Test-PSComplexity -Path $Fixture -MaxCyclomatic 1 -MaxCognitive 1 -WarningAction SilentlyContinue) {
+            throw 'Gate PASSED code that breaches the ceilings -- the shipped package cannot fail'
+        }
+
+        # And it must refuse to vouch for nothing, which is the other half of the same bug.
+        #
+        # The MESSAGE is asserted, not merely that something threw. This child runs with
+        # ErrorActionPreference Stop, so the missing directory makes Get-ChildItem terminate
+        # first -- a bare catch would be satisfied by that and would still pass with the
+        # refusal removed. A directory that EXISTS and simply holds no PowerShell is the
+        # case that isolates it.
+        $empty = Join-Path $Fixture 'no-powershell-here'
+        New-Item -ItemType Directory -Path $empty -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $empty 'notes.txt') 'not powershell' -Encoding utf8
+        $refusal = $null
+        try { Test-PSComplexity -Path $empty } catch { $refusal = $_.Exception.Message }
+        if ($refusal -notlike '*Measured no units*') {
+            throw "Gate did not refuse a path it measured nothing under (got: $refusal)"
+        }
+
+        'ok'
+    }
+
+    $out = & (Get-Process -Id $PID).Path -NoProfile -Command "& { $child } '$manifestPath' '$fixture'"
+    if ($LASTEXITCODE -ne 0 -or $out -notcontains 'ok') {
+        throw "Staged package failed its smoke test: $($out -join ' ')"
+    }
+    Write-Output '  imported in a fresh process; measured, gated and refused correctly'
+}
+finally { Remove-Item -LiteralPath $fixture -Recurse -Force -ErrorAction SilentlyContinue }
+
+Write-Output 'Staged package smoke test passed.'


### PR DESCRIPTION
Closes #53. Closes #23.

The publish path ran a **subset** of the merge gate, and its header comment claimed the opposite:

| | `ci.yml` | `publish.yml` (before) |
|---|---|---|
| Lint | ✓ | ✓ |
| Tests + self-complexity | ✓ | ✓ |
| Coverage | ✓ | ✗ |
| Self-mutation | ✓ | ✗ |
| Pester 5 compatibility | ✓ | ✗ |
| Windows | ✓ | ✗ |

So a tag could ship having never been mutation-tested, never proven against an older Pester, and never run on Windows — while the comment above it said *"the FULL quality set"*.

## Ask, don't re-run

Rather than copy those gates here, the run now asks whether **the run that already did all of them** passed for this exact commit. Faster, stronger, and every gate `ci.yml` gains later is inherited without editing this file — which is what stops the two drifting apart again. The local step is renamed to what it is: a **quick gate**, a fast fail, not the gate.

**Both matrix legs must have passed, not one.** Selecting a single leg would publish a tag never proven on the other platform, which is most of why the matrix exists.

## Load the artifact before it becomes permanent

The staged folder was assembled *inside* the publish step and pushed in the same breath — the artifact that becomes permanent was the one artifact nothing ever executed. Staging is now its own step, so there is a seam, and `tools/Test-PSCxPackage.ps1` runs in it.

Four checks. The fourth is the point: the package must measure a fixture correctly, **pass** a generous ceiling, **fail** a strict one, and **refuse** a path it measured nothing under. One outcome proves nothing — a gate wired to return `$true` satisfies the first half on its own.

## Proved against three broken packages

| Broken staging | Result |
|---|---|
| a file shipped but never dot-sourced by the `.psm1` | caught |
| manifest missing | caught |
| the empty-selection refusal deleted from the staged copy | **caught** |

That last is exactly the defect 0.2.1 fixes, so the gate proves the shipped artifact cannot regress it.

## A flaw in my own test, found while writing it

The child process runs with `$ErrorActionPreference = 'Stop'`, so pointing at a **missing** directory made `Get-ChildItem` terminate first — a bare `catch` was satisfied by the wrong error and would have passed with the refusal removed. It now uses a directory that **exists and holds no PowerShell**, and asserts the message.

## Gates

100 tests · coverage 100% over 216 commands · lint clean at every severity · release gate consistent · package smoke test green against a real staging.
