### PR TITLE
docs: correct the claims the code does not support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,10 @@ A run that starts failing after this upgrade is the honest one.
   logic against its reference-score suite, gated on the mutation score (~90%). The two
   Fortigi modules dogfood each other -- PSComplexity gates PSMutant's complexity, and
   PSMutant gates PSComplexity's test quality.
-- The self-mutation gate is now set at **100%**: coverage is 100% and
-  every one of the 41 mutants is killed, with no mutant declared equivalent. From here a
-  new survivor fails the build.
+- The self-mutation gate is now set at **100%**: every mutant is killed, with none declared
+  equivalent. From here a new survivor fails the build. (The count is deliberately not
+  quoted: it moves with every operator change and a hand-maintained figure goes stale
+  silently -- the gate prints it.)
 
 ### Fixed
 - Top-level script code -- decisions and calls outside any function -- is now covered by
@@ -99,6 +100,10 @@ A run that starts failing after this upgrade is the honest one.
   discovery are all pinned; each could previously be changed without a test noticing.
 
 ### Internal
+- Documentation claims the code does not support are corrected, each verified by running it
+  rather than by reading: load order is inert, the emitted `File` is absolute, and the
+  shipped `Get-Help` synopsis omitted class members for two releases. The self-complexity
+  gate now calls the shipped `Test-PSComplexity` instead of re-deriving the comparison.
 - **Every gate that judges a test run now checks that each test file actually ran.** A file
   with a parse error contributes zero tests and zero failures, so a run reported
   "passed / 0 failed" while an entire file never executed -- and each gate asked only about

--- a/PSComplexity.psm1
+++ b/PSComplexity.psm1
@@ -1,7 +1,12 @@
 # PSComplexity - cyclomatic + cognitive complexity for PowerShell.
 # Dot-source the implementation (small, single-responsibility units) and export the
