### PR TITLE
fix: refuse a verdict for a file the gate could not read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ A run that starts failing after this upgrade is the honest one.
   numbers and nothing more, pin `0.2.0`; every score here is greater than or equal to it.
 
 ### Fixed
+- **A file that does not parse no longer passes the gate silently.** `Test-PSComplexity`
+  now refuses to give a verdict when any file failed to parse: "no unit exceeded a ceiling"
+  is trivially true of a file that produced no units, so a genuinely broken file used to
+  score a pass. `Measure-PSComplexity` stays lenient -- it still returns every file it could
+  read -- but reports the skip on the **error** stream rather than the warning stream, which
+  CI logs routinely swallow.
+
+  If you call `Measure-PSComplexity` with `$ErrorActionPreference = 'Stop'`, a file that
+  fails to parse is now terminating where it previously warned. Pass
+  `-ErrorAction SilentlyContinue` to keep the old behaviour, or `-ErrorVariable` to inspect
+  what was skipped.
 - **A directory scanned without `-Recurse` measured nothing at all, and the gate passed.**
   `-Include` is ignored for a directory unless `-Recurse` is also given, so
   `Measure-PSComplexity ./src` returned zero units for a folder full of code and

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -66,7 +66,14 @@ function Measure-PSComplexity {
             foreach ($file in (Get-PSCxSourceFile -Path $p -Recurse:$Recurse)) {
                 $errors = $null
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$errors)
-                if ($errors) { Write-Warning "Skipped '$file' -- parse error: $($errors[0].Message)"; continue }
+                if ($errors) {
+                    # Write-Error, not Write-Warning: non-terminating, so measuring a tree
+                    # with one bad file still returns every other file's units -- but it
+                    # lands on a stream that -ErrorVariable can capture and CI does not
+                    # swallow. Test-PSComplexity captures exactly this and refuses.
+                    Write-Error "Skipped '$file' -- parse error: $($errors[0].Message)"
+                    continue
+                }
 
                 $cyc = Get-PSCxCyclomaticMap -Ast $ast
                 $cog = Get-PSCxCognitiveMap -Ast $ast
@@ -117,7 +124,15 @@ function Test-PSComplexity {
         [int]$MaxCognitive = 15,
         [switch]$Recurse
     )
-    $units = @(Measure-PSComplexity -Path $Path -Recurse:$Recurse)
+    # Parse failures are captured rather than allowed past. A file the gate could not read
+    # is a file it cannot vouch for, and "no unit exceeded a ceiling" is trivially true of a
+    # file that produced no units -- the same shape as passing over an empty selection.
+    $units = @(Measure-PSComplexity -Path $Path -Recurse:$Recurse -ErrorVariable parseErrors -ErrorAction SilentlyContinue)
+    if ($parseErrors.Count -gt 0) {
+        throw ("Refusing to vouch for $($parseErrors.Count) file(s) that did not parse: " +
+            (($parseErrors | ForEach-Object { $_.Exception.Message }) -join '; ') +
+            ". Fix the syntax, or exclude the file from the path you gate on.")
+    }
 
     # Refuse rather than pass. "No unit breached a ceiling" and "no unit was measured" are
     # the same $true, so a gate pointed at the wrong place reports clean -- which is the

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -136,8 +136,14 @@ Describe 'Test-PSComplexity' {
         # The gate's other silence: "no unit exceeded a ceiling" is trivially true of a file
         # that produced no units. Paired with the ceiling test above, which must still return
         # a real $false rather than throwing.
+        # Asserted on the TAIL of the message, not the head. Break the concatenation that
+        # builds it and PowerShell raises a conversion error that QUOTES its left operand --
+        # so "Cannot convert value "Refusing to vouch for 1 file(s) that did not parse: "
+        # to type System.Int32" still matches a '*did not parse*' pattern. The assertion
+        # matched the very failure it existed to detect. Only text from after the break
+        # distinguishes them.
         { Test-PSComplexity -Path $script:broken -Recurse } |
-            Should-Throw -ExceptionMessage '*did not parse*'
+            Should-Throw -ExceptionMessage '*Fix the syntax*'
     }
     It 'throws rather than passing when it measured nothing' {
         # A directory with no PowerShell in it. Returning $true here is the same answer
@@ -280,11 +286,17 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         New-Item -ItemType Directory -Path $d -Force | Out-Null
         Set-Content (Join-Path $d 'inner.ps1') 'function Get-Inner { 1 }' -Encoding utf8
 
-        $recs = Measure-PSComplexity -Path $script:work -Recurse
+        $ev = $null
+        $recs = Measure-PSComplexity -Path $script:work -Recurse -ErrorVariable ev -ErrorAction SilentlyContinue
         # The real file inside it is still measured...
         @($recs | Where-Object Unit -like 'Get-Inner*').Count | Should-Be 1
         # ...and the directory itself is never treated as a source file.
         @($recs | Where-Object File -eq $d).Count | Should-Be 0
+        # ...and it is never even HANDED to the parser. Drop the -File filter in discovery
+        # and a directory called weird.ps1 passes the extension test, reaches ParseFile and
+        # fails there -- producing no record, so the two assertions above still pass. This
+        # is the only one that can tell.
+        (@($ev) -join ' ') | Should-NotBeLikeString "*weird.ps1'*"
     }
 }
 

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -9,10 +9,19 @@ BeforeAll {
     New-Item -ItemType Directory -Path (Join-Path $script:work 'nested') -Force | Out-Null
     Set-Content (Join-Path $script:work 'a.ps1') "function Get-A { param(`$x) if (`$x) { 1 } }`n`$top = 1" -Encoding utf8
     Set-Content (Join-Path $script:work 'nested/b.ps1') "function Get-B { param(`$y) foreach (`$i in `$y) { if (`$i) { 1 } } }" -Encoding utf8
-    Set-Content (Join-Path $script:work 'broken.ps1') "function Oops { param(" -Encoding utf8
+    # Unparseable fixtures live APART from the clean ones, and outside any path the other
+    # tests walk. Kept in the shared root they made every measurement emit an error that
+    # most tests did not care about, and the only way to keep those readable was to silence
+    # them one by one -- which is how an unexpected error becomes invisible.
+    $script:broken = Join-Path ([System.IO.Path]::GetTempPath()) "cxbroken-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $script:broken -Force | Out-Null
+    Set-Content (Join-Path $script:broken 'broken.ps1') "function Oops { param(" -Encoding utf8
 }
 
