### PR TITLE
feat: watch the pinned dependencies instead of only writing them down

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Watches the one class of pin that .github/pins.env cannot hold.
+#
+# `uses:` does not expand variables, so action SHAs are written out per workflow and have to be
+# kept in step by hand. A SHA also cannot be read to find out whether something newer exists --
+# unlike a module version, looking at it tells you nothing. So this is the half that needs a
+# watcher rather than a shared file.
+#
+# It opens pull requests rather than failing builds: a stale pin is a decision to make, not a
+# build to break, and a scheduled job that goes red for something nobody chose gets muted.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci

--- a/.github/workflows/pin-freshness.yml
+++ b/.github/workflows/pin-freshness.yml
@@ -1,0 +1,63 @@
+# Watches the module pins. The action SHAs are Dependabot's half -- see .github/dependabot.yml.
+#
+# A pin is a decision that was correct on the day it was made. Nothing watched them, and the
+# failure is asymmetric: a stale pin never breaks the build, it just quietly stops protecting
+# you. The PSMutant pin sat at 0.1.0 across two majors -- one of which fixed a bug that scored
+# EVERY mutant killed -- and CI was green throughout. It was found by reading the file.
+name: Pin freshness
+
+on:
+  schedule:
+    # Weekly, and deliberately not on push: a pin does not go stale because someone committed.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: pin-freshness
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check pinned modules against the gallery
+        id: check
+        shell: pwsh
+        run: |
+          # The script REPORTS; it does not throw. A stale pin is a decision to make rather
+          # than a build to break, so the finding becomes an issue below.
+          $faults = @(./tools/Test-PSCxPinFreshness.ps1)
+          if ($faults.Count -eq 0) { Write-Host 'Every pinned module is current.'; return }
+          $faults | ForEach-Object { Write-Host "STALE: $_" }
+          $body = "The scheduled pin check found dependencies that have moved on.`n`n" +
+                  (($faults | ForEach-Object { "- $_" }) -join "`n") +
+                  "`n`nA pin is a decision that was correct on the day it was made. Bump it or " +
+                  "record why it stays, but do not leave it undecided -- a stale pin never breaks " +
+                  "the build, it just stops protecting you."
+          "body<<EOF"  >> $env:GITHUB_OUTPUT
+          $body        >> $env:GITHUB_OUTPUT
+          "EOF"        >> $env:GITHUB_OUTPUT
+
+      - name: Open or update the tracking issue
+        if: steps.check.outputs.body != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY: ${{ steps.check.outputs.body }}
+        shell: pwsh
+        run: |
+          # One issue, reopened and rewritten, rather than a new one every week -- a watcher
+          # that files duplicates gets muted, which is the same outcome as not watching.
+          $title = 'Pinned dependencies have moved on'
+          $existing = gh issue list --state all --search "$title in:title" --json number,state --limit 1 | ConvertFrom-Json
+          if ($existing) {
+            gh issue edit $existing[0].number --body $env:BODY
+            if ($existing[0].state -eq 'CLOSED') { gh issue reopen $existing[0].number }
+          }
+          else { gh issue create --title $title --body $env:BODY }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **Pinned dependencies are watched instead of only written down.** A weekly job checks each
+  pinned module against the gallery and opens one tracking issue when any has moved on;
+  Dependabot watches the action SHAs, which `pins.env` structurally cannot hold because `uses:`
+  does not expand variables and a SHA cannot be read to learn whether something newer exists.
+  A pin is a decision that was correct on the day it was made, and the failure is asymmetric --
+  a stale pin never breaks the build, it just quietly stops protecting you. The PSMutant pin sat
+  at 0.1.0 across two majors, one of which fixed a bug that scored **every** mutant killed, and
+  CI was green throughout. An unreachable gallery is reported as **unknown** rather than as
+  current, because a watcher that reads "could not look" as "nothing newer" has silently stopped
+  being able to fail.
+
+
 - **A scan says what it is reading.** `Measure-PSComplexity -Verbose` now names each file
   **before** parsing it, so a slow scan and a stuck one stop looking identical. The ordering is
   the feature: a line written afterwards names a file that is already finished, and a scan stuck

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -297,3 +297,50 @@ Describe 'main must not claim a version that already shipped' {
         Should-BeFalse -Actual (Test-PSCxHasUnreleasedContent -Lines $lines)
     }
 }
