### PR TITLE
ci: gate mutation against PSMutant 0.3.2, so neither module lags the other

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -19,7 +19,7 @@ PESTER_VERSION=6.1.0
 PESTER_COMPAT_VERSION=5.7.1
 
 PSSA_VERSION=1.25.0
-PSMUTANT_VERSION=0.3.1
+PSMUTANT_VERSION=0.3.2
 CONVERTTOSARIF_VERSION=1.0.0
 
 # What PSScriptAnalyzer looks at. Shared so the lint gate and the code-scanning check cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
+### Internal
+
+- The mutation gate moves from PSMutant 0.3.1 to **0.3.2**, so neither module gates on a
+  version behind the one it ships beside. The score is unchanged; two of that release's
+  guards -- a per-mutant budget shorter than the baseline suite, and a config path escaping
+  the source root -- are inert here, because this config sets no timeout keys and no path
+  leaves the root.
+
 ## [0.3.0] - 2026-08-22
 
 ### For consumers


### PR DESCRIPTION
The pin sat at **0.3.1** while PSMutant published **0.3.2** today. A pin that trails the sibling it gates is exactly the drift `.github/pins.env` exists to make visible, so it should not wait for the next feature branch to notice it.

## Measured against the published build

```
gallery PSMutant 0.3.2 / Pester 6.1.0
SCORE 100%  killed=168  survived=0  total=168  exit=0
```

Identical to 0.3.1. That was the expected outcome, and it is not what made this worth checking.

## The score was never the risk

0.3.2 added two guards that **refuse** configurations which previously ran. Either could have turned this red:

- a per-mutant budget resolving **shorter than the baseline suite** now throws, rather than timing every mutant out and scoring each expiry as a kill
- a config path that **escapes the source root** is refused, rather than being mutated where it actually lives

Both are inert here, and that was checked rather than assumed: this config sets no timeout keys, so the budget comes from defaults, and no path leaves the root.

## Gates

Release gate clean · analyzer clean at every severity · mutation 100% against the gallery build. No `src/` change, so coverage and complexity are untouched.

The CHANGELOG entry lands under `[Unreleased]` — `ModuleVersion` stays at 0.3.0, which is already published, so this rides into whatever ships next.