### PR TITLE
test: close the construct vocabulary against the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,17 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **The construct vocabulary is closed against the parser.** The metrics recognise a
+  hand-maintained allowlist spread over three places, and nothing compared it against what the
+  parser can actually produce -- so a construct the module has never heard of contributed
+  nothing and the unit containing it scored as straight-line code. The direction is what made
+  it dangerous: an unrecognised construct can only lower a score, so the gate passed most
+  easily on the code it understood least. Every one of the 66 concrete `Ast` types is now
+  either handled by a metric or carries a written reason for not being; 42 exclusions, each
+  with its argument. The next PowerShell release turns the suite red instead of quietly
+  lowering everyone's numbers.
+
+
 - **A score now says which metric produced it.** Records carry `MetricVersion`, an int that
   increments whenever a score can change for source that did not -- a narrower rule than the
   module version, so a fix that only affects messages, or a new field on the record, leaves it

--- a/tests/Vocabulary.Tests.ps1
+++ b/tests/Vocabulary.Tests.ps1
@@ -1,0 +1,106 @@
+# The construct vocabulary, closed against the parser.
+#
+# The metrics recognise a hand-maintained allowlist spread over three places, and nothing
+# compared those lists against what the parser can actually PRODUCE. The direction is what
+# makes that dangerous: a construct the module has never heard of contributes nothing, so the
+# unit containing it scores as straight-line code. A gate then passes most easily on the code
+# it understood least, which is the failure that looks like success.
+#
+# This test fails when PowerShell gains a type. That is the point -- the next release turns
+# the suite red instead of quietly lowering everyone's scores.
+
+BeforeAll {
+    $script:ExcludedWithReason = @{
+        'ScriptBlockAst' = 'a container for blocks; the unit boundary, not a branch'
+        'StatementBlockAst' = 'the body of something else -- whatever owns it is what decides'
+        'NamedBlockAst' = 'begin/process/end are phases, not branches'
+        'ParamBlockAst' = 'a declaration'
+        'PipelineAst' = 'sequencing; the commands in it are scored individually'
+        'CommandExpressionAst' = 'wraps an expression so it can sit in a pipeline'
+        'ParenExpressionAst' = 'grouping, with no effect on control flow'
+        'SubExpressionAst' = '$( ) evaluates its contents; those contents are scored on their own'
+        'ArrayExpressionAst' = '@( ) is grouping, same as above'
+        'ConstantExpressionAst' = 'a literal'
+        'StringConstantExpressionAst' = 'a literal'
+        'ExpandableStringExpressionAst' = 'a literal with interpolation; the interpolated parts are scored where they appear'
+        'ArrayLiteralAst' = 'a literal'
+        'HashtableAst' = 'a literal'
+        'MemberExpressionAst' = 'property access, no branch'
+        'IndexExpressionAst' = 'indexing, no branch'
+        'BaseCtorInvokeMemberExpressionAst' = 'a base constructor call is unconditional'
+        'ConvertExpressionAst' = 'a cast'
+        'AttributedExpressionAst' = 'an attribute on an expression'
+        'TypeConstraintAst' = 'a type annotation'
+        'AttributeAst' = 'metadata'
+        'NamedAttributeArgumentAst' = 'metadata'
+        'ParameterAst' = 'a declaration'
+        'CommandParameterAst' = 'an argument name'
+        'AssignmentTarget' = 'the left side of an assignment; the assignment is scored, not its target'
+        'UnaryExpressionAst' = '-not and friends invert a value without adding a path'
+        'ReturnStatementAst' = 'an unconditional exit. SonarSource increments for a LABELLED jump, and a return is never labelled'
+        'ThrowStatementAst' = 'an unconditional exit'
+        'ExitStatementAst' = 'an unconditional exit'
+        'TryStatementAst' = 'try itself is not a decision -- the CATCH is, and CatchClauseAst is scored'
+        'FileRedirectionAst' = 'plumbing'
+        'MergingRedirectionAst' = 'plumbing'
+        'UsingExpressionAst' = '$using: marks a variable for another scope'
+        'UsingStatementAst' = 'a module or namespace import'
+        'DataStatementAst' = 'a restricted-language literal section'
+        'ConfigurationDefinitionAst' = 'DSC, and a deliberate gap: a configuration is a declaration, so treating it as a unit would report numbers for something with no control flow'
+        'DynamicKeywordStatementAst' = 'DSC'
+        'BlockStatementAst' = 'DSC parallel/sequence blocks'
+        'ErrorExpressionAst' = 'only produced for source that did not parse, which Measure-PSComplexity refuses before it reaches a metric'
+        'ErrorStatementAst' = 'same: unparseable source is refused, not measured'
+        'CompilerGeneratedMemberFunctionAst' = 'a synthesised default constructor. Not in the source, so scoring it would report a unit nobody wrote'
+        'SequencePointAst' = 'a debugger artefact, never present in a tree from ParseFile'
+    }
+
+    $script:AllAstTypes = @(
+        [System.Management.Automation.Language.Ast].Assembly.GetTypes() |
+            Where-Object { $_.IsSubclassOf([System.Management.Automation.Language.Ast]) -and -not $_.IsAbstract } |
+            ForEach-Object { $_.Name }
+    )
+
+    # Handled = named in the CODE of src/, comments stripped. Tokenised rather than grepped,
+    # because a type mentioned only in a comment would otherwise count as handled -- the same
+    # optimism this test exists to remove, one level up.
+    $srcDir = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
+    $code = foreach ($f in Get-ChildItem $srcDir -Filter *.ps1) {
+        $tokens = $null; $errs = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($f.FullName, [ref]$tokens, [ref]$errs) | Out-Null
+        ($tokens | Where-Object { $_.Kind -ne 'Comment' } | ForEach-Object { $_.Text }) -join ' '
+    }
+    $joined = $code -join ' '
+    $script:HandledTypes = @($script:AllAstTypes | Where-Object { $joined -match "\b$_\b" })
+}
+
+Describe 'the construct vocabulary is closed against the parser' {
+    It 'classifies every Ast type the parser can emit' {
+        # Joined into one string so a failure names the newcomer, rather than reporting a
+        # count that differs by one.
+        $unclassified = @($script:AllAstTypes |
+                Where-Object { $_ -notin $script:HandledTypes -and -not $script:ExcludedWithReason.ContainsKey($_) })
+        ($unclassified | Sort-Object) -join ', ' | Should-Be ''
+    }
+
+    It 'excludes nothing it actually handles' {
+        # The other direction. An entry that is both handled and excluded means the list has
+        # gone stale, and its reason now argues against something the code does -- worse than
+        # no reason at all.
+        $both = @($script:ExcludedWithReason.Keys | Where-Object { $_ -in $script:HandledTypes })
+        ($both | Sort-Object) -join ', ' | Should-Be ''
+    }
+
+    It 'excludes nothing the parser cannot produce' {
+        # A third staleness direction: an exclusion for a type that no longer exists reads as
+        # a considered decision and is dead text.
+        $ghosts = @($script:ExcludedWithReason.Keys | Where-Object { $_ -notin $script:AllAstTypes })
+        ($ghosts | Sort-Object) -join ', ' | Should-Be ''
+    }
+
+    It 'gives every exclusion a reason' {
+        $blank = @($script:ExcludedWithReason.GetEnumerator() |
+                Where-Object { [string]::IsNullOrWhiteSpace($_.Value) } | ForEach-Object { $_.Key })
+        ($blank | Sort-Object) -join ', ' | Should-Be ''
+    }
+}


