### PR TITLE
feat: stamp every score with the metric that produced it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,22 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **A score now says which metric produced it.** Records carry `MetricVersion`, an int that
+  increments whenever a score can change for source that did not -- a narrower rule than the
+  module version, so a fix that only affects messages, or a new field on the record, leaves it
+  alone. It has already happened twice without being recorded: 0.3.0 taught the metric
+  PowerShell's own flow constructs, and 0.4.0 stopped merging two units written on one line.
+  Both were corrections, and both silently re-scored code nobody had touched. It starts at **1**
+  with this release; earlier releases carry no version and are not comparable with these.
+  Anything persisting or comparing scores should refuse to compare across two values rather than
+  mix them -- which is what a committed baseline will need.
+
+- The README's CI snippet now installs with **`-RequiredVersion`** rather than a floor. A gate
+  decides whether a build passes, so without an exact version two machines on the same commit
+  can legitimately disagree about whether it is green, and the one that upgraded first looks
+  like the one that broke it.
+
+
 - **The output record is now stated as the public contract and pinned by tests.** The five
   fields `Measure-PSComplexity` emits -- `File`, `Unit`, `Line`, `Cyclomatic`, `Cognitive` --
   are the module's API besides the two command names, and nothing asserted them, so adding,

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ nested loop-in-loop-in-`if` grows fast — mirroring how hard it is to follow.
 | `Line` | `[int]` | where the unit starts |
 | `Cyclomatic` | `[int]` | |
 | `Cognitive` | `[int]` | |
+| `MetricVersion` | `[int]` | which metric produced these numbers |
+
+`MetricVersion` increments whenever a score can change for source that did not -- a narrower
+rule than the module version, so a bug fix that only affects messages, or a new field on this
+record, leaves it alone. It has happened twice: 0.3.0 taught the metric PowerShell's own flow
+constructs, and 0.4.0 stopped merging two units written on one line. Both were corrections, and
+both silently re-scored code nobody had touched. Anything that persists or compares scores should
+refuse to compare across two values rather than mix them. It starts at **1** with 0.4.0; earlier
+releases carry no version and are not comparable with these.
 
 Those names, their order and their types are the public contract, and a test asserts them
 exactly -- a sixth field fails the suite, so widening this is a decision rather than a side
@@ -101,9 +110,14 @@ is edited, so it says where a unit currently starts, not which unit it is.
 ```yaml
 - shell: pwsh
   run: |
-    Install-Module PSComplexity -Force -Scope CurrentUser
+    Install-Module PSComplexity -RequiredVersion 0.4.0 -Force -Scope CurrentUser
     if (-not (Test-PSComplexity ./src -Recurse)) { throw 'Complexity gate failed' }
 ```
+
+**`-RequiredVersion`, not a floor.** A gate decides whether a build passes, and this
+module's metric has already moved twice for unchanged source. Without an exact version two
+machines on the same commit can legitimately disagree about whether the build is green --
+and the one that upgraded first looks like the one that broke it.
 
 ## Development
 

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -28,6 +28,20 @@ function Get-PSCxSourceFile {
             ForEach-Object { $_.FullName })
 }
 
