### PR TITLE
fix: make the gates see a test file that never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,11 @@ jobs:
           $cfg.Should.DisableV5 = $true
           $cfg.Output.Verbosity = 'Detailed'
           $r = Invoke-Pester -Configuration $cfg
-          if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed" }
+          . ./tools/ReleaseDecisions.ps1
+          $fault = Get-PSCxTestRunFault -FailedCount $r.FailedCount `
+              -ContainerResult @($r.Containers | ForEach-Object { [string]$_.Result }) `
+              -ContainerName @($r.Containers | ForEach-Object { Split-Path $_.Item -Leaf })
+          if ($fault) { throw $fault }
 
       # A committed script, not a snippet here, so measuring by hand and measuring in CI
       # cannot drift. The figure in CLAUDE.md was a claim nothing checked, and the one in

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,11 @@ jobs:
           # Match ci.yml: the classic `Should -Be` form is an error, not a style note.
           $cfg.Should.DisableV5 = $true
           $r = Invoke-Pester -Configuration $cfg
-          if ($r.FailedCount -gt 0) { throw "$($r.FailedCount) test(s) failed -- not publishing" }
+          . ./tools/ReleaseDecisions.ps1
+          $fault = Get-PSCxTestRunFault -FailedCount $r.FailedCount `
+              -ContainerResult @($r.Containers | ForEach-Object { [string]$_.Result }) `
+              -ContainerName @($r.Containers | ForEach-Object { Split-Path $_.Item -Leaf })
+          if ($fault) { throw "$fault Not publishing." }
 
       # The publish gate is a SUBSET of the merge gate -- it does not run self-mutation, the
       # Pester 5 compatibility guard, or anything on Windows. Re-running a subset here is both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ A run that starts failing after this upgrade is the honest one.
   discovery are all pinned; each could previously be changed without a test noticing.
 
 ### Internal
+- **Every gate that judges a test run now checks that each test file actually ran.** A file
+  with a parse error contributes zero tests and zero failures, so a run reported
+  "passed / 0 failed" while an entire file never executed -- and each gate asked only about
+  the failure count.
 - The test estate moves to **Pester 6.1.0**, pinned in `ci.yml` and `publish.yml`, and every
   step now imports it with `-RequiredVersion` rather than letting the name resolve -- an
   unimported pin documents an intention, it does not enforce one.

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -217,3 +217,36 @@ Describe 'the pins file itself' {
     }
 }
 
+Describe 'Get-PSCxTestRunFault' {
+    It 'says nothing about a run where every container passed' {
+        Get-PSCxTestRunFault -FailedCount 0 -ContainerResult @('Passed', 'Passed') -ContainerName @('a', 'b') |
+            Should-BeNull
+    }
+
+    It 'reports failing tests, and reports them FIRST' {
+        # When a test genuinely fails its container is 'Failed' too. "3 tests failed" is the
+        # better answer; "a file did not run" would send the reader to the wrong place.
+        Get-PSCxTestRunFault -FailedCount 3 -ContainerResult @('Failed') -ContainerName @('a') |
+            Should-BeLikeString '*3 test(s) failed*'
+    }
+
+    It 'catches a file that never ran, which FailedCount cannot see' {
+        # The whole point. A test file with a parse error contributes zero tests and zero
+        # failures, so every gate asking only about FailedCount reports green.
+        Get-PSCxTestRunFault -FailedCount 0 -ContainerResult @('Passed', 'Failed') -ContainerName @('ok.Tests.ps1', 'broken.Tests.ps1') |
+            Should-BeLikeString '*broken.Tests.ps1*'
+    }
+
+    It 'allows a deliberately skipped container' {
+        # Paired with the case above: treating every non-Passed result as a fault would make
+        # a legitimate -Skip fail the build, and the fix would be to remove the check.
+        Get-PSCxTestRunFault -FailedCount 0 -ContainerResult @('Passed', 'Skipped') -ContainerName @('a', 'b') |
+            Should-BeNull
+    }
+
+    It 'names every unrun file, not just the first' {
+        (Get-PSCxTestRunFault -FailedCount 0 -ContainerResult @('Failed', 'Failed') -ContainerName @('x.Tests.ps1', 'y.Tests.ps1')) |
+            Should-BeLikeString '*x.Tests.ps1, y.Tests.ps1*'
+    }
+}
+

--- a/tools/Measure-PSCxCoverage.ps1
+++ b/tools/Measure-PSCxCoverage.ps1
@@ -36,9 +36,11 @@ $cfg.CodeCoverage.Path = (Get-ChildItem (Join-Path $root 'src') -Filter *.ps1).F
 $cfg.CodeCoverage.OutputPath = Join-Path ([System.IO.Path]::GetTempPath()) "pscx-coverage-$PID.xml"
 
 $result = Invoke-Pester -Configuration $cfg
-if ($result.FailedCount -gt 0) {
-    throw "$($result.FailedCount) test(s) failed; coverage over a red suite means nothing."
-}
+. (Join-Path $PSScriptRoot 'ReleaseDecisions.ps1')
+$fault = Get-PSCxTestRunFault -FailedCount $result.FailedCount `
+    -ContainerResult @($result.Containers | ForEach-Object { [string]$_.Result }) `
+    -ContainerName @($result.Containers | ForEach-Object { Split-Path $_.Item -Leaf })
+if ($fault) { throw "$fault Coverage over a suite that did not fully run means nothing." }
 
 $covered = $result.CodeCoverage.CommandsExecuted
 $missed = $result.CodeCoverage.CommandsMissed

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -180,3 +180,42 @@ function Get-PSCxPinValue {
     }
     return $null
 }
