### PR TITLE
fix: resolve a relative path against Root, not the working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ keys it holds could not distinguish units the tool could.
 
 ### Fixed
 
+- **A relative path now resolves against the root it was given, not against the working
+  directory.** `Get-PSCxRelativePath` called `GetFullPath` on its `Path` argument directly, so
+  a relative one silently resolved against wherever the shell happened to be standing. It gave
+  the right answer only while its single caller passed an absolute path **and** a root equal to
+  the current directory -- two conditions that both had to hold and neither of which was
+  stated. Not reachable today; the sibling project shipped the same shape and it was a live
+  hole there, because a config may name a file by full path.
+
+
 - **CI now fails when `main` claims a version that has already shipped.** It once did: `main`
   stood at 0.2.0, 0.2.0 was on the gallery, and merged work sat under `[Unreleased]` with every
   gate green. Two people installing "0.2.0" -- one from the gallery, one from a clone -- got

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -65,7 +65,13 @@ function Get-PSCxRelativePath {
         [Parameter(Mandatory)] [string]$Path,
         [Parameter(Mandatory)] [string]$Root
     )
-    $full = [System.IO.Path]::GetFullPath($Path)
+    # A RELATIVE Path resolves against Root, not against the working directory. GetFullPath
+    # alone silently uses the CWD, so the function only gave the right answer while its one
+    # caller happened to pass an absolute path AND a Root equal to the CWD -- two conditions
+    # that both had to hold and neither of which was stated. The sibling project shipped the
+    # same shape and it was a live hole there, because a config may name a file by full path.
+    $full = if ([System.IO.Path]::IsPathRooted($Path)) { [System.IO.Path]::GetFullPath($Path) }
+    else { [System.IO.Path]::GetFullPath((Join-Path $Root $Path)) }
     $rootFull = [System.IO.Path]::GetFullPath($Root)
     if (-not $rootFull.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
         $rootFull += [System.IO.Path]::DirectorySeparatorChar

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -154,6 +154,24 @@ function Get-OuterB { function Get-Inner { if ($y) { 1 } if ($z) { 2 } } }
 }
 
 Describe 'Get-PSCxRelativePath' {
+    It 'resolves a relative path against Root, not against the working directory' {
+        # The function only gave the right answer while its one caller happened to pass an
+        # absolute path AND a Root equal to the CWD. Both had to hold; neither was stated. A
+        # second caller passing a relative path would have got a path under wherever the shell
+        # happened to be standing, which is a wrong answer that looks entirely plausible.
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) 'some-repo'
+        Push-Location ([System.IO.Path]::GetTempPath())
+        try { Get-PSCxRelativePath -Path 'src/a.ps1' -Root $root | Should-Be 'src/a.ps1' }
+        finally { Pop-Location }
+    }
+
+    It 'still takes an absolute path as it stands' {
+        # The kept half: the production caller passes absolute paths, so a fix that only
+        # handled the relative case would break the one path that actually runs.
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) 'some-repo'
+        Get-PSCxRelativePath -Path (Join-Path $root 'src/b.ps1') -Root $root | Should-Be 'src/b.ps1'
+    }
+
     It 'strips a root that already ends with a separator' {
         # A root ending in a separator is not exotic -- a drive root and the temp directory
         # both do. Appending a second one unconditionally makes the prefix match fail, and the


### PR DESCRIPTION
Carried across from a PSMutant finding — which is the point of the two repos being siblings. The same shape shipped in both, and it was a **live hole** there.

## The defect

`Get-PSCxRelativePath` called `GetFullPath` on its `Path` argument directly:

```powershell
$full = [System.IO.Path]::GetFullPath($Path)   # relative -> resolves against the CWD
```

So a relative `Path` resolved against wherever the shell happened to be standing, ignoring `Root` entirely:

```
Get-PSCxRelativePath -Path src/a.ps1 -Root C:\...\Temp\some-repo
  ->  C:/Users/taeke/source/repos/PSComplexity/src/a.ps1     # the CWD, not the root
```

It gave the right answer only because its single caller passes an absolute path from `Get-ChildItem` **and** `-Root (Get-Location).Path`. Two conditions that both had to hold, and neither was written down.

## Not reachable today

This is a trap for the next caller, not a bug for a user — and it costs three lines to remove. In PSMutant the equivalent *was* reachable, because a config may name a file by full path, and it reported a path pointing anywhere on the machine as safely inside the sandbox. Worth removing here before someone adds the second caller.

## Tests

Paired, per the house rule: the relative case is the fix, and the absolute case is the one that actually runs in production. A change that only handled the first would break the second.

## Gates

Covering suite only (`Measure.Tests.ps1`, **65 pass**) — it is a three-line change to one function. Analyzer clean, checked by **inspecting its findings** rather than its exit code, which is exactly the mistake #85 was just filed for.