### PR TITLE
test: attribute every reference score to its source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **Every reference score is attributed to something outside this project.** The README claims
+  the cognitive metric reproduces the SonarSource scores; the suite checked numbers the project
+  had chosen itself, so a wrong interpretation would have had the suite agreeing with the bug --
+  and the mutation gate agreeing too, because both only ever compare the code against itself.
+  Each case now names its source: 11 taken from the specification, the PowerShell extensions the
+  spec does not cover, and the vocabulary pins. A case added without attribution fails **by
+  name**, so a number this project chose cannot sit among the reference scores looking like one
+  of them -- including the two the specification calls the classic implementation errors, which
+  are asserted by count as well as present.
+
+
 - **A scan says what it is reading.** `Measure-PSComplexity -Verbose` now names each file
   **before** parsing it, so a slow scan and a stuck one stop looking identical. The ordering is
   the feature: a line written afterwards names a file that is already finished, and a scan stuck

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -4,7 +4,7 @@
 # these fail with the exact unit and number.
 
 $script:CognitiveCases = @(
-    @{ name = 'prime sieve: nested loops + labelled continue'; expected = 7; code = @'
+    @{ spec = 'Cognitive Complexity spec, Appendix C -- sumOfPrimes'; name = 'prime sieve: nested loops + labelled continue'; expected = 7; code = @'
 function Get-SumOfPrimes {
     param($max)
     $total = 0
@@ -19,64 +19,64 @@ function Get-SumOfPrimes {
     return $total
 }
 '@ }
-    @{ name = 'switch scores 1 (not per-case)'; expected = 1; code = @'
+    @{ spec = 'spec B1 -- switch takes ONE increment regardless of case count, unlike cyclomatic'; name = 'switch scores 1 (not per-case)'; expected = 1; code = @'
 function Get-Words { param($n) switch ($n) { 1 { 'one' } 2 { 'couple' } default { 'lots' } } }
 '@ }
-    @{ name = 'recursive fibonacci (if + 2 recursive calls)'; expected = 3; code = @'
+    @{ spec = 'spec B1 -- recursion is a structural increment; Appendix A fibonacci'; name = 'recursive fibonacci (if + 2 recursive calls)'; expected = 3; code = @'
 function Get-Fib { param($n) if ($n -le 1) { return $n }; return (Get-Fib ($n - 1)) + (Get-Fib ($n - 2)) }
 '@ }
-    @{ name = 'a -and b -and c is one run'; expected = 2; code = 'function T { param($a,$b,$c) if ($a -and $b -and $c) { 1 } }' }
-    @{ name = 'a -and b -or c is two runs'; expected = 3; code = 'function T { param($a,$b,$c) if ($a -and $b -or $c) { 1 } }' }
-    @{ name = 'nested if (structural + nesting)'; expected = 3; code = 'function T { param($a,$b) if ($a) { if ($b) { 1 } } }' }
+    @{ spec = 'spec B1 -- a sequence of like operators is ONE increment'; name = 'a -and b -and c is one run'; expected = 2; code = 'function T { param($a,$b,$c) if ($a -and $b -and $c) { 1 } }' }
+    @{ spec = 'spec B1 -- one increment per CHANGE of operator. The classic implementation error'; name = 'a -and b -or c is two runs'; expected = 3; code = 'function T { param($a,$b,$c) if ($a -and $b -or $c) { 1 } }' }
+    @{ spec = 'spec B3 -- a nested if takes its own increment plus the nesting level'; name = 'nested if (structural + nesting)'; expected = 3; code = 'function T { param($a,$b) if ($a) { if ($b) { 1 } } }' }
     # Paired deliberately: only the LABELLED jump adds a point. A fixture with just the
     # labelled case passes equally well against a rule that counts every break.
-    @{ name = 'bare break adds nothing beyond its loop'; expected = 1; code = 'function T { foreach ($i in 1..3) { break } }' }
-    @{ name = 'labelled break adds one'; expected = 2; code = 'function T { :outer foreach ($i in 1..3) { break outer } }' }
-    @{ name = 'else and elseif each add 1, no nesting bonus'; expected = 3; code = 'function T { param($a) if ($a -eq 1) { 1 } elseif ($a -eq 2) { 2 } else { 3 } }' }
-    @{ name = 'labelled break'; expected = 4; code = 'function T { param($n) :L for ($i = 0; $i -lt $n; $i++) { if ($i -eq 3) { break L } } }' }
-    @{ name = 'do-until loop'; expected = 1; code = 'function T { param($n) $i = 0; do { $i++ } until ($i -ge $n) }' }
-    @{ name = 'nested ternary'; expected = 3; code = 'function T { param($x, $y) $x ? ($y ? 1 : 2) : 3 }' }
+    @{ spec = 'spec B1 -- an unlabelled jump takes no increment'; name = 'bare break adds nothing beyond its loop'; expected = 1; code = 'function T { foreach ($i in 1..3) { break } }' }
+    @{ spec = 'spec B1 -- a LABELLED jump takes one, with no nesting bonus'; name = 'labelled break adds one'; expected = 2; code = 'function T { :outer foreach ($i in 1..3) { break outer } }' }
+    @{ spec = 'spec B2 -- else/else-if are +1 flat. The second classic implementation error'; name = 'else and elseif each add 1, no nesting bonus'; expected = 3; code = 'function T { param($a) if ($a -eq 1) { 1 } elseif ($a -eq 2) { 2 } else { 3 } }' }
+    @{ spec = 'spec B1/B3 -- labelled jump inside nested loops'; name = 'labelled break'; expected = 4; code = 'function T { param($n) :L for ($i = 0; $i -lt $n; $i++) { if ($i -eq 3) { break L } } }' }
+    @{ spec = 'spec B1 -- a loop takes one increment'; name = 'do-until loop'; expected = 1; code = 'function T { param($n) $i = 0; do { $i++ } until ($i -ge $n) }' }
+    @{ spec = 'EXTENSION -- the spec has no ternary; scored as the if it stands in for'; name = 'nested ternary'; expected = 3; code = 'function T { param($x, $y) $x ? ($y ? 1 : 2) : 3 }' }
     # 3, not 2: ForEach-Object is itself an increment now, on top of the nesting its block
     # already gave the if. The keyword form below must score the SAME, which is the whole
     # claim -- and is why the two are listed together rather than apart.
-    @{ name = 'if inside ForEach-Object'; expected = 3; code = 'function T { param($items) $items | ForEach-Object { if ($_) { 1 } } }' }
-    @{ name = 'if inside foreach keyword scores identically'; expected = 3; code = 'function T { param($items) foreach ($i in $items) { if ($i) { 1 } } }' }
-    @{ name = 'Where-Object is a conditional'; expected = 1; code = 'function T { param($items) $items | Where-Object { $_ -gt 0 } }' }
-    @{ name = '&& is one run, like -and'; expected = 1; code = 'function T { a && b && c }' }
-    @{ name = '&& then || is two runs'; expected = 2; code = 'function T { a && b || c }' }
-    @{ name = 'null-coalescing is a conditional'; expected = 1; code = 'function T { param($a, $b) $x = $a ?? $b }' }
-    @{ name = 'null-coalescing ASSIGNMENT is a conditional too'; expected = 1; code = 'function T { param($a) $a ??= 1 }' }
+    @{ spec = 'EXTENSION -- PowerShell pipeline flow the spec does not cover'; name = 'if inside ForEach-Object'; expected = 3; code = 'function T { param($items) $items | ForEach-Object { if ($_) { 1 } } }' }
+    @{ spec = 'EXTENSION -- the pipeline form must cost what the keyword form costs'; name = 'if inside foreach keyword scores identically'; expected = 3; code = 'function T { param($items) foreach ($i in $items) { if ($i) { 1 } } }' }
+    @{ spec = 'EXTENSION -- PowerShell pipeline flow the spec does not cover'; name = 'Where-Object is a conditional'; expected = 1; code = 'function T { param($items) $items | Where-Object { $_ -gt 0 } }' }
+    @{ spec = 'EXTENSION -- pipeline chains follow the spec B1 run rule'; name = '&& is one run, like -and'; expected = 1; code = 'function T { a && b && c }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = '&& then || is two runs'; expected = 2; code = 'function T { a && b || c }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'null-coalescing is a conditional'; expected = 1; code = 'function T { param($a, $b) $x = $a ?? $b }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'null-coalescing ASSIGNMENT is a conditional too'; expected = 1; code = 'function T { param($a) $a ??= 1 }' }
     # A command invoked through a variable has no name a static walk can read. The flow-command
     # test must answer "no" rather than dereference it -- paired with the ForEach-Object cases
     # above, which are the "yes" side of the same predicate.
-    @{ name = 'a command with no readable name is not flow'; expected = 0; code = 'function T { param($cmd) & $cmd arg }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'a command with no readable name is not flow'; expected = 0; code = 'function T { param($cmd) & $cmd arg }' }
     # NESTED, deliberately. At nesting 0 the increment is 1 + 0, which is indistinguishable
     # from 1 - 0: the arithmetic itself is only pinned when the nesting term is non-zero.
-    @{ name = 'ForEach-Object nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $xs) if ($a) { $xs | ForEach-Object { $_ } } }' }
-    @{ name = 'null-coalescing nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x, $y) if ($a) { $z = $x ?? $y } }' }
-    @{ name = 'null-coalescing assignment nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x) if ($a) { $x ??= 1 } }' }
-    @{ name = 'flat function scores 0'; expected = 0; code = 'function T { param($x) $y = $x + 1; return $y }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'ForEach-Object nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $xs) if ($a) { $xs | ForEach-Object { $_ } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'null-coalescing nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x, $y) if ($a) { $z = $x ?? $y } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'null-coalescing assignment nested in an if pays the nesting'; expected = 3; code = 'function T { param($a, $x) if ($a) { $x ??= 1 } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'flat function scores 0'; expected = 0; code = 'function T { param($x) $y = $x + 1; return $y }' }
     # Every remaining entry in the cognitive block list, flat. Four of the eight type names
     # could be DELETED with the whole suite green: tests/ contained no `catch` and no `trap`
     # at all, and a do-until but no do-while.
-    @{ name = 'while = 1'; expected = 1; code = 'function T { param($n) while ($n -gt 0) { $n-- } }' }
-    @{ name = 'do-while = 1'; expected = 1; code = 'function T { param($n) do { $n-- } while ($n -gt 0) }' }
-    @{ name = 'catch = 1'; expected = 1; code = 'function T { try { 1 } catch { 2 } }' }
-    @{ name = 'trap = 1'; expected = 1; code = 'function T { trap { continue } 1 }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'while = 1'; expected = 1; code = 'function T { param($n) while ($n -gt 0) { $n-- } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'do-while = 1'; expected = 1; code = 'function T { param($n) do { $n-- } while ($n -gt 0) }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'catch = 1'; expected = 1; code = 'function T { try { 1 } catch { 2 } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'trap = 1'; expected = 1; code = 'function T { trap { continue } 1 }' }
 
     # And every entry in $script:PSCxNestingTypes, which is a DIFFERENT list and needs a
     # different shape: an `if` INSIDE the construct. "X inside an if" pins IfStatementAst's
     # membership, not X's -- the nesting bonus belongs to whatever encloses. Each of these is
     # construct(1) + if(1 + 1 nesting) = 3, and drops to 2 the moment the construct stops
     # raising nesting.
-    @{ name = 'while raises nesting'; expected = 3; code = 'function T { param($n,$a) while ($n -gt 0) { if ($a) { 1 } } }' }
-    @{ name = 'for raises nesting'; expected = 3; code = 'function T { param($a) for ($i = 0; $i -lt 3; $i++) { if ($a) { 1 } } }' }
-    @{ name = 'do-while raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } while ($n -gt 0) }' }
-    @{ name = 'do-until raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } until ($n -le 0) }' }
-    @{ name = 'switch raises nesting'; expected = 3; code = 'function T { param($a,$b) switch ($a) { 1 { if ($b) { 2 } } } }' }
-    @{ name = 'catch raises nesting'; expected = 3; code = 'function T { param($a) try { 1 } catch { if ($a) { 2 } } }' }
-    @{ name = 'trap raises nesting'; expected = 3; code = 'function T { param($a) trap { if ($a) { continue } } 1 }' }
-    @{ name = 'foreach raises nesting'; expected = 3; code = 'function T { param($xs,$a) foreach ($x in $xs) { if ($a) { 1 } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'while raises nesting'; expected = 3; code = 'function T { param($n,$a) while ($n -gt 0) { if ($a) { 1 } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'for raises nesting'; expected = 3; code = 'function T { param($a) for ($i = 0; $i -lt 3; $i++) { if ($a) { 1 } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'do-while raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } while ($n -gt 0) }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'do-until raises nesting'; expected = 3; code = 'function T { param($n,$a) do { if ($a) { 1 } } until ($n -le 0) }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'switch raises nesting'; expected = 3; code = 'function T { param($a,$b) switch ($a) { 1 { if ($b) { 2 } } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'catch raises nesting'; expected = 3; code = 'function T { param($a) try { 1 } catch { if ($a) { 2 } } }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'trap raises nesting'; expected = 3; code = 'function T { param($a) trap { if ($a) { continue } } 1 }' }
+    @{ spec = 'VOCABULARY -- pins a construct-list entry, not a reference score'; name = 'foreach raises nesting'; expected = 3; code = 'function T { param($xs,$a) foreach ($x in $xs) { if ($a) { 1 } } }' }
 )
 
 BeforeAll {
@@ -238,5 +238,45 @@ Describe 'Test-PSCxLogicalRunStart' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput('$a + $b', [ref]$null, [ref]$null)
         $bin = $ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)[0]
         Test-PSCxLogicalRunStart -Node $bin | Should-BeFalse
+    }
+}
+
+# Counted at DISCOVERY, where the case table exists. Inside an It body $script:CognitiveCases
+# is out of scope and evaluates to nothing -- which made the first version of the attribution
+# test pass over an empty collection. A vacuous pass, in the test written to stop exactly that.
+$script:SpecCases = @($script:CognitiveCases | Where-Object { $_.spec -like 'spec*' -or $_.spec -like 'Cognitive Complexity spec*' })
+$script:ExtensionCases = @($script:CognitiveCases | Where-Object { $_.spec -like 'EXTENSION*' })
+$script:ClassicErrorCases = @($script:CognitiveCases | Where-Object { $_.spec -match 'classic implementation error' })
+
+Describe 'every reference score is attributed to something outside this project' {
+    # The README claims these reproduce the SonarSource scores. The suite checked numbers the
+    # project had chosen itself, so if an interpretation were wrong the suite would agree with
+    # the bug -- and so would the mutation gate, because both only ever compare the code
+    # against itself. An attribution does not make a number right; it makes the claim
+    # CHECKABLE by someone holding the specification.
+
+    It 'attributes <name>' -ForEach $script:CognitiveCases {
+        # One test per case, so a new case added without attribution fails by name. Nobody can
+        # add a number this project chose and have it sit among the reference scores looking
+        # like one of them.
+        [string]::IsNullOrWhiteSpace($spec) | Should-BeFalse
+    }
+
+    It 'carries <Count> cases taken from the specification itself' -ForEach @(@{ Count = 11; Actual = $script:SpecCases.Count }) {
+        $Actual | Should-Be $Count
+    }
+
+    It 'keeps <Count> case(s) the spec calls a classic implementation error' -ForEach @(@{ Count = 2; Actual = $script:ClassicErrorCases.Count }) {
+        # Named rather than counted alone: these two are where implementations are known to
+        # disagree -- one increment per CHANGE of boolean operator, and else/else-if flat with
+        # no nesting bonus. If either regressed the score would stay entirely plausible.
+        $Actual | Should-Be $Count
+    }
+
+    It 'keeps the PowerShell extensions distinguishable from the spec cases' -ForEach @(@{ Actual = $script:ExtensionCases.Count }) {
+        # The extensions are not reference scores and must not be mistaken for them: the spec
+        # says nothing about ForEach-Object or ??, so a disagreement there is a decision this
+        # project owns rather than a bug against an external standard.
+        $Actual | Should-BeGreaterThan 0
     }
 }


### PR DESCRIPTION
Closes #4 — **and closes Wave C with it.**

The README claims the cognitive metric reproduces the SonarSource reference scores. The suite checked numbers **the project had chosen itself**, so if an interpretation were wrong the suite would agree with the bug — and so would the mutation gate, because both only ever compare the code against itself. As the issue puts it, this is the one claim the current setup structurally cannot verify.

## What was already true

The behaviour is right. All eleven reference cases pass, including **both** the specification calls the classic implementation errors:

| | |
|---|---|
| `a -and b -or c` = 3 | one increment per **change** of operator, not per operator |
| `else` / `elseif` = 3 | flat, with no nesting bonus |

What was missing is **traceability**. An attribution does not make a number right; it makes the claim checkable by someone holding the spec.

## What changed

Every case now names its source — 11 from the specification, the PowerShell extensions the spec does not cover (`ForEach-Object`, `??`, ternary), and the vocabulary pins added for #32. A case added without attribution **fails by name**, so a number this project chose cannot sit among the reference scores looking like one of them.

Verified all three assertions can fail:

```
a case added with no attribution                 failures=1
a spec case quietly downgraded to an extension   failures=1
one classic-error case relabelled                failures=1
```

## Two mistakes worth recording

**The first version passed vacuously.** `$script:CognitiveCases` is out of scope inside an `It` body, so "no unattributed cases" was asserted over an **empty collection** — in the test written to stop exactly that. Counts now travel as data through `-ForEach`, which is evaluated at discovery where the table exists.

**The first attempt to prove the classic-error assertion could fail was self-cancelling.** It replaced the phrase in the cases *and* in the filter that counts them, so the count stayed 2 and it reported `failures=0`. Retargeted at a single case, it fails.

## Gates

Suite **93 pass** in the covering file · coverage **100%** over 341 commands · analyzer clean, checked by inspecting findings rather than exit code (#85) · release gate clean.