### PR TITLE
fix: fail when main claims a version that has already shipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Release consistency (ModuleVersion, CHANGELOG, ReleaseNotes)
         shell: pwsh
-        run: ./tools/Test-PSCxRelease.ps1
+        # -CheckGallery here and not locally: the question is whether this version has
+        # already shipped, which the working tree cannot answer.
+        run: ./tools/Test-PSCxRelease.ps1 -CheckGallery
 
       # One committed script, called by this gate and by code-scanning.yml. Spelled out in
       # both, they disagreed about severity and scope, so an Information finding failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ keys it holds could not distinguish units the tool could.
 
 ### Fixed
 
+- **CI now fails when `main` claims a version that has already shipped.** It once did: `main`
+  stood at 0.2.0, 0.2.0 was on the gallery, and merged work sat under `[Unreleased]` with every
+  gate green. Two people installing "0.2.0" -- one from the gallery, one from a clone -- got
+  different code, and nothing in the repo could tell them apart. The release gate now asks the
+  gallery, and faults only on the pair: a published version **and** unreleased entries above
+  it. Either alone is a normal state. It checks the gallery is reachable **first** and refuses
+  when it is not, because "never published" and "could not look" are the same empty answer and
+  treating them alike is how a gate silently stops being able to fail.
+
 - **Two units written on one line are two units again.** A unit was keyed by its name and its
   *line*, and a line is not unique: two overloads on one physical line shared a key, so their
   scores were **added** and the file reported a single unit that exists nowhere in the source.

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -250,3 +250,50 @@ Describe 'Get-PSCxTestRunFault' {
     }
 }
 
+Describe 'main must not claim a version that already shipped' {
+    # It once did: main stood at 0.2.0, 0.2.0 was on the gallery, and merged work sat under
+    # [Unreleased] with every gate passing. Two people installing "0.2.0" -- one from the
+    # gallery, one from a clone -- got different code, and nothing in the repo could tell
+    # them apart.
+
+    It 'faults when a published version has unreleased entries above it' {
+        Get-PSCxStaleVersionFault -ModuleVersion '0.2.0' -IsPublished $true -HasUnreleasedContent $true |
+            Should-MatchString ([regex]::Escape('already on the gallery'))
+    }
+
+    It 'is silent when a published version has nothing unreleased' {
+        # The resting state between releases, and the first of two kept cases. Without it a
+        # gate that faults on IsPublished alone would fail every green main.
+        Should-BeNull -Actual (Get-PSCxStaleVersionFault -ModuleVersion '0.2.0' -IsPublished $true -HasUnreleasedContent $false)
+    }
+
+    It 'is silent when unreleased entries sit above a version not yet shipped' {
+        # The second kept case: a release being prepared. Faulting here would refuse exactly
+        # the state this repo is in while writing a release.
+        Should-BeNull -Actual (Get-PSCxStaleVersionFault -ModuleVersion '0.5.0' -IsPublished $false -HasUnreleasedContent $true)
+    }
+
+    It 'reads content under [Unreleased] and stops at the next heading' {
+        $lines = @('# CL', '', '## [Unreleased]', '', '### Fixed', '- a thing', '', '## [0.4.0] - 2026-08-23', '- x')
+        Should-BeTrue -Actual (Test-PSCxHasUnreleasedContent -Lines $lines)
+    }
+
+    It 'treats a whitespace-only [Unreleased] as empty' {
+        # Blank lines are how the section looks between releases; counting them as content
+        # would fault every repo that keeps the heading in place.
+        $lines = @('# CL', '', '## [Unreleased]', '', '   ', '', '## [0.4.0] - 2026-08-23', '- x')
+        Should-BeFalse -Actual (Test-PSCxHasUnreleasedContent -Lines $lines)
+    }
+
+    It 'does not mistake a later version body for unreleased content' {
+        # The discriminating case: entries exist in the file, but below the next heading. A
+        # scan that forgets to stop would report every changelog as having unreleased work.
+        $lines = @('# CL', '', '## [Unreleased]', '', '## [0.4.0] - 2026-08-23', '', '### Fixed', '- a released thing')
+        Should-BeFalse -Actual (Test-PSCxHasUnreleasedContent -Lines $lines)
+    }
+
+    It 'is false when there is no [Unreleased] heading at all' {
+        $lines = @('# CL', '', '## [0.4.0] - 2026-08-23', '- x')
+        Should-BeFalse -Actual (Test-PSCxHasUnreleasedContent -Lines $lines)
+    }
+}

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -127,6 +127,56 @@ function Get-PSCxReleaseFault {
     return $faults.ToArray()
 }
 