### PR DESCRIPTION
Closes #18. Folded into the unreleased 0.4.0.

The metrics recognise a hand-maintained allowlist spread over three places, and **nothing compared it against what the parser can produce**. A construct the module has never heard of contributes nothing, so the unit containing it scores as straight-line code.

The direction is what makes that dangerous: an unrecognised construct can only make a score **lower**. So the gate passes most easily on the code it understood least — the failure that looks like success.

## What it asserts

All **66** concrete `Ast` types are either handled by a metric or carry a written reason for not being — **42 exclusions**, each with its argument:

- an unconditional exit is not a decision (`return`, `throw`, `exit`) — SonarSource increments for a *labelled* jump, and a return is never labelled
- a container is not a branch (`ScriptBlockAst`, `PipelineAst`, `ParenExpressionAst`, …)
- `try` is not a decision — the **catch** is, and `CatchClauseAst` is scored
- DSC is a deliberate gap: a configuration is a declaration, so treating it as a unit would report numbers for something with no control flow
- `ErrorExpressionAst` / `ErrorStatementAst` never reach a metric, because unparseable source is refused first

**Handled is derived from the code of `src/`, comments stripped** — tokenised, not grepped. A type named only in a comment would otherwise count as handled, which is the same optimism this test exists to remove, one level up.

## It fails in three staleness directions, not one

A bare exclusion list is just a second allowlist — and this issue rejects merging the three source lists for exactly that reason: *one list is as blind to a new construct as three*. So it also catches an exclusion that argues against something the code now handles, and an exclusion for a type the parser can no longer emit, plus one with no reason.

Verified by breaking each claim in a copy:

```
a type nobody classified (exclusion removed)     failures=1
an exclusion for a type the code handles         failures=1
an exclusion for a type the parser cannot emit   failures=1
an exclusion with an empty reason                failures=1
```

Each fails alone, and only for its own case.

## The open question in the issue is already answered

#18 asks whether `PipelineChainAst` should count. **It already does**, since 0.3.0 — that half was settled before the mechanism to notice it existed.

## Gates

Full suite **187 pass** · analyzer clean, checked by inspecting findings rather than exit code (#85) · release gate clean.