### PR TITLE
fix: measure a file once, and stop counting enum labels as units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ A run that starts failing after this upgrade is the honest one.
   bucket layout rather than insertion or line position and is not required to be stable, so
   two runs over one unchanged file could differ. Units within a file now sort by start line,
   with the unit name breaking a same-line tie.
+- **A file named by two inputs is measured once.** Passing a directory and a file inside it
+  emitted every unit of that file twice, doubling its contribution to anything that counts
+  rows. Deduplicated on the resolved path, case-insensitively.
+- **Enum members are no longer reported as units.** An initialised member (`Red = 1`) is a
+  `PropertyMemberAst` with a value, exactly like a class property, so it became a unit while
+  a bare `Green` did not -- an enum's complexity depended on whether anyone numbered it.
 - **A directory scanned without `-Recurse` measured nothing at all, and the gate passed.**
   `-Include` is ignored for a directory unless `-Recurse` is also given, so
   `Measure-PSComplexity ./src` returned zero units for a folder full of code and

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -131,7 +131,19 @@ function Get-PSCxUnitTable {
     # $script:PSCxUnitBoundaryTypes would come back empty and match nothing.
     $isBodyOwner = {
         param($x)
-        if ($x -is [System.Management.Automation.Language.PropertyMemberAst]) { return [bool]$x.InitialValue }
+        if ($x -is [System.Management.Automation.Language.PropertyMemberAst]) {
+            # An ENUM member is a PropertyMemberAst too, and an initialised one -- `Red = 1`
+            # -- would otherwise become a unit while a bare `Green` would not, making an
+            # enum's complexity depend on whether anyone numbered its members. A label is
+            # not code; there is nothing in it to measure.
+            #
+            # Folded into ONE returned expression rather than an early `return $false`: this
+            # is a FindAll predicate, so $false and $null behave identically and a separate
+            # return is unobservable -- it survived every mutant. The `-and` is observable,
+            # because flipping it turns enum members back into units.
+            $isEnumMember = $x.Parent -is [System.Management.Automation.Language.TypeDefinitionAst] -and $x.Parent.IsEnum
+            return (-not $isEnumMember) -and [bool]$x.InitialValue
+        }
         return $x.GetType().Name -in $script:PSCxUnitBoundaryTypes
     }
     foreach ($node in $Ast.FindAll($isBodyOwner, $true)) {

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -61,9 +61,20 @@ function Measure-PSComplexity {
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
         [switch]$Recurse
     )
+    begin {
+        # Resolved paths already emitted. Two inputs can name one file -- a directory and
+        # something inside it, or a wildcard and a literal -- and measuring it twice put
+        # duplicate rows in the output, doubling that file's contribution to anything that
+        # counts. In `begin` rather than `process` so it also spans pipeline input, where
+        # each item arrives as its own invocation of the block below.
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    }
     process {
         foreach ($p in $Path) {
             foreach ($file in (Get-PSCxSourceFile -Path $p -Recurse:$Recurse)) {
+                # OrdinalIgnoreCase: Windows and macOS resolve the same file under different
+                # casing, and a case-sensitive check would let those through as two files.
+                if (-not $seen.Add($file)) { continue }
                 $errors = $null
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$errors)
                 if ($errors) {

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -57,6 +57,44 @@ function Mike { if ($c) { 1 } }
             Should-Be 'Alfa,Beta'
     }
 
+    It 'measures a file once when two inputs name it' {
+        # A directory and a file inside it. Measuring it twice doubled that file's
+        # contribution to anything that counts rows rather than taking a max.
+        $recs = @(Measure-PSComplexity -Path $script:work, (Join-Path $script:work 'a.ps1'))
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-Be 1
+    }
+
+    It 'still measures two DIFFERENT files given as two inputs' {
+        # Paired with the test above: deduplicating on something too coarse -- the input
+        # string, or the directory -- would satisfy it by measuring less.
+        $recs = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1'), (Join-Path $script:work 'nested/b.ps1'))
+        @($recs | Where-Object Unit -eq 'Get-A').Count | Should-Be 1
+        @($recs | Where-Object Unit -eq 'Get-B').Count | Should-Be 1
+    }
+
+    It 'does not report enum members as units' {
+        # An initialised member is a PropertyMemberAst with a value, exactly like a class
+        # property, so `Red = 1` became a unit while a bare `Green` did not -- an enum's
+        # complexity depended on whether anyone numbered it. A label is not code.
+        $f = Join-Path $script:work 'enum.ps1'
+        Set-Content $f @'
+enum Colour {
+    Red = 1
+    Green
+    Blue = 3
+}
+'@ -Encoding utf8
+        ((Measure-PSComplexity -Path $f | ForEach-Object Unit) -join ',') | Should-Be '<script-body>'
+    }
+
+    It 'still reports an initialised CLASS property as a unit' {
+        # The other half of the same predicate. Excluding enum members by testing for an
+        # initialiser alone would take class properties with it, and those do hold code.
+        $f = Join-Path $script:work 'class-prop.ps1'
+        Set-Content $f 'class Box { [int]$Size = $(if ($env:BIG) { 9 } else { 1 }) }' -Encoding utf8
+        @(Measure-PSComplexity -Path $f | Where-Object Unit -eq 'Box.Size').Count | Should-Be 1
+    }
+
     It 'reports Cyclomatic 1 / Cognitive 0 for a decision-free unit' {
         $flat = Join-Path $script:work 'flat.ps1'
         Set-Content $flat 'function Get-Flat { param($x) $x }' -Encoding utf8


### PR DESCRIPTION
Closes #45.

Two defects that both put rows in the output nobody asked for. Both reproduced before fixing:

```
overlapping paths -> rows for Get-A: 2   (expected 1)
enum members      -> Colour.Red, Colour.Blue, <script-body>
```

## Overlapping inputs

`Measure-PSComplexity -Path ./src, ./src/a.ps1` measured `a.ps1` twice and emitted every one of its units twice.

It never reached the gate, because the gate takes a **max** and a doubled max is the same max. But anything that *counts rows* — which is every queued feature (#2, #3, #5, #7) — was reading inflated numbers.

Deduplicated on the resolved path with `OrdinalIgnoreCase`: Windows and macOS resolve one file under different casing, and an ordinal check would let those through as two. The set lives in **`begin`**, not `process`, so it also spans pipeline input, where each item arrives as its own invocation.

## Enum members

An initialised member is a `PropertyMemberAst` carrying a value — structurally identical to a class property — so `Red = 1` became a unit and a bare `Green` did not. **An enum's complexity depended on whether anyone had numbered its members**, which is not a property of anything.

## Four tests, each paired

| assertion | the case it must not break |
|---|---|
| one file measured once when two inputs name it | two *different* files still both measured — a too-coarse dedupe cannot pass by measuring less |
| enum members excluded | an initialised **class property** still reported — excluding on "has an initialiser" alone would take those with it |

## The mutation gate caught the guard

I wrote the enum check as an early `return $false`. It survived: inside a `FindAll` predicate, `$false` and `$null` are indistinguishable, so the branch could not be observed at all.

Folded into one returned expression instead, then both mutants on that expression applied **by hand** and confirmed to fail tests:

```
-and -> -or       -> KILLED (2 fail)
negation removed  -> KILLED (3 fail)
```

An unkillable return traded for a killable operator, rather than for nothing.

## Gates (this branch)

125 tests · coverage 100% over 276 commands · lint clean at every severity · complexity gate green · release gate consistent. Self-mutation was 99.4% with the single survivor above; that survivor is now removed rather than tested.
