### PR TITLE
fix: emit rows in source order rather than hashtable order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ A run that starts failing after this upgrade is the honest one.
   fails to parse is now terminating where it previously warned. Pass
   `-ErrorAction SilentlyContinue` to keep the old behaviour, or `-ErrorVariable` to inspect
   what was skipped.
+- **Rows are emitted in source order.** They came back in .NET hashtable order, which follows
+  bucket layout rather than insertion or line position and is not required to be stable, so
+  two runs over one unchanged file could differ. Units within a file now sort by start line,
+  with the unit name breaking a same-line tie.
 - **A directory scanned without `-Recurse` measured nothing at all, and the gate passed.**
   `-Include` is ignored for a directory unless `-Recurse` is also given, so
   `Measure-PSComplexity ./src` returned zero units for a folder full of code and

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -78,7 +78,18 @@ function Measure-PSComplexity {
                 $cyc = Get-PSCxCyclomaticMap -Ast $ast
                 $cog = Get-PSCxCognitiveMap -Ast $ast
                 $lines = Get-PSCxUnitTable -Ast $ast
-                foreach ($k in $lines.Keys) {
+                # Source order, not hashtable order. .NET enumerates a hashtable by bucket
+                # layout, which is neither insertion nor line order and is not required to
+                # be stable -- so two runs over one unchanged file could emit the same rows
+                # in different sequences. Nothing here noticed, because the gate takes a
+                # max and a human reads a table; a committed baseline or a diffed report
+                # would have.
+                #
+                # Line first, then unit name: two units CAN start on the same line
+                # (`function A { } function B { }`), and a tie left unbroken puts the
+                # nondeterminism straight back.
+                $ordered = $lines.Keys | Sort-Object @{ Expression = { $lines[$_] } }, @{ Expression = { $_ } }
+                foreach ($k in $ordered) {
                     [pscustomobject]@{
                         File       = $file
                         Unit       = ($k -replace '@\d+$', '')

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -29,6 +29,34 @@ Describe 'Measure-PSComplexity' {
         ($recs | Where-Object Unit -eq 'Get-A').Cyclomatic | Should-Be 2
         @($recs | Where-Object Unit -eq '<script-body>').Count | Should-Be 1
     }
+    It 'emits units in SOURCE order, not hashtable order' {
+        # The names are deliberately anti-alphabetical, and the hashtable happens to
+        # enumerate them Alpha, Mike, <script-body>, Zulu -- neither source order nor
+        # alphabetical, and not required to be stable at all.
+        #
+        # JOINED and compared as a string: Should-BeCollection ignores order and has no
+        # switch to make it strict, so it would pass against every permutation -- which is
+        # the entire claim being made here.
+        $f = Join-Path $script:work 'order.ps1'
+        Set-Content $f @'
+$top = 1
+function Zulu { if ($a) { 1 } }
+function Alpha { if ($b) { 1 } }
+function Mike { if ($c) { 1 } }
+'@ -Encoding utf8
+        ((Measure-PSComplexity -Path $f | ForEach-Object Unit) -join ',') |
+            Should-Be '<script-body>,Zulu,Alpha,Mike'
+    }
+
+    It 'breaks a same-line tie by unit name, so the order is total' {
+        # Two units CAN start on one line. A tie left unbroken puts the nondeterminism
+        # straight back, in the one case a line-number sort cannot separate.
+        $f = Join-Path $script:work 'sameline.ps1'
+        Set-Content $f 'function Beta { if ($a) { 1 } } function Alfa { if ($b) { 1 } }' -Encoding utf8
+        ((Measure-PSComplexity -Path $f | Where-Object Unit -ne '<script-body>' | ForEach-Object Unit) -join ',') |
+            Should-Be 'Alfa,Beta'
+    }
+
     It 'reports Cyclomatic 1 / Cognitive 0 for a decision-free unit' {
         $flat = Join-Path $script:work 'flat.ps1'
         Set-Content $flat 'function Get-Flat { param($x) $x }' -Encoding utf8


### PR DESCRIPTION
Closes #43.

Units came back in .NET **hashtable order** — bucket layout, neither insertion order nor line position, and not required to be stable at all. Two runs over one unchanged file could emit the same rows in different sequences.

Demonstrated rather than argued, on a fixture whose names are deliberately anti-alphabetical:

```
before:  Alpha -> Mike -> <script-body> -> Zulu
after:   <script-body> -> Zulu -> Alpha -> Mike
```

The "before" is neither source order **nor** alphabetical, which is what makes it hard to notice — it looks arbitrary because it is.

## Why nothing caught it

Nothing yet **diffs** two runs. The gate takes a max, and a max does not care about order; a human reads a table and does not remember the last one.

It stops being invisible the moment anything compares runs — a committed baseline (#2), a JSON report (#5), or a diff-scoped scan (#7) — and by then the order is written into a file somebody has committed.

## Line first, then unit name

Two units can legitimately start on the same line (`function A { } function B { }`). A tie left unbroken puts the nondeterminism straight back in the one case a line sort cannot separate. Both have a test.

The order test **joins** the units and compares one string: `Should-BeCollection` ignores order and has no switch to make it strict, so it would pass against every permutation — which is the entire claim being made here.

## Gates

123 tests · coverage 100% over 277 commands · lint clean at every severity · complexity gate green · release gate consistent.