-# public surface. Ast.ps1 provides the shared helpers the metric files depend on, so
-# it loads first.
+# public surface.
+#
+# The ORDER is a readable convention, not a constraint: every cross-file reference sits
+# inside a function body and resolves at call time, so loading these four in reverse
+# produces byte-identical output over this repo's own source. Verified, because this file
+# used to claim Ast.ps1 had to load first and a reader could have refused a sensible change
+# on the strength of it.
 
 $src = Join-Path $PSScriptRoot 'src'
 foreach ($file in @('Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1')) {

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ if (-not (Test-PSComplexity ./src -Recurse -MaxCyclomatic 15 -MaxCognitive 15)) 
 `Measure-PSComplexity` accepts files or directories (pipeline-friendly) and emits objects:
 
 ```
-File        Unit                 Line Cyclomatic Cognitive
-----        ----                 ---- ---------- ---------
-src\Foo.ps1 Get-Foo                12          8         9
-src\Foo.ps1 Order.Process          31          5        10
-src\Foo.ps1 <script-body>          1           1         0
+File                    Unit                 Line Cyclomatic Cognitive
+----                    ----                 ---- ---------- ---------
+C:\proj\src\Foo.ps1     <script-body>           1          1         0
+C:\proj\src\Foo.ps1     Get-Foo                12          8         9
+C:\proj\src\Foo.ps1     Order.Process          31          5        10
 ```
 
 Class members are reported as `Class.Member`, so two classes with a method of the same

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -31,8 +31,9 @@ function Get-PSCxSourceFile {
 function Measure-PSComplexity {
     <#
     .SYNOPSIS
-        Measure cyclomatic and cognitive complexity of PowerShell code, per unit
-        (each function/filter, plus one <script-body> per file for top-level code).
+        Measure cyclomatic and cognitive complexity of PowerShell code, per unit: each
+        function and filter, each class method, constructor and initialised property, plus
+        one <script-body> per file for top-level code.
 
     .DESCRIPTION
         Parses each .ps1/.psm1 file with the PowerShell AST and reports both metrics.

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -35,6 +35,26 @@ Describe 'the declared output types' {
     }
 }
 
+Describe 'the shipped help' {
+    It 'describes every kind of unit the module actually reports' {
+        # The synopsis said "each function/filter, plus one <script-body>" for two releases
+        # after class members became units. Nothing contradicted it, because help text is
+        # prose and prose is checked by nobody. This asserts the claim against the vocabulary
+        # the code actually produces.
+        $h = (Get-Help Measure-PSComplexity).Synopsis -replace '\s+', ' '
+        foreach ($kind in 'function', 'class method', 'constructor', 'property', '<script-body>') {
+            $h | Should-BeLikeString "*$kind*" -Because "the synopsis omits $kind"
+        }
+    }
+
+    It 'resolves to the command help, not to a file header' {
+        # A <# #> block immediately before `function` becomes that function's help, so a file
+        # header written that way silently shadows the documentation meant for users. Paired
+        # with the case above: both would pass on an empty synopsis otherwise.
+        (Get-Help Test-PSComplexity).Synopsis | Should-BeLikeString '*Return $true if every unit*'
+    }
+}
+
 Describe 'Measure-PSComplexity' {
     It 'reports a record per unit including the script body' {
         $recs = Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1')

--- a/tests/SelfComplexity.Tests.ps1
+++ b/tests/SelfComplexity.Tests.ps1
@@ -1,10 +1,10 @@
-# Dogfood: PSComplexity measures its own source and gates itself at <= 15 on both
-# metrics -- the same bar it exists to enforce for others.
+# Dogfood: PSComplexity gates its own source with the command it ships, at that command's
+# own default ceilings -- the same bar it exists to enforce for others.
 
 BeforeAll {
-    $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
-    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $src $f) }
-    $script:units = @(Measure-PSComplexity -Path $src -Recurse)
+    $script:src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $script:src $f) }
+    $script:units = @(Measure-PSComplexity -Path $script:src -Recurse)
 }
 
 Describe 'Self complexity gate' {
@@ -13,14 +13,15 @@ Describe 'Self complexity gate' {
         # and a literal here would fail on every unrelated edit to src/ while proving no more.
         $script:units.Count | Should-BeGreaterThan 0
     }
-    It 'has no unit over cyclomatic 15' {
-        $over = @($script:units | Where-Object Cyclomatic -gt 15)
-        $detail = ($over | ForEach-Object { "$($_.Unit)=$($_.Cyclomatic)" }) -join ', '
-        $over.Count | Should-Be 0 -Because "over cyclomatic 15: $detail"
-    }
-    It 'has no unit over cognitive 15' {
-        $over = @($script:units | Where-Object Cognitive -gt 15)
-        $detail = ($over | ForEach-Object { "$($_.Unit)=$($_.Cognitive)" }) -join ', '
-        $over.Count | Should-Be 0 -Because "over cognitive 15: $detail"
+    It 'passes the gate it ships, at the ceilings it ships' {
+        # Calls Test-PSComplexity rather than re-deriving the comparison. It used to do the
+        # latter, which meant the shipped command and the gate that proves this project
+        # meets its own bar could disagree without anything noticing -- and the ceilings had
+        # to be written out again here, so changing the default missed this file.
+        #
+        # The warnings carry the offending units, so a failure still names them.
+        $wv = $null
+        $ok = Test-PSComplexity -Path $script:src -Recurse -WarningVariable wv -WarningAction SilentlyContinue
+        $ok | Should-BeTrue -Because (($wv | ForEach-Object { $_.Message }) -join '; ')
     }
 }


### PR DESCRIPTION
Closes #28. Closes #44.

Five claims, each checked **by running it** rather than by reading — the issue asked for that on the first one, and it was right to.

## Load order is inert

`PSComplexity.psm1` said *"Ast.ps1 provides the shared helpers the metric files depend on, so it loads first."*

Loading the four files in **reverse** produces byte-identical output over this repo's own source (882 characters of unit/score pairs, matched exactly). Every cross-file reference sits inside a function body and resolves at call time.

The comment now says the order is a readable convention, and says why — a reader could otherwise refuse a sensible change believing they would break something.

## The self gate did not call the shipped command

It re-derived the comparison, so `Test-PSComplexity` and the gate proving this project meets its own bar could disagree with nothing noticing. It now **calls the command at the command's own default ceilings** — which also removes two of the places `15` was written out, so changing the default can no longer miss this file.

Verified it still *fails*: adding a deliberately complex unit turns it red, with the offending units named from the warnings.

## The emitted path is absolute

The README showed `src\Foo.ps1`. The module emits `C:\proj\src\Foo.ps1`, platform-separated. The example now shows what a user actually sees — in source order, which is also what they now get.

## The stale count is removed, not updated

*"every one of the 41 mutants"* was 41 when written and is 163 now. Replacing one number with another recreates the problem, so the sentence states the property — every mutant is killed — and notes that the gate prints the figure.

## The shipped synopsis omitted class members

For the two releases since 0.2.0 added them. Now pinned by a test asserting the synopsis against the vocabulary the code produces, **paired** with one asserting the help resolves to the command rather than a file header — both would pass on an empty synopsis otherwise.

## What I dropped rather than fixed

#44 also claimed file headers shadow `Get-Help` in three of four `src` files. **They do not.** `Get-Help` returns the real synopsis for both public commands, because the headers precede *internal* functions and the public ones carry their own help blocks. I filed that by pattern-matching a trap from the sibling repo instead of running it.

## Gates

139 tests, every container confirmed to have run · coverage 100% over 291 commands · lint clean at every severity · complexity gate green · release gate consistent.
