### PR TITLE
fix: take the tag name through the environment, not through ${{ }}

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,11 +121,18 @@ jobs:
         shell: pwsh
         run: ./tools/Test-PSCxRelease.ps1
 
+      # The tag name arrives through the ENVIRONMENT, never through ${{ }}. An expression is
+      # pasted into this script as text before pwsh parses it, so a tag name that closes the
+      # string literal runs as code -- in the one job holding the gallery API key. git permits
+      # a quote in a ref name, `v1.0";$x;"` is a legal tag, and pushing a tag needs no review
+      # while pushing to main does. An env var is read at run time and is data whatever it says.
       - name: Verify tag matches ModuleVersion
         if: startsWith(github.ref, 'refs/tags/')
         shell: pwsh
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          $tag = "${{ github.ref_name }}".TrimStart('v')
+          $tag = $env:TAG_NAME.TrimStart('v')
           $ver = (Import-PowerShellDataFile ./PSComplexity.psd1).ModuleVersion
           if ($tag -ne $ver) { throw "Tag $tag does not match ModuleVersion $ver" }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
+### Security
+
+- `publish.yml` no longer interpolates the tag name into a PowerShell script. An Actions
+  expression is pasted into the script as text before pwsh parses it, so a tag name
+  containing a quote closed the string literal and ran as code -- in the one job holding
+  the gallery API key. git accepts `v1.0";$x;"` as a ref name, and pushing a tag requires
+  no review while pushing to main does. The name now arrives through an environment
+  variable, which is read at run time and stays data whatever it contains.
+
 ## [0.3.0] - 2026-08-22
 
 ### For consumers


### PR DESCRIPTION
Closes #33. PSMutant has the identical fix in its own PR — the defect was in both repos at nearly the same line.

## The defect

An Actions expression is pasted into a `run:` script as **text, before pwsh parses it**. The tag name is free-form data chosen by whoever pushes the tag:

```powershell
$tag = "${{ github.ref_name }}".TrimStart('v')
```

A tag name containing a quote closes that literal; the rest runs as code. git accepts one — `v1.0";$x;"` passes `check-ref-format`. Ref rules forbid space and `:`, which constrains a payload without stopping it: `[char]58` rebuilds a colon and `iex()` needs no spaces.

## Why it matters here specifically

This is the job holding the gallery API key, and the ruleset targets **branches only**. `main` requires a reviewed PR; a **tag** requires nothing. The step authorizing an unwithdrawable publish was both the least protected thing in the repo and the one taking attacker-controlled text into a shell.

## Proven in both directions

```
script Actions would run:  $tag = "v1.0";$global:PWNED=1;"".TrimStart('v')
OLD  interpolated : PWNED=1  tag='v1.0'
NEW  env var      : PWNED=0  tag='1.0";$global:PWNED=1;"'
NEW  normal tag   : tag=0.3.2  ModuleVersion=0.3.2  match=True
```

The payload executes under the old form and survives as inert text under the new one — where it then fails the version check, which is what should happen to a garbage tag. The negative was checked against a case that does execute, so it is not vacuous.

## Scope

Swept every interpolation reaching a `run:` block. `github.ref_name` was the only free-form one; `github.sha` and `github.repository` are fixed-format.

`ModuleVersion` stays 0.3.0 (already published), so the entry sits under `[Unreleased]`.

## Still worth a separate decision

A **tag ruleset** restricting who may push `v*`. The injection is the bug; nothing controlling the trigger for an irreversible publish is why it mattered. Related: #38.