### PR TITLE
feat: name each file before measuring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **A scan says what it is reading.** `Measure-PSComplexity -Verbose` now names each file
+  **before** parsing it, so a slow scan and a stuck one stop looking identical. The ordering is
+  the feature: a line written afterwards names a file that is already finished, and a scan stuck
+  on the next one would read exactly like a scan that completed. It matters because analysis is
+  O(nodes x depth), so one deeply nested file can dominate a run -- and because
+  `Test-PSComplexity` is the entry point people automate, so it runs against whole repositories
+  where nobody is watching a terminal. The gate inherits it through the nested call; silent
+  unless asked, because a gate that chatters by default gets its output filtered, and the filter
+  takes the parse errors with it.
+
+
 - **The construct vocabulary is closed against the parser.** The metrics recognise a
   hand-maintained allowlist spread over three places, and nothing compared it against what the
   parser can actually produce -- so a construct the module has never heard of contributed

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -152,6 +152,15 @@ function Measure-PSComplexity {
                 # OrdinalIgnoreCase: Windows and macOS resolve the same file under different
                 # casing, and a case-sensitive check would let those through as two files.
                 if (-not $seen.Add($file)) { continue }
+                # BEFORE the parse, not after. A line written afterwards names files that are
+                # already done, so a scan stuck on one file looks exactly like a scan that has
+                # finished -- which is the whole complaint. Named here, the last line printed
+                # IS the file being read.
+                #
+                # Verbose rather than a progress bar or a default-on line: this is the command
+                # a CI gate calls, and a gate that chatters gets its output filtered, which
+                # takes the parse errors with it.
+                Write-Verbose "Measuring $file"
                 $errors = $null
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$errors)
                 if ($errors) {

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -223,6 +223,48 @@ Describe 'a score says which metric produced it' {
     }
 }
 
+Describe 'a scan says what it is reading' {
+    # A slow scan and a stuck one looked identical: no output at all until everything was
+    # measured. That matters because analysis is O(nodes x depth), so one deeply nested file
+    # can dominate a run -- and because Test-PSComplexity is the entry point people automate,
+    # so it runs against whole repositories where nobody is watching a terminal.
+
+    It 'names each file as it is read' {
+        $lines = @(Measure-PSComplexity -Path $script:work -Recurse -Verbose 4>&1 |
+                Where-Object { $_ -is [System.Management.Automation.VerboseRecord] })
+        ($lines -join "`n") | Should-MatchString 'a\.ps1'
+        ($lines -join "`n") | Should-MatchString 'b\.ps1'
+    }
+
+    It 'names the file BEFORE measuring it, so a stuck scan points at the culprit' {
+        # The ordering is the whole feature. Written afterwards, the last line names a file
+        # that is already finished, and a scan stuck on the next one looks exactly like a scan
+        # that completed. Asserted by counting: the first verbose line must arrive before the
+        # first record does.
+        $stream = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1') -Verbose 4>&1)
+        $firstVerbose = [array]::FindIndex($stream, [Predicate[object]] { param($x) $x -is [System.Management.Automation.VerboseRecord] })
+        $firstRecord = [array]::FindIndex($stream, [Predicate[object]] { param($x) $x -isnot [System.Management.Automation.VerboseRecord] })
+        $firstVerbose | Should-BeLessThan $firstRecord
+    }
+
+    It 'says nothing when the caller did not ask' {
+        # The kept half. A gate that chatters by default gets its output filtered, and the
+        # filter takes the parse errors with it -- which are the one thing this command must
+        # never lose.
+        $lines = @(Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1') 4>&1 |
+                Where-Object { $_ -is [System.Management.Automation.VerboseRecord] })
+        $lines.Count | Should-Be 0
+    }
+
+    It 'reaches the gate, which is the command people automate' {
+        # Test-PSComplexity calls Measure-PSComplexity, so -Verbose has to survive the nested
+        # call for this to be worth anything to CI.
+        $lines = @(Test-PSComplexity -Path $script:work -Recurse -Verbose 4>&1 |
+                Where-Object { $_ -is [System.Management.Automation.VerboseRecord] })
+        $lines.Count | Should-BeGreaterThan 0
+    }
+}
+
 Describe 'the declared output types' {
     It 'declares what a caller actually receives, not an array of it' {
         # These commands STREAM individual records. [pscustomobject[]] claimed a single


### PR DESCRIPTION
Closes #73.

A scan produced **no output at all** until everything was measured, so a slow scan and a stuck one looked identical to whoever ran it.

```
Measure-PSComplexity   first record at 889ms, total 2092ms   -> streams
Test-PSComplexity      silent for 1676ms, then one boolean
```

Two things make that expensive rather than merely quiet: analysis is **O(nodes × depth)**, so cost per byte is not uniform and one deeply nested file can dominate a run; and `Test-PSComplexity` is the entry point people **automate**, so it runs against whole repositories, in CI, where nobody is watching a terminal.

## The ordering is the feature

The line goes **before** the parse. Written afterwards it names files that are already done — so a scan stuck on one file reads exactly like a scan that finished, which is the complaint. Named before, the last line printed *is* the file being read.

That is asserted rather than described: the test compares the index of the first verbose record against the index of the first output record.

## Where it lives, and why

In `Measure-PSComplexity`, because that is where the file list exists. `Test-PSComplexity` inherits it through the nested call — asserted, not assumed, since it is the command that makes this worth anything to CI.

**Verbose, not a progress bar or a default-on line.** A gate that chatters gets its output filtered, and the filter takes the parse errors with it — and those are the one thing this command must never lose. There is a paired test for the silent case for exactly that reason.

## Scope

Option 1 from the issue. Option 2 — emit the records as well — is #17’s business. Option 3 (a timeout or file-count bound) was rejected there: the honest answer to a slow scan is knowing which file is slow, not abandoning the scan.

## Gates

Suite **69 pass** in the covering file · coverage **100%** over 341 commands · analyzer clean, checked by inspecting findings rather than exit code (#85) · release gate clean.