+# Which metric produced a number. Two scores are comparable only if the same metric produced
+# them, and this module's metric has already moved twice for unchanged source: 0.3.0 taught it
+# PowerShell's own flow constructs, and 0.4.0 stopped merging two units written on one line.
+# Both were correct, and both silently re-scored code nobody had touched.
+#
+# It increments whenever a score can change for source that did not, which is a narrower rule
+# than the module version: a bug fix that only affects messages, or a new field on the record,
+# leaves it alone. Anything persisting or comparing scores -- a committed baseline, a diffed
+# report -- must refuse to compare across two different values rather than mix them.
+#
+# Starts at 1 with 0.4.0. Scores from earlier releases carry no version and are not comparable
+# with these; that is a statement about what was never recorded, not a claim that they agree.
+$script:PSCxMetricVersion = 1
+
 function Get-PSCxRelativePath {
     # A path two machines can agree on.
     #
@@ -171,6 +185,10 @@ function Measure-PSComplexity {
                         Line       = $lines[$k]
                         Cyclomatic = $cyc[$k]
                         Cognitive  = $cog[$k]
+                        # Last, so the four fields a reader scans stay together. Widening this
+                        # record fails the test that pins it, which is how this addition became
+                        # a decision rather than a side effect.
+                        MetricVersion = $script:PSCxMetricVersion
                     }
                 }
             }

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'the record shape a consumer depends on' {
         $row = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1'))[0]
         # Joined rather than Should-BeCollection, which ignores order: property order is
         # what Format-Table shows a consumer, so a reordering is a visible change.
-        ($row.PSObject.Properties.Name -join ',') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive'
+        ($row.PSObject.Properties.Name -join ',') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive,MetricVersion'
     }
 
     It 'emits those fields with the types a consumer sorts and compares on' {
@@ -45,6 +45,7 @@ Describe 'the record shape a consumer depends on' {
         $row.Line       | Should-HaveType ([int])
         $row.Cyclomatic | Should-HaveType ([int])
         $row.Cognitive  | Should-HaveType ([int])
+        $row.MetricVersion | Should-HaveType ([int])
     }
 
     It 'pins the shape for every record, not only the first' {
@@ -54,7 +55,7 @@ Describe 'the record shape a consumer depends on' {
         $rows = @(Measure-PSComplexity -Path $script:work -Recurse)
         $rows.Count | Should-BeGreaterThan 2
         $shapes = @($rows | ForEach-Object { $_.PSObject.Properties.Name -join ',' } | Sort-Object -Unique)
-        ($shapes -join ' | ') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive'
+        ($shapes -join ' | ') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive,MetricVersion'
     }
 }
 
@@ -180,6 +181,27 @@ Describe 'a function nested inside a class method' {
         $rows = @(Measure-PSComplexity -Path $f | Where-Object Unit -like '*Get-Inner')
         $rows.Count | Should-Be 1
         $rows[0].Unit | Should-Be 'C.M/Get-Inner'
+    }
+}
+
+Describe 'a score says which metric produced it' {
+    # Two numbers are comparable only if the same metric produced them, and this one has moved
+    # twice for unchanged source: 0.3.0 taught it PowerShell's flow constructs, 0.4.0 stopped
+    # merging two units written on one line. Both were corrections; both silently re-scored code
+    # nobody had touched. A committed baseline (#2) compares a stored score with a fresh one, so
+    # without this it would absorb an upgrade as if it were a change in the code.
+
+    It 'stamps every record with the metric version' {
+        $rows = @(Measure-PSComplexity -Path $script:work -Recurse)
+        $rows.Count | Should-BeGreaterThan 1
+        # Every record, not the first: a stamp applied in one branch of the emitter and not
+        # another is worse than none, because the gap is invisible.
+        @($rows | Where-Object { $_.MetricVersion -ne 1 }).Count | Should-Be 0
+    }
+
+    It 'is an int, so a consumer can compare it rather than parse it' {
+        (@(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1'))[0]).MetricVersion |
+            Should-HaveType ([int])
     }
 }
 


### PR DESCRIPTION
Closes #20. Folded into the unreleased 0.4.0 — which is the right release for it, because the metric moves in this one.

Two numbers are comparable only if the same metric produced them. This module’s metric has already moved **twice** for unchanged source:

| Release | What moved |
|---|---|
| 0.3.0 | learned PowerShell’s own flow constructs — `ForEach-Object`, `Where-Object`, `&&`, `\|\|`, `??` |
| 0.4.0 | stopped merging two units written on one line |

Both were corrections. Both silently re-scored code nobody had touched, and nothing in the output said so.

## The rule

`MetricVersion` increments **only when a score can change for source that did not** — narrower than the module version, so a fix affecting messages, or a new field on this record, leaves it alone.

It starts at **1** here. Earlier releases carry no version: that is a statement about what was never recorded, not a claim that they agree.

This is what #2 will need. A committed baseline compares a stored score against a fresh one, so without this an upgrade re-baselines every unit at once — either flooding the ratchet with regressions nobody caused, or absorbing real ones.

## The pin from #42 did its job

Adding a sixth field **failed** the test that asserts the record’s exact shape. Widening it was a decision made on purpose rather than something a consumer discovered later. That is the entire reason that test exists, and this is the first time it has been exercised.

## `-RequiredVersion`, not a floor

The README’s CI snippet installed with a version floor. A gate decides whether a build passes, so without an exact version two machines on the same commit can legitimately disagree about whether it is green — and the one that upgraded first looks like the one that broke it. That was wrong independently of this change; the issue says so too.

## Tested across every record

Not the first one. A stamp applied in one branch of the emitter and not another is worse than none, because the gap is invisible.

## Gates

Analyzer clean at every severity · suite **181 pass** · coverage **100%** over 337 commands · release gate clean. Self-mutation to follow.