+
+Describe 'a pin is watched, not just written down' {
+    # A pin is a decision that was correct on the day it was made. Nothing watched them, and
+    # the failure is asymmetric: a stale pin never breaks the build, it just quietly stops
+    # protecting you. The PSMutant pin sat at 0.1.0 across two majors -- one of which fixed a
+    # bug that scored EVERY mutant killed -- and CI was green throughout.
+
+    It 'reports a pin the gallery has moved past' {
+        Get-PSCxStalePinFault -Name 'Pester' -Pinned '5.0.0' -Latest '6.1.0' |
+            Should-MatchString ([regex]::Escape('6.1.0 is available'))
+    }
+
+    It 'says nothing when the pin is the newest release' {
+        # First kept case. Without it, a checker that faulted on every pin would pass the
+        # test above and file an issue every week about nothing.
+        Should-BeNull -Actual (Get-PSCxStalePinFault -Name 'Pester' -Pinned '6.1.0' -Latest '6.1.0')
+    }
+
+    It 'says nothing when the pin is ahead of the gallery' {
+        # Second kept case, and not hypothetical: a prerelease or a yanked version leaves the
+        # pin ahead, and a string comparison would call 6.1.0 newer than 10.0.0.
+        Should-BeNull -Actual (Get-PSCxStalePinFault -Name 'Pester' -Pinned '10.0.0' -Latest '6.1.0')
+    }
+
+    It 'reports an unreachable gallery as unknown, not as current' {
+        # The one that decides whether this is worth having. Find-Module returns nothing both
+        # when a module is current and when the gallery cannot be reached; treating those
+        # alike would make every run report all-clear -- a watcher that has silently stopped
+        # being able to fail.
+        Get-PSCxStalePinFault -Name 'Pester' -Pinned '6.1.0' -Latest '' |
+            Should-MatchString 'freshness is unknown'
+    }
+
+    It 'reports a module with no pin at all' {
+        Get-PSCxStalePinFault -Name 'Pester' -Pinned '' -Latest '6.1.0' |
+            Should-MatchString 'no pinned version'
+    }
+
+    It 'watches every module the workflows install' {
+        # The list in the checker and the keys in pins.env must not drift apart: a module
+        # installed by CI and absent from the watcher is exactly the pin that goes stale.
+        $script = Get-Content -LiteralPath (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/Test-PSCxPinFreshness.ps1') -Raw
+        foreach ($key in 'PESTER_VERSION', 'PSSA_VERSION', 'PSMUTANT_VERSION', 'CONVERTTOSARIF_VERSION') {
+            $script | Should-MatchString ([regex]::Escape($key))
+        }
+    }
+}

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -177,6 +177,35 @@ function Test-PSCxHasUnreleasedContent {
     return $false
 }
 
+function Get-PSCxStalePinFault {
+    <#
+    .SYNOPSIS
+        The fault, if any, when a pinned module has a newer release available.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$Pinned,
+        [Parameter(Mandatory)] [AllowEmptyString()] [AllowNull()] [string]$Latest
+    )
+    # A pin is a decision that was correct on the day it was made. Without a watcher it decays
+    # into a decision nobody is making, and the failure is asymmetric: a stale pin never breaks
+    # the build, it just quietly stops protecting you. The PSMutant pin sat at 0.1.0 across two
+    # majors -- one of which fixed a bug that scored EVERY mutant killed -- and CI was green
+    # throughout.
+    if ([string]::IsNullOrWhiteSpace($Pinned)) { return "$Name has no pinned version in .github/pins.env." }
+    # "Could not look" is not "nothing newer". Reported as its own fault, because a checker
+    # that treats an unreachable gallery as good news stops being able to fail at all.
+    if ([string]::IsNullOrWhiteSpace($Latest)) {
+        return "$Name is pinned at $Pinned and the gallery did not answer, so freshness is unknown."
+    }
+    $p = [version]$Pinned
+    $l = [version]$Latest
+    if ($l -le $p) { return $null }
+    return "$Name is pinned at $Pinned; $Latest is available."
+}
+
 function Get-PSCxRewrittenManifest {
     # The manifest TEXT with only its ReleaseNotes value replaced. Returns a string and writes
     # nothing -- the caller decides whether to save it.

--- a/tools/Test-PSCxPinFreshness.ps1
+++ b/tools/Test-PSCxPinFreshness.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+    Report pinned modules that have a newer release on the PowerShell Gallery.
+
+.DESCRIPTION
+    A pin is a decision that was correct on the day it was made. Nothing here watched them, and
+    the failure mode is asymmetric: a stale pin never breaks the build, it just quietly stops
+    protecting you. The PSMutant pin sat at 0.1.0 across two majors -- one of which fixed a bug
+    that scored every mutant killed -- and CI was green throughout. It was found by reading the
+    file.
+
+    Reports rather than throws, because a stale pin is a decision to make, not a build to
+    break. The scheduled workflow turns the output into an issue.
+
+.OUTPUTS
+    [string[]] one sentence per stale or unverifiable pin. Empty means every pin is current.
+#>
+[CmdletBinding()]
+[OutputType([string[]])]
+param([string]$PinsPath)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path -Path $PSScriptRoot -ChildPath 'ReleaseDecisions.ps1')
+$repo = Split-Path -Parent $PSScriptRoot
+if (-not $PinsPath) { $PinsPath = Join-Path $repo '.github/pins.env' }
+if (-not (Test-Path -LiteralPath $PinsPath)) { throw "Cannot check pins: '$PinsPath' does not exist." }
+
+$pins = Get-Content -LiteralPath $PinsPath
+# Name in the gallery -> key in pins.env. Both Pester keys point at the same module: the estate
+# pin and the compatibility pin are different decisions and go stale independently.
+$watched = [ordered]@{
+    'Pester'           = 'PESTER_VERSION'
+    'PSScriptAnalyzer' = 'PSSA_VERSION'
+    'PSMutant'         = 'PSMUTANT_VERSION'
+    'ConvertToSARIF'   = 'CONVERTTOSARIF_VERSION'
+}
+
+$faults = [System.Collections.Generic.List[string]]::new()
+foreach ($name in $watched.Keys) {
+    $pinned = Get-PSCxPinValue -Line $pins -Name $watched[$name]
+    $latest = ''
+    try {
+        $found = Find-Module -Name $name -ErrorAction Stop
+        $latest = [string]$found.Version
+    }
+    catch {
+        # Left empty on purpose: the decision function reports "could not look" as its own
+        # fault rather than as good news.
+        Write-Verbose "Find-Module failed for ${name}: $($_.Exception.Message)"
+    }
+    $fault = Get-PSCxStalePinFault -Name $name -Pinned $pinned -Latest $latest
+    if ($fault) { $faults.Add($fault) }
+}
+return [string[]]@($faults)