+
+function Get-PSCxTestRunFault {
+    # Why a Pester run must not be treated as green, or $null when it may be.
+    #
+    # FailedCount alone is not enough, and that is the whole reason this exists. A test file
+    # that fails to PARSE contributes zero tests and zero failures: the run reports
+    # "passed=87 failed=0" while an entire file never executed, and every gate that asks
+    # only about FailedCount says yes. Observed, not theorised -- one dropped brace in a
+    # merge resolution hid 42 tests behind a green result.
+    #
+    # Pure so it can be tested without running Pester, because a gate that quietly stops
+    # being able to fail looks exactly like a gate with nothing to report.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [int]$FailedCount,
+        # Container results, one string each: 'Passed', 'Failed', 'Skipped'...
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$ContainerResult,
+        # Names for the message, aligned with $ContainerResult.
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$ContainerName
+    )
+    # Failures first: when a test genuinely fails its container is 'Failed' too, and
+    # "3 tests failed" is a better answer than "a file did not run".
+    if ($FailedCount -gt 0) { return "$FailedCount test(s) failed." }
+
+    $unrun = @()
+    for ($i = 0; $i -lt $ContainerResult.Count; $i++) {
+        # Skipped is legitimate -- a container can be filtered out deliberately. Anything
+        # else with no failures behind it means the file did not run at all.
+        if ($ContainerResult[$i] -ne 'Passed' -and $ContainerResult[$i] -ne 'Skipped') {
+            $unrun += $(if ($i -lt $ContainerName.Count) { $ContainerName[$i] } else { "container $i" })
+        }
+    }
+    if ($unrun.Count -gt 0) {
+        return ("$($unrun.Count) test file(s) reported no failures because they never ran: " +
+            ($unrun -join ', ') + '. A parse error in a test file looks exactly like a green suite.')
+    }
+    return $null
+}

--- a/tools/Test-PSCxPesterCompatibility.ps1
+++ b/tools/Test-PSCxPesterCompatibility.ps1
@@ -90,13 +90,22 @@ if ($Child) {
     Import-Module (Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'PSComplexity.psd1') -Force
 
     $control = Invoke-PSCxCompatSuite -Path (Join-Path $FixtureRoot 'Control.Tests.ps1')
-    if ($control.FailedCount -gt 0) {
+    # PassedCount, not FailedCount. A control that failed to PARSE reports neither, so
+    # asking only about failures would read "this Pester works" from a file that never ran.
+    if ($control.PassedCount -eq 0) {
         Write-Output "ENVIRONMENT: Pester $PesterVersion cannot run a trivial test on PowerShell $($PSVersionTable.PSVersion)."
         Write-Output 'This is not a PSComplexity failure. The control assertion (1 + 1 = 2) failed.'
         exit 2
     }
 
     $consumer = Invoke-PSCxCompatSuite -Path (Join-Path $FixtureRoot 'Consumer.Tests.ps1')
+    # The fixture is written out by this script, so a typo in it would otherwise report a
+    # clean pass over a file that never parsed -- the gate certifying its own mistake.
+    if (@($consumer.Containers | Where-Object { $_.Result -ne 'Passed' -and $_.Result -ne 'Skipped' }).Count -gt 0 -and
+        $consumer.FailedCount -eq 0) {
+        Write-Output 'The consumer fixture reported no failures because it never ran.'
+        exit 4
+    }
     Write-Output "Pester ${PesterVersion}: control passed, consumer $($consumer.PassedCount) passed / $($consumer.FailedCount) failed."
     foreach ($f in $consumer.Failed) { Write-Output "  FAILED: $($f.Name)" }
     exit ([int]($consumer.FailedCount -gt 0))


### PR DESCRIPTION
Every gate judging a Pester run asked only about `FailedCount`. A test file that fails to **parse** contributes zero tests *and* zero failures:

```
total=87  passed=87  failed=0        <- gate says green
Measure.Tests.ps1  result=Failed     <- 42 tests never executed
```

Found by doing it: one dropped brace in a merge resolution hid a whole file behind a passing result, and I pushed on the strength of it.

## What changed

Four call sites — `ci.yml`, `publish.yml`, the coverage script and the compatibility gate — and the decision behind them is **one pure function with five tests**, because a gate that quietly stops being able to fail looks exactly like a gate with nothing to report.

Two design points have their own tests:

- **Failures are reported first.** When a test genuinely fails its container is `Failed` too, and *"3 tests failed"* sends the reader somewhere better than *"a file did not run"*.
- **A `Skipped` container is allowed.** Treating every non-`Passed` result as a fault would break a legitimate `-Skip`, and the fix for that would be to delete the check.

The compatibility gate's **control** now asserts `PassedCount` rather than `FailedCount` — one step further in, a control that failed to parse reports neither, so asking about failures alone would read *"this Pester works"* off a file that never ran.

## Proved by breaking a test file

```
GATE FAILS: 1 test file(s) reported no failures because they never ran:
Cyclomatic.Tests.ps1. A parse error in a test file looks exactly like a green suite.
```

Both the coverage gate and the `ci.yml` check now name the file. Previously both reported a clean pass.

## It did not reach main, but only by luck

Coverage drops when an unrun file stops exercising its source, so the build went red — with a message about **coverage**, pointing at the wrong problem, and only because this repo happens to enforce 100%. Lower that bar, or break a file that barely moves coverage, and it ships.

Where it bites hardest is `publish.yml`, where the unit-test gate runs before anything measures coverage.

**The same defect exists in PSMutant** (proven there too) and is fixed in its own PR.

## Gates

134 tests · coverage 100% over 291 commands · lint clean at every severity · compatibility gate green · release gate consistent.