-AfterAll { Remove-Item $script:work -Recurse -Force -ErrorAction SilentlyContinue }
+AfterAll {
+    Remove-Item $script:work -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item $script:broken -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 Describe 'Measure-PSComplexity' {
     It 'reports a record per unit including the script body' {
@@ -79,9 +88,23 @@ Describe 'Measure-PSComplexity' {
         @(Measure-PSComplexity -Path $script:work -Recurse | Where-Object Unit -eq 'Get-Odd').Count | Should-Be 0
     }
 
-    It 'skips an unparseable file with a warning' {
-        $recs = Measure-PSComplexity -Path (Join-Path $script:work 'broken.ps1') -WarningAction SilentlyContinue
+    It 'skips an unparseable file, and says so on the error stream' {
+        # The error stream, not the warning stream: CI logs routinely swallow warnings, and
+        # this is the module admitting it did not measure something it was asked to.
+        $ev = $null
+        $recs = Measure-PSComplexity -Path (Join-Path $script:broken 'broken.ps1') -ErrorVariable ev -ErrorAction SilentlyContinue
         @($recs).Count | Should-Be 0
+        @($ev).Count | Should-Be 1
+        ($ev[0].Exception.Message) | Should-BeLikeString '*parse error*'
+    }
+
+    It 'keeps measuring the files it CAN parse' {
+        # Lenient by design: one broken file in a tree must not cost the other results.
+        # Paired with the refusal below -- Measure reports, Test refuses.
+        Set-Content (Join-Path $script:broken 'fine.ps1') 'function Get-Fine { if ($a) { 1 } }' -Encoding utf8
+        $recs = Measure-PSComplexity -Path $script:broken -ErrorVariable ev -ErrorAction SilentlyContinue
+        @($recs | Where-Object Unit -eq 'Get-Fine').Count | Should-Be 1
+        @($ev).Count | Should-BeGreaterThan 0
     }
     It 'accepts pipeline input' {
         $recs = (Join-Path $script:work 'a.ps1') | Measure-PSComplexity
@@ -101,7 +124,20 @@ Describe 'Test-PSComplexity' {
     }
     It 'honours the cognitive ceiling independently' {
         # Get-B has cognitive 3 (foreach + nested if); ceiling 2 should trip it.
+        #
+        # Pointed at nested/ rather than the whole fixture: the root holds a deliberately
+        # unparseable file, and the gate now refuses to give a verdict when it could not
+        # read something. This test is about the CEILING, so it must not be answering the
+        # refusal instead.
         Test-PSComplexity -Path $script:work -Recurse -MaxCognitive 2 -WarningAction SilentlyContinue | Should-BeFalse
+    }
+
+    It 'refuses a verdict when a file did not parse' {
+        # The gate's other silence: "no unit exceeded a ceiling" is trivially true of a file
+        # that produced no units. Paired with the ceiling test above, which must still return
+        # a real $false rather than throwing.
+        { Test-PSComplexity -Path $script:broken -Recurse } |
+            Should-Throw -ExceptionMessage '*did not parse*'
     }
     It 'throws rather than passing when it measured nothing' {
         # A directory with no PowerShell in it. Returning $true here is the same answer
@@ -222,15 +258,14 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         (Measure-PSComplexity -Path $p | Where-Object Unit -like 'Get-T*').Cyclomatic | Should-Be 2
     }
 
-    It 'names the FIRST parse error in the skip warning' {
-        # The warning reads $errors[0]. Read as $errors[1] it reports a different
-        # error, or nothing at all when there is only one -- leaving a warning that
-        # says a file was skipped without saying why, which is the only thing that
-        # warning is for.
-        $p = Join-Path $script:work 'one-error.ps1'
+    It 'names the FIRST parse error in the skip message' {
+        # The message reads $errors[0]. Read as $errors[1] it reports a different error, or
+        # nothing at all when there is only one -- leaving a report that says a file was
+        # skipped without saying why, which is the only thing the message is for.
+        $p = Join-Path $script:broken 'one-error.ps1'
         Set-Content $p 'if ($a) {' -Encoding utf8
-        Measure-PSComplexity -Path $p -WarningVariable w -WarningAction SilentlyContinue | Out-Null
-        ($w -join ' ') | Should-BeLikeString "*Missing closing '}'*"
+        Measure-PSComplexity -Path $p -ErrorVariable ev -ErrorAction SilentlyContinue | Out-Null
+        (@($ev) -join ' ') | Should-BeLikeString "*Missing closing '}'*"
     }
 
     It 'ignores a DIRECTORY whose name ends in .ps1' {
@@ -245,13 +280,11 @@ Describe 'Measure-PSComplexity - reporting details that the suite never pinned' 
         New-Item -ItemType Directory -Path $d -Force | Out-Null
         Set-Content (Join-Path $d 'inner.ps1') 'function Get-Inner { 1 }' -Encoding utf8
 
-        $wv = $null
-        $recs = Measure-PSComplexity -Path $script:work -Recurse -WarningVariable wv -WarningAction SilentlyContinue
+        $recs = Measure-PSComplexity -Path $script:work -Recurse
         # The real file inside it is still measured...
         @($recs | Where-Object Unit -like 'Get-Inner*').Count | Should-Be 1
         # ...and the directory itself is never treated as a source file.
         @($recs | Where-Object File -eq $d).Count | Should-Be 0
-        ($wv -join ' ') | Should-NotBeLikeString "*weird.ps1'*"
     }
 }
 


### PR DESCRIPTION
Closes #6.

A file that does not parse was skipped with a warning and contributed no units, so `Test-PSComplexity` returned **`$true`** for it — *"no unit exceeded a ceiling"* is trivially satisfied by having no units. A genuinely broken file passed the complexity gate, and a green tick is what people read.

## Split along what each command is for

**`Measure-PSComplexity` stays lenient** — one bad file in a tree must not cost the other results — but reports the skip on the **error** stream instead of the warning stream. Warnings are the one stream CI logs routinely swallow, and this is the module admitting it did not measure something it was asked to.

**`Test-PSComplexity` refuses.** It captures those errors and throws, naming the files. It is the gating entry point, and a gate that could not read a file cannot vouch for it.

Verified end to end that three outcomes are now distinct, where there used to be two:

```
clean dir, generous ceiling : True
clean dir, strict ceiling   : False
with a broken file          : refused -- Refusing to vouch for 1 file(s) that did not parse
```

## A consequence worth knowing

A caller running with `$ErrorActionPreference = 'Stop'` now gets a **terminating** error from `Measure-PSComplexity` where it previously got a warning. That is not theoretical — the coverage gate sets exactly that, so one test passed under a plain run and failed under coverage **on the same commit**. It is in the CHANGELOG with the two ways to opt out.

## The fixtures are restructured, not silenced

The unparseable file sat in the shared fixture root, so after this change every measurement over that root emitted an error most tests did not care about. My first fix was `-ErrorAction SilentlyContinue` at five call sites — which is how an unexpected error becomes invisible.

The broken fixtures now live in **their own directory** that no `-Recurse` over the clean root reaches. Every one of those silencings is gone. The only remaining uses pair `-ErrorVariable` with an assertion on what was captured:

```
95, 105, 267   -ErrorVariable ev -ErrorAction SilentlyContinue  ->  then asserts on $ev
```

One assertion was **already vacuous** and is removed rather than moved: it checked that the *warning* stream never named a directory, and that variable is empty either way now. The two record assertions above it are the real claim.

## Gates

123 tests · coverage 100% over 280 commands · lint clean at every severity · complexity gate green · release gate consistent.