### PR DESCRIPTION
Closes #54 — **and empties the CI/release cluster with it.**

A pin is a decision that was correct on the day it was made. Nothing watched them, and the failure is **asymmetric**: a stale pin never breaks the build, it just quietly stops protecting you.

The proof is in this repo’s own history. The PSMutant pin sat at **0.1.0 across two majors** — one of which fixed a bug that scored *every* mutant killed — and CI was green throughout. It was found by reading the file.

## Both halves, because they cannot be solved the same way

| Half | Watcher | Why not the other way |
|---|---|---|
| module versions | weekly job over `.github/pins.env` | #26 gave the pins one home to read from |
| action SHAs | Dependabot | `uses:` does not expand variables, so these cannot live in `pins.env` — and a SHA cannot be *read* to learn whether something newer exists |

Both **open a PR or an issue rather than failing a build**. A stale pin is a decision to make, not a build to break, and a scheduled job that goes red for something nobody chose gets muted — the same outcome as not watching at all. One tracking issue, reopened and rewritten, for the same reason.

## The case that decides whether this is worth having

`Find-Module` returns nothing both when a module is current **and** when the gallery cannot be reached. Treating those alike would make every run report all-clear — a watcher that has silently stopped being able to fail, which is the exact shape of the problem it was built for.

```
stale pin        -> Pester is pinned at 5.0.0; 6.1.0 is available.
current pin      -> (silent)
ahead of gallery -> (silent)
gallery silent   -> Pester is pinned at 6.1.0 and the gallery did not answer, so freshness is unknown.
no pin at all    -> Pester has no pinned version in .github/pins.env.
```

The *ahead of gallery* case is not hypothetical either — a prerelease or a yanked version leaves the pin ahead, and a string comparison would call `6.1.0` newer than `10.0.0`.

## Verified against the real gallery

All four pins are genuinely current right now — checked, not assumed:

```
Pester 6.1.0 · PSScriptAnalyzer 1.25.0 · PSMutant 0.3.2 · ConvertToSARIF 1.0.0
```

A test also asserts the watcher’s list and the `pins.env` keys cannot drift apart: a module CI installs but the watcher ignores is exactly the pin that goes stale.

## Gates

Full suite **197 pass** · coverage **100%** over 341 commands · analyzer clean, checked by inspecting findings rather than exit code (#85) · release gate clean · both YAML files parse.

The sibling has the same gap open as PSMutant #89 — this is a gap in both, not catch-up.