+function Get-PSCxStaleVersionFault {
+    <#
+    .SYNOPSIS
+        The fault, if any, when main claims a version that has already shipped.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$ModuleVersion,
+        [Parameter(Mandatory)] [bool]$IsPublished,
+        [Parameter(Mandatory)] [bool]$HasUnreleasedContent
+    )
+    # The question that stays open after ModuleVersion, the newest heading and ReleaseNotes
+    # all agree: HAS the version they agree on already shipped? It once had -- main stood at
+    # 0.2.0 with 0.2.0 on the gallery and merged work sitting under [Unreleased], and every
+    # gate passed. Two people installing "0.2.0", one from the gallery and one from a clone,
+    # got different code with nothing in the repo able to tell them apart.
+    #
+    # BOTH conditions, because either alone is a normal state. Sitting on a published version
+    # with nothing unreleased is exactly where a repo rests between releases; unreleased work
+    # under a version not yet shipped is a release being prepared. Only the pair is wrong.
+    if (-not $IsPublished) { return $null }
+    if (-not $HasUnreleasedContent) { return $null }
+    return ("ModuleVersion $ModuleVersion is already on the gallery, and CHANGELOG.md has " +
+        "unreleased entries above it. Anyone installing $ModuleVersion gets different code " +
+        "depending on whether they took it from the gallery or from this repository. Bump " +
+        "ModuleVersion and give the entries their own heading.")
+}
+
+function Test-PSCxHasUnreleasedContent {
+    <#
+    .SYNOPSIS
+        Whether the [Unreleased] heading has anything under it.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$Lines)
+    # Scanned in one pass, in the same style as Get-PSCxConsumerNotes: enter at the
+    # [Unreleased] heading, leave at the next `## [` heading of any kind.
+    $inside = $false
+    foreach ($line in $Lines) {
+        if ($line -match '^##\s*\[Unreleased\]') { $inside = $true; continue }
+        if ($inside -and $line -match '^##\s*\[') { return $false }
+        # Any non-blank line counts. A section holding only whitespace is the resting state
+        # between releases and must not read as pending work.
+        if ($inside -and -not [string]::IsNullOrWhiteSpace($line)) { return $true }
+    }
+    return $false
+}
+
 function Get-PSCxRewrittenManifest {
     # The manifest TEXT with only its ReleaseNotes value replaced. Returns a string and writes
     # nothing -- the caller decides whether to save it.

--- a/tools/Test-PSCxRelease.ps1
+++ b/tools/Test-PSCxRelease.ps1
@@ -11,6 +11,9 @@
 [CmdletBinding()]
 param(
     [switch]$Apply,
+    # Off by default so the gate runs offline. CI passes it: the question it answers -- has
+    # this version already shipped? -- cannot be answered from the working tree.
+    [switch]$CheckGallery,
     [string]$ManifestPath,
     [string]$ChangelogPath
 )
@@ -54,8 +57,24 @@ if ($Apply) {
     return
 }
 
-$faults = @(Get-PSCxReleaseFault -ModuleVersion $moduleVersion -ChangelogVersion $changelogVersion `
-        -ConsumerNotes $notes -ActualNotes $actual -DetailUrl $detailUrl)
+$faults = [System.Collections.Generic.List[string]]::new()
+$faults.AddRange([string[]]@(Get-PSCxReleaseFault -ModuleVersion $moduleVersion -ChangelogVersion $changelogVersion `
+        -ConsumerNotes $notes -ActualNotes $actual -DetailUrl $detailUrl))
+
+if ($CheckGallery) {
+    # Reachability FIRST, and separately. Find-Module returns nothing both when a version was
+    # never published and when the gallery cannot be reached, and treating those alike is how
+    # a gate stops being able to fail: every run would report "not published" and pass.
+    $any = @(Find-Module PSComplexity -ErrorAction SilentlyContinue)
+    if ($any.Count -eq 0) {
+        throw ('Release gate cannot reach the PowerShell Gallery, so it cannot tell whether ' +
+            "$moduleVersion has already shipped. Refusing rather than assuming it has not.")
+    }
+    $published = @(Find-Module PSComplexity -RequiredVersion $moduleVersion -ErrorAction SilentlyContinue).Count -gt 0
+    $stale = Get-PSCxStaleVersionFault -ModuleVersion $moduleVersion -IsPublished $published `
+        -HasUnreleasedContent (Test-PSCxHasUnreleasedContent -Lines $lines)
+    if ($stale) { $faults.Add($stale) }
+}
 if ($faults.Count -gt 0) {
     foreach ($f in $faults) { Write-Output "RELEASE FAULT: $f" }
     throw "$($faults.Count) release consistency fault(s)."


### PR DESCRIPTION
Closes #50. Folded into the unreleased 0.4.0.

It happened once: `main` stood at 0.2.0, 0.2.0 was on the gallery, and merged work sat under `[Unreleased]` with **every gate green**. Two people installing "PSComplexity 0.2.0" — one from the gallery, one from a clone — got different code, and nothing in the repo could tell them apart.

This is the question that stays open after `ModuleVersion`, the newest heading and `ReleaseNotes` all agree (#24): *has the version they agree on already shipped?*

## Faults only on the pair

| published | unreleased entries | |
|---|---|---|
| yes | yes | **fault** |
| yes | no | fine — the resting state between releases |
| no | yes | fine — a release being prepared |

Either condition alone is normal, so both kept cases have their own test. A gate that faulted on `IsPublished` alone would fail every green `main`.

## Reachability is checked first, and separately

`Find-Module` returns nothing both when a version was never published **and** when the gallery cannot be reached. Treating those alike would make every run report "not published" and pass — a gate that has silently stopped being able to fail. It refuses instead:

> Release gate cannot reach the PowerShell Gallery, so it cannot tell whether 0.4.0 has already shipped. Refusing rather than assuming it has not.

`-CheckGallery` is off by default so the gate still runs offline; `ci.yml` passes it, because the question cannot be answered from the working tree.

## Verified it fires

Recreated the exact state the issue describes — `ModuleVersion` set to the published 0.3.0, entries added under `[Unreleased]`:

```
RELEASE FAULT: ModuleVersion 0.3.0 is already on the gallery, and CHANGELOG.md has
unreleased entries above it. Anyone installing 0.3.0 gets different code depending on
whether they took it from the gallery or from this repository.
exit was non-zero: yes
```

## Gates

Analyzer clean · suite **159 pass** · coverage **100%** over 335 commands · release gate clean both offline and against the gallery.

Also closed today: **#35** was already fixed — ConvertToSARIF is pinned from `pins.env` and imported with `-RequiredVersion`.