### PR TITLE
test: pin the output record, which is the whole public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **The output record is now stated as the public contract and pinned by tests.** The five
+  fields `Measure-PSComplexity` emits -- `File`, `Unit`, `Line`, `Cyclomatic`, `Cognitive` --
+  are the module's API besides the two command names, and nothing asserted them, so adding,
+  renaming or reordering one was a silent breaking change. Their names, order and types are
+  now asserted exactly, for every record rather than the first; a sixth field fails the suite.
+  Documented in the README and in `Get-Help`, including that `Line` is deliberately **not**
+  an identity: it moves whenever anything above a unit is edited.
+
 ### Security
 
 - `publish.yml` no longer interpolates the tag name into a PowerShell script. An Actions

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ nested loop-in-loop-in-`if` grows fast — mirroring how hard it is to follow.
 | `Measure-PSComplexity -Path <files/dirs> [-Recurse]` | per-unit records | inspect / report |
 | `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15]` | `[bool]` | CI gate (warns per offender) |
 
+### The record is the API
+
+`Measure-PSComplexity` emits one object per unit with exactly these fields, in this order:
+
+| Field | Type | |
+|---|---|---|
+| `File` | `[string]` | absolute path |
+| `Unit` | `[string]` | function, method, or `<script-body>` |
+| `Line` | `[int]` | where the unit starts |
+| `Cyclomatic` | `[int]` | |
+| `Cognitive` | `[int]` | |
+
+Those names, their order and their types are the public contract, and a test asserts them
+exactly -- a sixth field fails the suite, so widening this is a decision rather than a side
+effect. `Line` is deliberately **not** an identity: it moves whenever anything above a unit
+is edited, so it says where a unit currently starts, not which unit it is.
+
 ## Use it in CI
 
 ```yaml

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -53,6 +53,16 @@ function Measure-PSComplexity {
     .OUTPUTS
         [pscustomobject] with File, Unit, Line, Cyclomatic, Cognitive -- one per unit.
 
+        These five names, their order and their types are the module's public contract
+        alongside the two command names, and a test asserts them exactly: widening the
+        record fails that test, so it is a decision rather than a side effect of an
+        internal change. File and Unit are [string]; Line, Cyclomatic and Cognitive are
+        [int] -- Line as a string would silently turn a numeric sort into a lexical one.
+
+        Line is NOT an identity. It moves whenever anything above a unit is edited, so it
+        says where a unit currently starts, not which unit it is. Anything persisting or
+        comparing records across commits needs something else.
+
     .EXAMPLE
         Measure-PSComplexity ./src -Recurse | Sort-Object Cognitive -Descending
 

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -23,6 +23,41 @@ AfterAll {
     Remove-Item $script:broken -Recurse -Force -ErrorAction SilentlyContinue
 }
 
+Describe 'the record shape a consumer depends on' {
+    # This object IS the public API, besides the two command names. Unpinned, it was still a
+    # contract -- just one discoverable only by running the command, and unchangeable once
+    # anyone had. Four queued features want to widen it (#2 baseline, #3 attribution,
+    # #5 report, #7 changed-files), so widening has to fail here first and be a decision.
+
+    It 'emits exactly these five fields, in this order' {
+        $row = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1'))[0]
+        # Joined rather than Should-BeCollection, which ignores order: property order is
+        # what Format-Table shows a consumer, so a reordering is a visible change.
+        ($row.PSObject.Properties.Name -join ',') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive'
+    }
+
+    It 'emits those fields with the types a consumer sorts and compares on' {
+        # Line being a string rather than an int is as breaking as a rename: it silently
+        # turns a numeric sort into a lexical one, where 10 precedes 2.
+        $row = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1'))[0]
+        $row.File       | Should-HaveType ([string])
+        $row.Unit       | Should-HaveType ([string])
+        $row.Line       | Should-HaveType ([int])
+        $row.Cyclomatic | Should-HaveType ([int])
+        $row.Cognitive  | Should-HaveType ([int])
+    }
+
+    It 'pins the shape for every record, not only the first' {
+        # The kept half of the pair. Asserting the first record alone passes against a
+        # command that emits a different shape for the <script-body> unit, or for the second
+        # file in a directory walk -- which is exactly where a widening would land.
+        $rows = @(Measure-PSComplexity -Path $script:work -Recurse)
+        $rows.Count | Should-BeGreaterThan 2
+        $shapes = @($rows | ForEach-Object { $_.PSObject.Properties.Name -join ',' } | Sort-Object -Unique)
+        ($shapes -join ' | ') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive'
+    }
+}
+
 Describe 'the declared output types' {
     It 'declares what a caller actually receives, not an array of it' {
         # These commands STREAM individual records. [pscustomobject[]] claimed a single


### PR DESCRIPTION
Closes #42.

`Measure-PSComplexity` emits five fields and **nothing asserted them**, so adding, renaming or reordering one was a silent breaking change to every consumer. An unpinned shape is not a smaller contract than a pinned one — it is the same contract, discoverable only by running the command, and unchangeable once someone has.

## Three assertions, three different claims

| | Why it is separate |
|---|---|
| exact names **in order** | joined rather than compared as a collection: `Should-BeCollection` ignores order, and property order is what `Format-Table` shows a consumer |
| the **types** | `Line` as a string turns a numeric sort into a lexical one, where 10 precedes 2 — as breaking as a rename, and quieter |
| the shape of **every** record | asserting the first alone passes against a command that emits a different shape for `<script-body>`, or for the second file in a walk — which is exactly where a widening would land |

## Verified it can fail

Adding a sixth field to the record breaks **two of the three** tests. A pin that cannot detect a widening looks identical to one that can, and this repo has shipped tests that passed while proving nothing.

## `Line` is documented as not an identity

In the README and in the docstring `Get-Help` serves: it moves whenever anything above a unit is edited, so it says *where a unit starts*, not *which unit it is*. That is the same note the sibling project gives its mutant `Id`, and #14 is the issue that needs it.

## Why now

Four queued features want to widen this record — #2 (baseline), #3 (attribution), #5 (report), #7 (changed files). Each now has to change the test first. Once a consumer persists a record the shape is fixed whether or not a test says so, so this is cheap today and not later.

## Gates

Analyzer clean at every severity · suite green · coverage **100%** over 294 commands · release gate clean. Self-mutation to follow — no `src/` logic changed, only the docstring.