### PR TITLE
fix: gate every piped path, and declare the types callers actually get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ A run that starts failing after this upgrade is the honest one.
   numbers and nothing more, pin `0.2.0`; every score here is greater than or equal to it.
 
 ### Fixed
+- **`Test-PSComplexity` accepts paths from the pipeline**, and judges all of them.
+  `Get-ChildItem ./modules | Test-PSComplexity` previously bound nothing at all; the command
+  now collects every piped path and gates them together.
+- **`OutputType` declares what a caller receives.** The streaming collectors claimed
+  `[pscustomobject[]]` -- a single return value that is a collection -- where they emit
+  records one at a time, and three `Ast.ps1` functions declared nothing.
 - **A file that does not parse no longer passes the gate silently.** `Test-PSComplexity`
   now refuses to give a verdict when any file failed to parse: "no unit exceeded a ceiling"
   is trivially true of a file that produced no units, so a genuinely broken file used to

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -59,6 +59,7 @@ function Resolve-PSCxUnitBoundary {
     # FunctionMemberAst. Both are body owners, so without this the same method is
     # discovered twice -- once unqualified. The MEMBER is the unit: it is the node
     # that knows the class name.
+    [OutputType([System.Management.Automation.Language.Ast])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Boundary)
     if ($Boundary -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
@@ -70,6 +71,7 @@ function Resolve-PSCxUnitBoundary {
 
 function Get-PSCxUnitBoundary {
     # Nearest enclosing body-owner, or $null for top-level code.
+    [OutputType([System.Management.Automation.Language.Ast])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
     $p = $Node.Parent
@@ -170,6 +172,7 @@ function Get-PSCxEnclosingMethod {
     # Nearest enclosing class method/constructor, else $null. Method recursion goes
     # through a member invocation ($this.X()), not a command, so it needs the AST
     # node -- the class name on it is what tells a static self-call apart.
+    [OutputType([System.Management.Automation.Language.Ast])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
     $boundary = Get-PSCxUnitBoundary -Node $Node

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -36,7 +36,7 @@ function Test-PSCxLogicalRunStart {
 
 function Get-PSCxCogIfRow {
     # if leading clause: 1 + nesting; each else-if and the else: +1 (no nesting bonus).
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
@@ -47,7 +47,7 @@ function Get-PSCxCogIfRow {
 
 function Get-PSCxCogBlockRow {
     # switch / loops / catch / trap: one increment + nesting (switch is not per-case).
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($tn in 'SwitchStatementAst', 'ForEachStatementAst', 'ForStatementAst', 'WhileStatementAst', 'DoWhileStatementAst', 'DoUntilStatementAst', 'CatchClauseAst', 'TrapStatementAst') {
@@ -58,7 +58,7 @@ function Get-PSCxCogBlockRow {
 }
 
 function Get-PSCxCogTernaryRow {
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.TernaryExpressionAst] }, $true)) {
@@ -71,7 +71,7 @@ function Get-PSCxCogFlowCommandRow {
     # and conditional get. Their script block is a ScriptBlockExpressionAst, which already
     # raises nesting for anything inside, so a body written this way now costs the same as
     # the keyword form rather than less.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) Test-PSCxFlowCommand -Node $x }, $true)) {
@@ -82,7 +82,7 @@ function Get-PSCxCogFlowCommandRow {
 function Get-PSCxCogNullCoalesceRow {
     # ?? and ??= choose between two values on a null test, so they are scored as the
     # conditional shorthand they are -- the same treatment the ternary already gets.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
@@ -102,7 +102,7 @@ function Get-PSCxCogPipelineChainRow {
     # operators is one increment, so `a && b && c` costs the same as `$a -and $b -and $c`.
     # Scoring each link separately would make the shell idiom dearer than the expression it
     # mirrors, which is the inverse of the bug this exists to fix.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.PipelineChainAst] }, $true)) {
@@ -115,7 +115,7 @@ function Get-PSCxCogPipelineChainRow {
 
 function Get-PSCxCogBooleanRow {
     # +1 per maximal run of a logical operator; no nesting bonus.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
@@ -125,7 +125,7 @@ function Get-PSCxCogBooleanRow {
 
 function Get-PSCxCogJumpRow {
     # labelled break / continue: +1.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     $isJump = { param($x) $x -is [System.Management.Automation.Language.BreakStatementAst] -or $x -is [System.Management.Automation.Language.ContinueStatementAst] }
@@ -136,7 +136,7 @@ function Get-PSCxCogJumpRow {
 
 function Get-PSCxCogRecursionRow {
     # direct recursion: +1 per call to the enclosing function.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.CommandAst] }, $true)) {
@@ -163,7 +163,7 @@ function Test-PSCxSelfInvocation {
 function Get-PSCxCogMethodRecursionRow {
     # direct recursion inside a class method: +1, same as the function case. A method
     # cannot recurse by bare command name, so Get-PSCxCogRecursionRow never sees it.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.InvokeMemberExpressionAst] }, $true)) {

--- a/src/Cyclomatic.ps1
+++ b/src/Cyclomatic.ps1
@@ -13,7 +13,7 @@
 function Get-PSCxCycClauseRow {
     # if / switch: one decision per CLAUSE. `else` is not a clause -- it is the absence of a
     # decision -- so Clauses.Count is the count, not Clauses.Count + 1.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
@@ -26,7 +26,7 @@ function Get-PSCxCycClauseRow {
 
 function Get-PSCxCycBlockRow {
     # Loops, catch and trap: one decision each.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($tn in 'ForEachStatementAst', 'ForStatementAst', 'WhileStatementAst', 'DoWhileStatementAst', 'DoUntilStatementAst', 'CatchClauseAst', 'TrapStatementAst') {
@@ -41,7 +41,7 @@ function Get-PSCxCycBlockRow {
 function Get-PSCxCycFlowCommandRow {
     # ForEach-Object / Where-Object and their aliases: one decision each, exactly as the
     # keyword loop and conditional they stand in for.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) Test-PSCxFlowCommand -Node $x }, $true)) {
@@ -55,7 +55,7 @@ function Get-PSCxCycOperatorRow {
     # && and || are control flow between pipelines, not boolean operators: `a && b` runs b
     # only if a succeeded, which is a decision exactly as `if ($?)` would be. ?? and ??= each
     # choose between two values on a null test.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.PipelineChainAst] }, $true)) {
@@ -76,7 +76,7 @@ function Get-PSCxCyclomaticRow {
     # Every decision-point row, attributed per unit. Composed from one collector per KIND of
     # decision, mirroring Cognitive.ps1 -- adding a construct then means a new collector or a
     # new entry in one, never another loop in a function that already has eight.
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     @(Get-PSCxCycClauseRow -Ast $Ast) + @(Get-PSCxCycBlockRow -Ast $Ast) +

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -5,6 +5,10 @@
 
 function Get-PSCxSourceFile {
     # Resolve a path (file or directory) to the PowerShell source files to measure.
+    #
+    # [string[]] and not [string], unlike the streaming collectors: this RETURNS the whole
+    # collection as one value rather than emitting items, so the array form is the accurate
+    # declaration. The analyzer says so, which is how the distinction was found.
     [OutputType([string[]])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] [string]$Path, [switch]$Recurse)
@@ -55,7 +59,7 @@ function Measure-PSComplexity {
         # Fail a build if anything is too complex:
         if (-not (Test-PSComplexity ./src -Recurse)) { exit 1 }
     #>
-    [OutputType([pscustomobject[]])]
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
@@ -141,36 +145,51 @@ function Test-PSComplexity {
     [OutputType([bool])]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
+        [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
         [int]$MaxCyclomatic = 15,
         [int]$MaxCognitive = 15,
         [switch]$Recurse
     )
-    # Parse failures are captured rather than allowed past. A file the gate could not read
-    # is a file it cannot vouch for, and "no unit exceeded a ceiling" is trivially true of a
-    # file that produced no units -- the same shape as passing over an empty selection.
-    $units = @(Measure-PSComplexity -Path $Path -Recurse:$Recurse -ErrorVariable parseErrors -ErrorAction SilentlyContinue)
-    if ($parseErrors.Count -gt 0) {
-        throw ("Refusing to vouch for $($parseErrors.Count) file(s) that did not parse: " +
-            (($parseErrors | ForEach-Object { $_.Exception.Message }) -join '; ') +
-            ". Fix the syntax, or exclude the file from the path you gate on.")
+    # ValueFromPipeline needs begin/process/end, not a bare body. A bare body IS the `end`
+    # block, so it would run once with $Path holding only the LAST item piped in -- and the
+    # gate would return a confident verdict about one path while silently ignoring the rest.
+    # Every path is collected first, then judged together, because the verdict is about the
+    # whole selection.
+    begin {
+        $collected = [System.Collections.Generic.List[string]]::new()
     }
+    process {
+        $collected.AddRange([string[]]$Path)
+    }
+    end {
+        # Parse failures are captured rather than allowed past. A file the gate could not
+        # read is a file it cannot vouch for, and "no unit exceeded a ceiling" is trivially
+        # true of a file that produced no units -- the same shape as passing over an empty
+        # selection.
+        $paths = $collected.ToArray()
+        $units = @(Measure-PSComplexity -Path $paths -Recurse:$Recurse -ErrorVariable parseErrors -ErrorAction SilentlyContinue)
+        if ($parseErrors.Count -gt 0) {
+            throw ("Refusing to vouch for $($parseErrors.Count) file(s) that did not parse: " +
+                (($parseErrors | ForEach-Object { $_.Exception.Message }) -join '; ') +
+                ". Fix the syntax, or exclude the file from the path you gate on.")
+        }
 
-    # Refuse rather than pass. "No unit breached a ceiling" and "no unit was measured" are
-    # the same $true, so a gate pointed at the wrong place reports clean -- which is the
-    # failure this module exists to find in other people's code.
-    if ($units.Count -eq 0) {
-        $hint = if ($Recurse) { '' } else { ', or add -Recurse if they are in subdirectories' }
-        throw ("Measured no units under: " + ($Path -join ', ') + ". Nothing was checked, so " +
-            "a pass here would describe an empty set. Check the path exists and holds .ps1 " +
-            "or .psm1 files" + $hint + '.')
-    }
+        # Refuse rather than pass. "No unit breached a ceiling" and "no unit was measured"
+        # are the same $true, so a gate pointed at the wrong place reports clean -- which is
+        # the failure this module exists to find in other people's code.
+        if ($units.Count -eq 0) {
+            $hint = if ($Recurse) { '' } else { ', or add -Recurse if they are in subdirectories' }
+            throw ("Measured no units under: " + ($paths -join ', ') + ". Nothing was checked, " +
+                "so a pass here would describe an empty set. Check the path exists and holds " +
+                ".ps1 or .psm1 files" + $hint + '.')
+        }
 
-    $violations = @($units |
-            Where-Object { $_.Cyclomatic -gt $MaxCyclomatic -or $_.Cognitive -gt $MaxCognitive })
-    foreach ($v in $violations) {
-        Write-Warning ("{0}:{1} {2} -- cyclomatic {3} (max {4}), cognitive {5} (max {6})" -f `
-                $v.File, $v.Line, $v.Unit, $v.Cyclomatic, $MaxCyclomatic, $v.Cognitive, $MaxCognitive)
+        $violations = @($units |
+                Where-Object { $_.Cyclomatic -gt $MaxCyclomatic -or $_.Cognitive -gt $MaxCognitive })
+        foreach ($v in $violations) {
+            Write-Warning ("{0}:{1} {2} -- cyclomatic {3} (max {4}), cognitive {5} (max {6})" -f `
+                    $v.File, $v.Line, $v.Unit, $v.Cyclomatic, $MaxCyclomatic, $v.Cognitive, $MaxCognitive)
+        }
+        return $violations.Count -eq 0
     }
-    return $violations.Count -eq 0
 }

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -23,6 +23,18 @@ AfterAll {
     Remove-Item $script:broken -Recurse -Force -ErrorAction SilentlyContinue
 }
 
+Describe 'the declared output types' {
+    It 'declares what a caller actually receives, not an array of it' {
+        # These commands STREAM individual records. [pscustomobject[]] claimed a single
+        # return value that is a collection, which neither ever produces -- and OutputType
+        # is what Get-Help and IntelliSense show, so it is documentation that no test could
+        # previously contradict.
+        ((Get-Command Measure-PSComplexity).OutputType.Name -join ',') |
+            Should-Be 'System.Management.Automation.PSObject'
+        ((Get-Command Test-PSComplexity).OutputType.Name -join ',') | Should-Be 'System.Boolean'
+    }
+}
+
 Describe 'Measure-PSComplexity' {
     It 'reports a record per unit including the script body' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1')
@@ -179,6 +191,37 @@ enum Colour {
 }
 
 Describe 'Test-PSComplexity' {
+    It 'judges EVERY path piped to it, not just the last' {
+        # The discriminating case, and the reason this is not a one-word fix. Adding
+        # ValueFromPipeline to a function whose body is a bare block gives it an `end` block
+        # only: it runs once, with $Path holding the LAST item, and the gate then returns a
+        # confident verdict about one path while silently ignoring the rest.
+        #
+        # The breaching file is piped FIRST and the clean one second, so a gate that kept
+        # only the last item would answer $true.
+        $big = Join-Path $script:work 'piped-big.ps1'
+        $small = Join-Path $script:work 'piped-small.ps1'
+        Set-Content $big 'function PipedBig { if ($a) { if ($b) { if ($c) { 1 } } } }' -Encoding utf8
+        Set-Content $small 'function PipedSmall { 1 }' -Encoding utf8
+
+        (@($big, $small) | Test-PSComplexity -MaxCognitive 1 -WarningAction SilentlyContinue) |
+            Should-BeFalse
+    }
+
+    It 'accepts a single path from the pipeline' {
+        $small = Join-Path $script:work 'piped-only.ps1'
+        Set-Content $small 'function PipedOnly { 1 }' -Encoding utf8
+        ($small | Test-PSComplexity) | Should-BeTrue
+    }
+
+    It 'still accepts paths as an argument' {
+        # Paired with the pipeline cases: restructuring into begin/process/end must not cost
+        # the ordinary call, which is how every consumer uses it today.
+        $small = Join-Path $script:work 'piped-only.ps1'
+        Set-Content $small 'function PipedOnly { 1 }' -Encoding utf8
+        Test-PSComplexity -Path $small | Should-BeTrue
+    }
+
     It 'returns $true when everything is within the ceilings' {
         Test-PSComplexity -Path (Join-Path $script:work 'a.ps1') | Should-BeTrue
     }


### PR DESCRIPTION
Closes #48.

## The pipeline half, and why it was not a one-word fix

`Measure-PSComplexity` took `-Path` from the pipeline and `Test-PSComplexity` did not, so `Get-ChildItem ./modules | Test-PSComplexity` bound nothing at all. Since #15 that now *throws* rather than returning a confident `$true`, which is the only reason it was merely annoying instead of dangerous.

**Adding `ValueFromPipeline` alone would have been the dangerous fix.** The function's body was a bare block — and a bare block **is** the `end` block. It runs once, with `$Path` holding only the **last** item piped in, so the gate would return a confident verdict about one path while silently ignoring the rest.

It is now `begin`/`process`/`end`, collecting every path and judging them together.

The test pipes the **breaching file first** and the clean one second, so a gate that kept only the last item answers `$true` and fails:

```powershell
(@($big, $small) | Test-PSComplexity -MaxCognitive 1) | Should-BeFalse
```

Paired with a single-item pipe and an ordinary argument call, because restructuring must not cost the way every consumer uses it today.

## The output-type half, where the analyzer caught me

Fifteen collectors declared `[pscustomobject[]]` while emitting records one at a time — a claim that a single return value is a collection — and three `Ast.ps1` functions declared nothing at all.

Then `PSUseOutputTypeCorrectly` flagged my own change, twice. `Get-PSCxSourceFile` does `return [string[]]@(...)` — it **returns the whole collection as one value** rather than emitting items — so the array form was correct there and I had broken it.

The rule is not *"arrays are wrong"*. It is **whether the function returns a collection or streams items**. Restored, and `PSUseOutputTypeCorrectly` now reports **zero findings across `src/`**, which is a stronger check than the reasoning that got it wrong.

## Not applicable to PSMutant

Checked: zero `ValueFromPipeline` parameters and zero `process` blocks across its `src/` and `tools/`. `Invoke-PSMutation` takes plain parameters, so there is no pipeline surface to get wrong.

## Gates

138 tests, **every container confirmed to have run** · coverage 100% over 294 commands · lint clean at every severity · complexity and Pester 5 compatibility gates green · release gate consistent.
