### PR TITLE
test: pin every entry in the construct vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ keys it holds could not distinguish units the tool could.
 
 ### Fixed
 
+- **The construct vocabulary is pinned, so a half-finished addition cannot ship green.** Three
+  hardcoded type lists drive every number this module produces, and a leave-one-out sweep found
+  most entries deletable with the whole suite green at 100% coverage: 5 of 7 cyclomatic types,
+  4 of 8 cognitive types, and the entire `switch` decision-point block -- which made a 12-case
+  switch score cyclomatic **1** instead of 13. The cause was blunt: `tests/` contained no
+  `catch` and no `trap` at all, one `switch` fixture asserting cognitive only, and a `do-until`
+  but no `do-while`. The mutation gate cannot reach this -- its operators are arithmetic and
+  boolean, and none deletes a statement or touches a type name -- so "100% self-mutation" was
+  true and said nothing about the vocabulary. Twenty reference cases now pin every entry;
+  re-running the sweep against a green control leaves **28 of 29** entries failing when deleted.
+
+
 - **Two units written on one line are two units again.** A unit was keyed by its name and its
   *line*, and a line is not unique: two overloads on one physical line shared a key, so their
   scores were **added** and the file reported a single unit that exists nowhere in the source.

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -56,6 +56,27 @@ function Get-Fib { param($n) if ($n -le 1) { return $n }; return (Get-Fib ($n - 
     @{ name = 'null-coalescing nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x, $y) if ($a) { $z = $x ?? $y } }' }
     @{ name = 'null-coalescing assignment nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x) if ($a) { $x ??= 1 } }' }
     @{ name = 'flat function scores 0'; expected = 0; code = 'function T { param($x) $y = $x + 1; return $y }' }
+    # Every remaining entry in the cognitive block list, flat. Four of the eight type names
+    # could be DELETED with the whole suite green: tests/ contained no `catch` and no `trap`
+    # at all, and a do-until but no do-while.
+    @{ name = 'while = 1'; expected = 1; code = 'function T { param($n) while ($n -gt 0) { $n-- } }' }
+    @{ name = 'do-while = 1'; expected = 1; code = 'function T { param($n) do { $n-- } while ($n -gt 0) }' }
+    @{ name = 'catch = 1'; expected = 1; code = 'function T { try { 1 } catch { 2 } }' }
+    @{ name = 'trap = 1'; expected = 1; code = 'function T { trap { continue } 1 }' }
+
+    # And every entry in $script:PSCxNestingTypes, which is a DIFFERENT list and needs a
+    # different shape: an `if` INSIDE the construct. "X inside an if" pins IfStatementAst's
+    # membership, not X's -- the nesting bonus belongs to whatever encloses. Each of these is
+    # construct(1) + if(1 + 1 nesting) = 3, and drops to 2 the moment the construct stops
+    # raising nesting.
+    @{ name = 'while raises nesting'; expected = 3; code = 'function T { param($n,$a) while ($n -gt 0) { if ($a) { 1 } } }' }
+    @{ name = 'for raises nesting'; expected = 3; code = 'function T { param($a) for ($i = 0; $i -lt 3; $i++) { if ($a) { 1 } } }' }
+    @{ name = 'do-while raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } while ($n -gt 0) }' }
+    @{ name = 'do-until raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } until ($n -le 0) }' }
+    @{ name = 'switch raises nesting'; expected = 3; code = 'function T { param($a,$b) switch ($a) { 1 { if ($b) { 2 } } } }' }
+    @{ name = 'catch raises nesting'; expected = 3; code = 'function T { param($a) try { 1 } catch { if ($a) { 2 } } }' }
+    @{ name = 'trap raises nesting'; expected = 3; code = 'function T { param($a) trap { if ($a) { continue } } 1 }' }
+    @{ name = 'foreach raises nesting'; expected = 3; code = 'function T { param($xs,$a) foreach ($x in $xs) { if ($a) { 1 } } }' }
 )
 
 BeforeAll {

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -24,6 +24,21 @@ $script:CyclomaticCases = @(
     # Paired with the cases above: a command whose name a static walk cannot read must not
     # be treated as flow, and must not make the predicate throw either.
     @{ name = 'a command with no readable name is not flow'; expected = 1; code = 'function T { param($cmd) & $cmd arg }' }
+    # Every remaining entry in the decision-point lists, pinned. Before these, five of the
+    # seven type names in Cyclomatic.ps1 could be DELETED with the whole suite green at 100%
+    # coverage -- and so could the entire switch block, which made a 12-case switch score 1
+    # instead of 13. The mutation gate cannot see this: its operators are arithmetic and
+    # boolean, and none deletes a statement or touches a type name.
+    @{ name = 'switch scores one per clause'; expected = 13; code = 'function T { param($a) switch ($a) { 1 { "1" } 2 { "2" } 3 { "3" } 4 { "4" } 5 { "5" } 6 { "6" } 7 { "7" } 8 { "8" } 9 { "9" } 10 { "10" } 11 { "11" } 12 { "12" } } }' }
+    # The pair that pins `default` NOT being a clause: same clause count, same score. Either
+    # fixture alone passes against code that counts the default arm.
+    @{ name = 'switch with a default'; expected = 3; code = 'function T { param($a) switch ($a) { 1 { "a" } 2 { "b" } default { "c" } } }' }
+    @{ name = 'switch without a default scores the same'; expected = 3; code = 'function T { param($a) switch ($a) { 1 { "a" } 2 { "b" } } }' }
+    @{ name = 'for loop = 2'; expected = 2; code = 'function T { for ($i = 0; $i -lt 3; $i++) { $i } }' }
+    @{ name = 'do-while = 2'; expected = 2; code = 'function T { param($n) do { $n-- } while ($n -gt 0) }' }
+    @{ name = 'do-until = 2'; expected = 2; code = 'function T { param($n) do { $n-- } until ($n -le 0) }' }
+    @{ name = 'catch = 2'; expected = 2; code = 'function T { try { 1 } catch { 2 } }' }
+    @{ name = 'trap = 2'; expected = 2; code = 'function T { trap { continue } 1 }' }
 )
 
 BeforeAll {


### PR DESCRIPTION
Closes #32. Folded into the unreleased 0.4.0.

Three hardcoded type lists drive **every number this module produces**, and most of their entries could be deleted with the whole suite green at 100% coverage:

| List | Deletable before |
|---|---|
| cyclomatic block | 5 of 7 |
| cognitive block | 4 of 8 |
| nesting types | 6 of 11 |

Plus the entire `switch` decision-point block — which made a 12-case switch score cyclomatic **1** instead of 13. I confirmed that number before pinning it.

The cause was blunt: `tests/` contained **no `catch` and no `trap` at all**, one `switch` fixture asserting cognitive only, and a `do-until` but no `do-while`. And the mutation gate structurally cannot reach this — its operators are arithmetic and boolean, none deletes a statement or touches a type name — so "100% self-mutation" was true and said nothing whatever about the vocabulary.

## Twenty cases, and one that needed a different shape

The nesting cases are **not** what the issue proposed. "X inside an `if`" pins `IfStatementAst`’s membership, not X’s, because the nesting bonus belongs to whatever **encloses**. The `if` has to be inside X:

```
construct(1) + if(1 + 1 nesting) = 3      drops to 2 the moment X stops raising nesting
```

## The verification needed fixing before it meant anything

My first sweep copied only `src/` and `tests/`, so `Release.Tests.ps1` could not reach `tools/ReleaseDecisions.ps1` and failed on every run. That put a **~31-failure noise floor** under every number, and the "0 unpinned" it produced was meaningless — I reported it before catching that.

Rerun with `tools/` copied and a **control run asserted green** first:

```
CONTROL (nothing deleted): failures=0
UNPINNED against a GREEN control: 1 of 29
```

Deleting only the switch arm is caught by exactly the three new switch cases, which is a claim that holds regardless of counts.

## The one entry I could not pin

`FunctionMemberAst` in the unit-boundary list changes no observable answer when removed, because `Resolve-PSCxUnitBoundary` maps a method body back to its member and the body is itself a boundary. I tried to build a discriminating case — a ternary in a method parameter default — and it attributes identically with and without the entry.

So it is redundant rather than untested. Recorded and filed separately rather than removed on a guess, or covered by a test that would pass either way.

## Gates

Analyzer clean · suite **172 pass** · release gate clean. Coverage and self-mutation to follow.