### PR TITLE
feat: attribute every cognitive increment, and let a score say where it came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,17 @@ keys it holds could not distinguish units the tool could.
   reported `Line` is unchanged and remains display data, not identity -- it moves whenever
   anything above a unit is edited.
 
+### Internal
+
+- **Every metric increment now records the construct that caused it and the line it is on.**
+  Nineteen producers emitted an anonymous `{Key; Amount}` pair and the amounts were folded into
+  a total, so *what* caused an increment and *where* were destroyed at the moment the increment
+  was created rather than at the boundary. The rows carry both now; the maps stay projections
+  over them, so summation happens exactly once and **no published number changes**. This is what
+  #3 needs -- reporting which construct contributed each point asks the pipeline for information
+  it used to throw away two layers below where the question is asked, which makes that an
+  architectural change rather than an addition.
+
 ### Added
 
 - **Every reference score is attributed to something outside this project.** The README claims

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **A score can say where it came from: `Measure-PSComplexity -Detailed`.** A unit reported as
+  `Cognitive = 23` was correct and unactionable -- nothing distinguished one deeply-nested loop
+  from twenty flat guards, and those call for opposite fixes. `-Detailed` attaches a
+  `Contributions` list of `{ Line, Construct, Amount }` in line order, and the amounts **sum to
+  the score**, asserted by a test -- which guards attribution, not scoring: both sides are
+  computed from the same rows, so a row lost on the way to the list fails the check and a
+  construct scored wrong does not. Confirmed in both directions rather than assumed. Read the amounts and not the
+  count -- anything above `+1` is a structure plus the nesting charged for it, so the same total
+  reached flat and reached nested look different and say different things. Default output is
+  unchanged: no switch, no property, and the six published fields stay exactly as they were.
+
 - **Every reference score is attributed to something outside this project.** The README claims
   the cognitive metric reproduces the SonarSource scores; the suite checked numbers the project
   had chosen itself, so a wrong interpretation would have had the suite agreeing with the bug --

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ nested loop-in-loop-in-`if` grows fast — mirroring how hard it is to follow.
 
 | Command | Returns | Purpose |
 |---|---|---|
-| `Measure-PSComplexity -Path <files/dirs> [-Recurse]` | per-unit records | inspect / report |
+| `Measure-PSComplexity -Path <files/dirs> [-Recurse] [-Detailed]` | per-unit records | inspect / report |
 | `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15]` | `[bool]` | CI gate (warns per offender) |
 
 ### The record is the API
@@ -104,6 +104,64 @@ Those names, their order and their types are the public contract, and a test ass
 exactly -- a sixth field fails the suite, so widening this is a decision rather than a side
 effect. `Line` is deliberately **not** an identity: it moves whenever anything above a unit
 is edited, so it says where a unit currently starts, not which unit it is.
+
+### Where a score came from
+
+A unit comes back as `Cognitive = 23`. That number is correct and, on its own, unactionable:
+it does not say whether it is one deeply-nested loop or twenty flat guards, and those call for
+opposite fixes. `-Detailed` adds a `Contributions` list holding every increment that made up
+the total:
+
+```powershell
+# Thing.ps1
+# 1  function Invoke-Thing {
+# 2      param($a, $b)
+# 3      & {
+# 4          if ($a) {
+# 5              if ($a -and $b) { 'x' }
+# 6          }
+# 7      }
+# 8  }
+
+$unit = Measure-PSComplexity ./Thing.ps1 -Detailed | Where-Object Unit -eq 'Invoke-Thing'
+$unit.Contributions | Format-Table Line, Construct, Amount
+```
+
+```
+Line Construct   Amount
+---- ---------   ------
+   4 if               2
+   5 boolean-run      1
+   5 if               3
+```
+
+`Cognitive = 6`, and the breakdown says where: the `if` on line 4 costs 2 rather than 1
+because the `& { }` lambda already raised the nesting level, and the one on line 5 costs 3
+for sitting inside it. Two `if`s and one `-and` would be 3 points written flat; the same
+three constructs nested cost 6.
+
+Read the **amounts**, not just the count. A `+1` is a structure; anything larger is that
+structure plus its nesting depth, because nesting is what the B2 rule charges for. So four
+`+1` rows and one `+4` row reach the same total and mean different things -- points spread flat
+say the unit does too many things, points concentrated in one deep row say extract. That is
+the distinction the bare total cannot make.
+
+Three properties of the list are worth relying on:
+
+- **The amounts sum to `Cognitive`**, and a test asserts it. Be precise about what that buys:
+  the score and the breakdown are computed from the *same* rows, so the sum catches a row
+  dropped or misattributed on the way to this list -- it cannot catch a construct scored wrong
+  in the first place, because that moves both sides together. Verified both ways rather than
+  assumed. Whether the scores themselves are right is the reference-score suite's job.
+- **Rows are in line order**, so a unit reads top to bottom.
+- **A decision-free unit gets an empty list, not a missing property.** Absent and empty are
+  different answers, and iterating the property should not require telling them apart.
+
+`Contributions` covers the **cognitive** score only; cyclomatic is a count of decision points
+and its total is already its own explanation.
+
+Nothing changes without the switch. The six fields above are what a default run emits, in that
+order, and CI consumers that parse it are unaffected.
 
 ## Use it in CI
 

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -176,16 +176,55 @@ function Get-PSCxCogMethodRecursionRow {
     }
 }
 
+function Get-PSCxCognitiveRow {
+    # Every cognitive increment, attributed per unit. Composed from one collector per KIND of
+    # increment, mirroring Cyclomatic.ps1 -- and separate from the map so that "the map is a
+    # projection of the rows" is structural rather than a claim about a private local.
+    #
+    # The rows are what -Detailed publishes: a total of 23 is correct and unactionable, because
+    # nothing in it says whether that is one deeply-nested loop or twenty flat guards, and those
+    # call for opposite fixes.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Ast)
+    @(Get-PSCxCogIfRow -Ast $Ast) + @(Get-PSCxCogBlockRow -Ast $Ast) + @(Get-PSCxCogTernaryRow -Ast $Ast) +
+    @(Get-PSCxCogFlowCommandRow -Ast $Ast) + @(Get-PSCxCogNullCoalesceRow -Ast $Ast) +
+    @(Get-PSCxCogPipelineChainRow -Ast $Ast) + @(Get-PSCxCogBooleanRow -Ast $Ast) +
+    @(Get-PSCxCogJumpRow -Ast $Ast) + @(Get-PSCxCogRecursionRow -Ast $Ast) +
+    @(Get-PSCxCogMethodRecursionRow -Ast $Ast)
+}
+
+function Get-PSCxContributionMap {
+    # unit key -> the increments that produced its cognitive score, in line order.
+    #
+    # Its own function because the caller is already a nested walk over files and units, where
+    # this loop would carry that nesting on top of its own and put the caller over the cognitive
+    # ceiling this module gates itself on. Grouping rows by unit is also a separable question
+    # with its own test, which is what keeps the split from being a branch hidden to buy a
+    # number.
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Ast)
+    $byUnit = @{}
+    foreach ($row in (Get-PSCxCognitiveRow -Ast $Ast)) {
+        if (-not $byUnit.ContainsKey($row.Key)) {
+            $byUnit[$row.Key] = [System.Collections.Generic.List[object]]::new()
+        }
+        $byUnit[$row.Key].Add([pscustomobject]@{ Line = $row.Line; Construct = $row.Construct; Amount = $row.Amount })
+    }
+    # Sorted here rather than at the call site: the question this answers is "where did 23 come
+    # from", and a reader scans a unit top to bottom.
+    $out = @{}
+    foreach ($k in $byUnit.Keys) { $out[$k] = @($byUnit[$k] | Sort-Object Line, Construct) }
+    return $out
+}
+
 function Get-PSCxCognitiveMap {
     # unit key -> cognitive complexity (summed rows; decision-free unit = 0).
     [OutputType([hashtable])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    $rows = @(Get-PSCxCogIfRow -Ast $Ast) + @(Get-PSCxCogBlockRow -Ast $Ast) + @(Get-PSCxCogTernaryRow -Ast $Ast) +
-        @(Get-PSCxCogFlowCommandRow -Ast $Ast) + @(Get-PSCxCogNullCoalesceRow -Ast $Ast) +
-        @(Get-PSCxCogPipelineChainRow -Ast $Ast) +
-            @(Get-PSCxCogBooleanRow -Ast $Ast) + @(Get-PSCxCogJumpRow -Ast $Ast) + @(Get-PSCxCogRecursionRow -Ast $Ast) +
-            @(Get-PSCxCogMethodRecursionRow -Ast $Ast)
+    $rows = @(Get-PSCxCognitiveRow -Ast $Ast)
     $map = @{}
     foreach ($row in $rows) { $map[$row.Key] = [int]$map[$row.Key] + $row.Amount }
     $out = @{}

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -41,7 +41,7 @@ function Get-PSCxCogIfRow {
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
         $extra = ($n.Clauses.Count - 1) + [int][bool]$n.ElseClause
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) + $extra }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'if'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) + $extra }
     }
 }
 
@@ -52,7 +52,7 @@ function Get-PSCxCogBlockRow {
     param([Parameter(Mandatory)] $Ast)
     foreach ($tn in 'SwitchStatementAst', 'ForEachStatementAst', 'ForStatementAst', 'WhileStatementAst', 'DoWhileStatementAst', 'DoUntilStatementAst', 'CatchClauseAst', 'TrapStatementAst') {
         foreach ($n in $Ast.FindAll({ param($x) $x.GetType().Name -eq $tn }.GetNewClosure(), $true)) {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'block'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
         }
     }
 }
@@ -62,7 +62,7 @@ function Get-PSCxCogTernaryRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.TernaryExpressionAst] }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'ternary'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
     }
 }
 
@@ -75,7 +75,7 @@ function Get-PSCxCogFlowCommandRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) Test-PSCxFlowCommand -Node $x }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'flow-command'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
     }
 }
 
@@ -87,12 +87,12 @@ function Get-PSCxCogNullCoalesceRow {
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
         if ($n.Operator -eq 'QuestionQuestion') {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'null-coalesce'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
         }
     }
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
         if ($n.Operator -eq 'QuestionQuestionEquals') {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 + (Get-PSCxNesting -Node $n) }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'null-coalesce'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
         }
     }
 }
@@ -108,7 +108,7 @@ function Get-PSCxCogPipelineChainRow {
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.PipelineChainAst] }, $true)) {
         if ($n.Parent -isnot [System.Management.Automation.Language.PipelineChainAst] -or
             $n.Parent.Operator -ne $n.Operator) {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'pipeline-chain'; Line = $n.Extent.StartLineNumber; Amount = 1 }
         }
     }
 }
@@ -119,7 +119,7 @@ function Get-PSCxCogBooleanRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
-        if (Test-PSCxLogicalRunStart -Node $n) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 } }
+        if (Test-PSCxLogicalRunStart -Node $n) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'boolean-run'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }
 
@@ -130,7 +130,7 @@ function Get-PSCxCogJumpRow {
     param([Parameter(Mandatory)] $Ast)
     $isJump = { param($x) $x -is [System.Management.Automation.Language.BreakStatementAst] -or $x -is [System.Management.Automation.Language.ContinueStatementAst] }
     foreach ($n in $Ast.FindAll($isJump, $true)) {
-        if ($n.Label) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 } }
+        if ($n.Label) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'labelled-jump'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }
 
@@ -141,7 +141,7 @@ function Get-PSCxCogRecursionRow {
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.CommandAst] }, $true)) {
         $fn = Get-PSCxEnclosingFunctionName -Node $n
-        if ($fn -and $n.GetCommandName() -eq $fn) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 } }
+        if ($fn -and $n.GetCommandName() -eq $fn) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'recursion'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }
 
@@ -171,7 +171,7 @@ function Get-PSCxCogMethodRecursionRow {
         if (-not $method) { continue }
         if ($n.Member.Value -ne $method.Name) { continue }
         if (Test-PSCxSelfInvocation -Node $n -Method $method) {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'unknown'; Line = $n.Extent.StartLineNumber; Amount = 1 }
         }
     }
 }

--- a/src/Cyclomatic.ps1
+++ b/src/Cyclomatic.ps1
@@ -17,10 +17,10 @@ function Get-PSCxCycClauseRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = $n.Clauses.Count }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'clause'; Line = $n.Extent.StartLineNumber; Amount = $n.Clauses.Count }
     }
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.SwitchStatementAst] }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = $n.Clauses.Count }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'clause'; Line = $n.Extent.StartLineNumber; Amount = $n.Clauses.Count }
     }
 }
 
@@ -33,7 +33,7 @@ function Get-PSCxCycBlockRow {
         # The closure is required: without it $tn resolves at CALL time, when the loop has
         # already finished, and every type matches the last name in the list.
         foreach ($n in $Ast.FindAll({ param($x) $x.GetType().Name -eq $tn }.GetNewClosure(), $true)) {
-            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+            [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'block'; Line = $n.Extent.StartLineNumber; Amount = 1 }
         }
     }
 }
@@ -45,7 +45,7 @@ function Get-PSCxCycFlowCommandRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) Test-PSCxFlowCommand -Node $x }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'flow-command'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
 }
 
@@ -59,16 +59,16 @@ function Get-PSCxCycOperatorRow {
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.PipelineChainAst] }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.TernaryExpressionAst] }, $true)) {
-        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 }
+        [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
-        if ($n.Operator -in 'And', 'Or', 'QuestionQuestion') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 } }
+        if ($n.Operator -in 'And', 'Or', 'QuestionQuestion') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
     foreach ($n in $Ast.FindAll({ param($x) $x -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
-        if ($n.Operator -eq 'QuestionQuestionEquals') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Amount = 1 } }
+        if ($n.Operator -eq 'QuestionQuestionEquals') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }
 

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -84,6 +84,111 @@ function Get-PSCxRelativePath {
     return $full.Substring($rootFull.Length).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
 }
 
+function Get-PSCxUnitRecord {
+    # Shape one output record. The only place the published shape is decided.
+    #
+    # A function rather than inline, because the caller sits inside a per-unit loop and a
+    # conditional there costs its nesting depth rather than one point. Folded back into that
+    # loop, the -Detailed branch alone puts Measure-PSComplexity over the cognitive ceiling
+    # this module gates itself on.
+    #
+    # Get-, not New-, although it builds something: New- is a state-changing verb, so
+    # PSUseShouldProcessForStateChangingFunctions demands -WhatIf support this has no use for.
+    # It also matches the Get-PSCx*Row composers, which build rows the same way.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$File,
+        [Parameter(Mandatory)] [string]$Unit,
+        [Parameter(Mandatory)] [int]$Line,
+        [Parameter(Mandatory)] [int]$Cyclomatic,
+        [Parameter(Mandatory)] [int]$Cognitive,
+        [Parameter(Mandatory)] [int]$MetricVersion,
+        [AllowEmptyCollection()] [object[]]$Contributions,
+        [switch]$Detailed
+    )
+    $record = [pscustomobject]@{
+        File          = $File
+        Unit          = $Unit
+        Line          = $Line
+        Cyclomatic    = $Cyclomatic
+        Cognitive     = $Cognitive
+        MetricVersion = $MetricVersion
+    }
+    # Absent and empty are different answers, and a consumer iterating this should not have to
+    # tell them apart -- so -Detailed always adds the property, even for a decision-free unit.
+    if ($Detailed) { $record | Add-Member -NotePropertyName Contributions -NotePropertyValue @($Contributions) }
+    return $record
+}
+
+function Get-PSCxFileRecord {
+    # Every unit in ONE file, in source order. The caller owns which files and whether one
+    # has been seen already; this owns what a file yields.
+    #
+    # Separate from the caller because the caller is two foreach levels deep before it does
+    # anything: everything here would start at +3 inside it, and the parse-error guard and the
+    # emit loop together are enough to put Measure-PSComplexity over the ceiling this module
+    # gates itself on. Keeping it here is also what makes "measure one file" testable alone.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$File,
+        [switch]$Detailed
+    )
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($File, [ref]$null, [ref]$errors)
+    if ($errors) {
+        # Write-Error, not Write-Warning: non-terminating, so measuring a tree with one bad
+        # file still returns every other file's units -- but it lands on a stream that
+        # -ErrorVariable can capture and CI does not swallow. Test-PSComplexity captures
+        # exactly this and refuses.
+        Write-Error "Skipped '$File' -- parse error: $($errors[0].Message)"
+        return
+    }
+
+    # Relative to where the caller is standing, which for a repo-scoped run is the repo.
+    # Not a parameter: a root nobody passes is a root nobody gets wrong.
+    $relative = Get-PSCxRelativePath -Path $File -Root (Get-Location).Path
+    $cyc = Get-PSCxCyclomaticMap -Ast $ast
+    $cog = Get-PSCxCognitiveMap -Ast $ast
+    $lines = Get-PSCxUnitTable -Ast $ast
+    # Source order, not hashtable order. .NET enumerates a hashtable by bucket layout, which
+    # is neither insertion nor line order and is not required to be stable -- so two runs over
+    # one unchanged file could emit the same rows in different sequences. Nothing noticed,
+    # because the gate takes a max and a human reads a table; a committed baseline or a diffed
+    # report would have.
+    #
+    # Line first, then unit name: two units CAN start on the same line
+    # (`function A { } function B { }`), and a tie left unbroken puts the nondeterminism
+    # straight back.
+    $ordered = @($lines.Keys | Sort-Object @{ Expression = { $lines[$_] } }, @{ Expression = { $_ } })
+    # Names computed over the whole file, because disambiguating a repeat needs to know there
+    # IS a repeat. Done per row, the first of a pair could not be told apart from a unit that
+    # never had a twin.
+    $display = Get-PSCxDisplayName -OrderedKeys $ordered
+    # Once per file rather than per unit: the rows are one walk, and asking for them per unit
+    # would re-walk the tree for every function in the file.
+    $byUnit = @{}
+    if ($Detailed) { $byUnit = Get-PSCxContributionMap -Ast $ast }
+    foreach ($k in $ordered) {
+        # Two traps stacked here, and the empty list has to survive BOTH.
+        #
+        # A decision-free unit has no entry, and @($byUnit[$k]) on a missing key gives an
+        # array of ONE null rather than an empty one -- a contribution with no line, no
+        # construct and no amount, which is worse than the absent property this exists to
+        # avoid because it survives a count check.
+        #
+        # And the fix cannot be written as `$c = if (...) { ... } else { @() }`: an if used
+        # as an expression yields its branch's OUTPUT, and emitting @() emits nothing, so
+        # the variable lands back on $null. Assign first, then overwrite.
+        $contrib = @()
+        if ($byUnit.ContainsKey($k)) { $contrib = $byUnit[$k] }
+        Get-PSCxUnitRecord -File $relative -Unit $display[$k] -Line $lines[$k] `
+            -Cyclomatic $cyc[$k] -Cognitive $cog[$k] -MetricVersion $script:PSCxMetricVersion `
+            -Contributions $contrib -Detailed:$Detailed
+    }
+}
+
 function Measure-PSComplexity {
     <#
     .SYNOPSIS
@@ -137,7 +242,10 @@ function Measure-PSComplexity {
     param(
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
         [switch]$Recurse
-    )
+        ,
+        # Off by default because the DEFAULT SHAPE IS A CONTRACT: CI consumers parse these
+        # records, and a field that appears unbidden is a breaking change dressed as a feature.
+        [switch]$Detailed    )
     begin {
         # Resolved paths already emitted. Two inputs can name one file -- a directory and
         # something inside it, or a wildcard and a literal -- and measuring it twice put
@@ -161,51 +269,7 @@ function Measure-PSComplexity {
                 # a CI gate calls, and a gate that chatters gets its output filtered, which
                 # takes the parse errors with it.
                 Write-Verbose "Measuring $file"
-                $errors = $null
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$errors)
-                if ($errors) {
-                    # Write-Error, not Write-Warning: non-terminating, so measuring a tree
-                    # with one bad file still returns every other file's units -- but it
-                    # lands on a stream that -ErrorVariable can capture and CI does not
-                    # swallow. Test-PSComplexity captures exactly this and refuses.
-                    Write-Error "Skipped '$file' -- parse error: $($errors[0].Message)"
-                    continue
-                }
-
-                # Relative to where the caller is standing, which for a repo-scoped run is
-                # the repo. Not a parameter: a root nobody passes is a root nobody gets wrong.
-                $relative = Get-PSCxRelativePath -Path $file -Root (Get-Location).Path
-                $cyc = Get-PSCxCyclomaticMap -Ast $ast
-                $cog = Get-PSCxCognitiveMap -Ast $ast
-                $lines = Get-PSCxUnitTable -Ast $ast
-                # Source order, not hashtable order. .NET enumerates a hashtable by bucket
-                # layout, which is neither insertion nor line order and is not required to
-                # be stable -- so two runs over one unchanged file could emit the same rows
-                # in different sequences. Nothing here noticed, because the gate takes a
-                # max and a human reads a table; a committed baseline or a diffed report
-                # would have.
-                #
-                # Line first, then unit name: two units CAN start on the same line
-                # (`function A { } function B { }`), and a tie left unbroken puts the
-                # nondeterminism straight back.
-                $ordered = @($lines.Keys | Sort-Object @{ Expression = { $lines[$_] } }, @{ Expression = { $_ } })
-                # Names computed over the whole file, because disambiguating a repeat needs to
-                # know there IS a repeat. Done per row, the first of a pair could not be told
-                # apart from a unit that never had a twin.
-                $display = Get-PSCxDisplayName -OrderedKeys $ordered
-                foreach ($k in $ordered) {
-                    [pscustomobject]@{
-                        File       = $relative
-                        Unit       = $display[$k]
-                        Line       = $lines[$k]
-                        Cyclomatic = $cyc[$k]
-                        Cognitive  = $cog[$k]
-                        # Last, so the four fields a reader scans stay together. Widening this
-                        # record fails the test that pins it, which is how this addition became
-                        # a decision rather than a side effect.
-                        MetricVersion = $script:PSCxMetricVersion
-                    }
-                }
+                Get-PSCxFileRecord -File $file -Detailed:$Detailed
             }
         }
     }

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -280,3 +280,55 @@ Describe 'every reference score is attributed to something outside this project'
         $Actual | Should-BeGreaterThan 0
     }
 }
+
+Describe 'every increment says which construct produced it' {
+    # The amounts used to be summed at emission, so the construct that caused an increment and
+    # where it was were gone at the moment the increment was created rather than at the
+    # boundary. #3 asks the pipeline for information the pipeline destroyed two layers below
+    # where the question is asked -- which makes it an architectural change, not an addition.
+    #
+    # The maps stay projections over these rows, so the published output does not change and
+    # summation happens exactly once, in the fold.
+
+    BeforeAll {
+        $script:AttrFile = Join-Path ([System.IO.Path]::GetTempPath()) "cxattr-$([System.Guid]::NewGuid().ToString('N')).ps1"
+        Set-Content $script:AttrFile @'
+function T {
+    param($a, $b, $xs)
+    foreach ($x in $xs) {
+        if ($a -and $b) { 1 }
+    }
+}
+'@ -Encoding utf8
+        $script:AttrAst = [System.Management.Automation.Language.Parser]::ParseFile($script:AttrFile, [ref]$null, [ref]$null)
+    }
+
+    AfterAll { Remove-Item $script:AttrFile -Force -ErrorAction SilentlyContinue }
+
+    It 'names the construct on every row' {
+        $rows = @(Get-PSCxCogIfRow -Ast $script:AttrAst) + @(Get-PSCxCogBlockRow -Ast $script:AttrAst) +
+                @(Get-PSCxCogBooleanRow -Ast $script:AttrAst)
+        $unnamed = @($rows | Where-Object { [string]::IsNullOrWhiteSpace($_.Construct) })
+        $unnamed.Count | Should-Be 0
+        # And the names are the ones a reader would expect, not a placeholder.
+        (@($rows | ForEach-Object { $_.Construct } | Sort-Object -Unique) -join ',') |
+            Should-Be 'block,boolean-run,if'
+    }
+
+    It 'points each row at the line the construct is on' {
+        # The `if` is on line 4 of the fixture and the `foreach` on line 3. Without a line a
+        # diagnostic can only point at a unit, which is what the SARIF half of #5 needs and
+        # cannot get from a per-unit total.
+        (@(Get-PSCxCogIfRow -Ast $script:AttrAst)[0]).Line | Should-Be 4
+        (@(Get-PSCxCogBlockRow -Ast $script:AttrAst)[0]).Line | Should-Be 3
+    }
+
+    It 'leaves the summed map exactly as it was' {
+        # The point of keeping the maps as projections: the published number must not move
+        # because the intermediate representation grew a field.
+        $map = Get-PSCxCognitiveMap -Ast $script:AttrAst
+        $unit = @($map.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
+        # foreach(1) + if(1 + 1 nesting) + boolean run(1) = 4
+        $map[$unit] | Should-Be 4
+    }
+}

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -323,6 +323,35 @@ function T {
         (@(Get-PSCxCogBlockRow -Ast $script:AttrAst)[0]).Line | Should-Be 3
     }
 
+    It 'groups every row under the unit that produced it' {
+        # Three rows for one unit, deliberately: a map that starts a fresh list per row keeps
+        # only the LAST one, and a fixture whose unit has a single increment cannot tell the
+        # two apart. The full breakdown is asserted rather than the count, so a row landing
+        # under the wrong key fails here too.
+        $map = Get-PSCxContributionMap -Ast $script:AttrAst
+        $unit = @($map.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
+        (@($map[$unit] | ForEach-Object { "$($_.Construct)@$($_.Line)+$($_.Amount)" }) -join ' ') |
+            Should-Be 'block@3+1 boolean-run@4+1 if@4+2'
+    }
+
+    It 'accounts for exactly the points the summed map reports' {
+        # The two projections over the same rows have to agree. This is what a consumer relies
+        # on when it reads a breakdown next to a score -- and it is the check that fails if the
+        # grouping drops a row on the way, which the summed map would not notice.
+        $map = Get-PSCxContributionMap -Ast $script:AttrAst
+        $sums = Get-PSCxCognitiveMap -Ast $script:AttrAst
+        $unit = @($sums.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
+        (($map[$unit] | Measure-Object Amount -Sum).Sum) | Should-Be $sums[$unit]
+    }
+
+    It 'keeps a unit with no increments out of the map entirely' {
+        # The decision-free unit is absent HERE and empty at the published boundary. Two
+        # different jobs: this map answers "which rows exist", and Measure-PSComplexity turns
+        # a missing key into an empty list so a consumer never has to tell absent from empty.
+        $map = Get-PSCxContributionMap -Ast $script:AttrAst
+        @($map.Keys | Where-Object { $_ -like '<script-body>*' }).Count | Should-Be 0
+    }
+
     It 'leaves the summed map exactly as it was' {
         # The point of keeping the maps as projections: the published number must not move
         # because the intermediate representation grew a field.

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -58,3 +58,45 @@ Describe 'Cyclomatic complexity - reference scores' {
         Get-CyclomaticOf -Code $code | Should-Be $expected
     }
 }
+
+Describe 'every cyclomatic increment says which construct produced it' {
+    # Same change as the cognitive side, and for the same reason: the amount was summed at
+    # emission, so what caused it and where were gone before anything could report them.
+
+    BeforeAll {
+        $script:CycAttrFile = Join-Path ([System.IO.Path]::GetTempPath()) "cxcycattr-$([System.Guid]::NewGuid().ToString('N')).ps1"
+        Set-Content $script:CycAttrFile @'
+function T {
+    param($a, $xs)
+    foreach ($x in $xs) {
+        if ($a) { 1 }
+    }
+}
+'@ -Encoding utf8
+        $script:CycAttrAst = [System.Management.Automation.Language.Parser]::ParseFile($script:CycAttrFile, [ref]$null, [ref]$null)
+    }
+
+    AfterAll { Remove-Item $script:CycAttrFile -Force -ErrorAction SilentlyContinue }
+
+    It 'names the construct and the line on every row' {
+        $rows = @(Get-PSCxCycClauseRow -Ast $script:CycAttrAst) + @(Get-PSCxCycBlockRow -Ast $script:CycAttrAst)
+        @($rows | Where-Object { [string]::IsNullOrWhiteSpace($_.Construct) }).Count | Should-Be 0
+        @($rows | Where-Object { $_.Line -le 0 }).Count | Should-Be 0
+    }
+
+    It 'leaves the map a projection of the rows: base 1 plus their sum' {
+        # Asserted as the relationship rather than as a number, because the number is what a
+        # reference case already pins -- what THIS test protects is that widening the row did
+        # not change how the map is derived from it. Summation happens once, in the fold.
+        #
+        # The base 1 lives in the MAP, not in Measure-PSComplexity: rows sum to 2 here and the
+        # map reads 3. I had that backwards in the first version of this test, and the failure
+        # is what corrected it.
+        $rows = @(Get-PSCxCycClauseRow -Ast $script:CycAttrAst) + @(Get-PSCxCycBlockRow -Ast $script:CycAttrAst) +
+                @(Get-PSCxCycFlowCommandRow -Ast $script:CycAttrAst) + @(Get-PSCxCycOperatorRow -Ast $script:CycAttrAst)
+        $map = Get-PSCxCyclomaticMap -Ast $script:CycAttrAst
+        $unit = @($map.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
+        $unitRows = @($rows | Where-Object { $_.Key -eq $unit })
+        $map[$unit] | Should-Be (1 + (($unitRows | Measure-Object Amount -Sum).Sum))
+    }
+}

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -741,3 +741,86 @@ function Process { if (1) { } }
         Test-PSComplexity -Path $script:clsFile -MaxCognitive 10 -WarningAction SilentlyContinue | Should-BeTrue
     }
 }
+
+Describe 'a score can say where it came from' {
+    # A unit comes back as Cognitive = 23. Correct, and completely unactionable: nothing says
+    # whether that is one deeply-nested loop or twenty flat guards, and those call for opposite
+    # fixes. The data existed internally and the summation was the only reason it was lost.
+
+    BeforeAll {
+        $script:DetailFile = Join-Path $script:work 'detail.ps1'
+        Set-Content $script:DetailFile @'
+function Invoke-Thing {
+    param($a, $b, $xs)
+    foreach ($x in $xs) {
+        if ($a) { 1 }
+        if ($a -and $b) { 2 }
+    }
+}
+'@ -Encoding utf8
+    }
+
+    It 'says nothing extra by default' {
+        # The default shape is a CONTRACT -- CI consumers parse these records, and a field that
+        # appears unbidden is a breaking change dressed as a feature.
+        $row = @(Measure-PSComplexity -Path $script:DetailFile)[0]
+        ($row.PSObject.Properties.Name -join ',') | Should-Be 'File,Unit,Line,Cyclomatic,Cognitive,MetricVersion'
+    }
+
+    It 'adds Contributions when asked' {
+        $row = @(Measure-PSComplexity -Path $script:DetailFile -Detailed)[0]
+        ($row.PSObject.Properties.Name -join ',') |
+            Should-Be 'File,Unit,Line,Cyclomatic,Cognitive,MetricVersion,Contributions'
+    }
+
+    It 'accounts for every point: the contributions sum to the score' {
+        # Guards ATTRIBUTION, not scoring, and the difference is worth stating because the
+        # test looks stronger than it is: the score and this list are summed from the same
+        # rows, so dropping or misgrouping a row on the way here fails, while a collector that
+        # scores a construct wrong moves both sides equally and passes. Checked by doing both.
+        # Whether a construct is scored correctly is what the reference-score suite is for.
+        $unit = @(Measure-PSComplexity -Path $script:DetailFile -Detailed | Where-Object Unit -eq 'Invoke-Thing')[0]
+        (($unit.Contributions | Measure-Object Amount -Sum).Sum) | Should-Be $unit.Cognitive
+    }
+
+    It 'names the construct and the line for each point' {
+        $unit = @(Measure-PSComplexity -Path $script:DetailFile -Detailed | Where-Object Unit -eq 'Invoke-Thing')[0]
+        # foreach at 3, if at 4 (+1 nesting), then the boolean run and the if at 5.
+        (($unit.Contributions | ForEach-Object { "$($_.Construct)@$($_.Line)+$($_.Amount)" }) -join ' ') |
+            Should-Be 'block@3+1 if@4+2 boolean-run@5+1 if@5+2'
+    }
+
+    It 'orders them by line, because that is how the unit is read' {
+        $unit = @(Measure-PSComplexity -Path $script:DetailFile -Detailed | Where-Object Unit -eq 'Invoke-Thing')[0]
+        $lines = @($unit.Contributions | ForEach-Object { $_.Line })
+        ($lines -join ',') | Should-Be (($lines | Sort-Object) -join ',')
+    }
+
+    It 'does not build a breakdown nobody asked for' {
+        # -Detailed costs an extra walk of the whole AST per file, and this is the command a
+        # CI gate runs on every push. The guard is invisible in the output either way -- the
+        # records are identical whether or not the map was built -- so nothing but this
+        # assertion stops it being dropped, and the cost would land on every consumer.
+        #
+        # Both halves, because the negative alone passes just as well against a guard that
+        # never calls it at all.
+        Mock Get-PSCxContributionMap { @{} }
+        Measure-PSComplexity -Path $script:DetailFile | Out-Null
+        Should-NotInvoke Get-PSCxContributionMap
+        Measure-PSComplexity -Path $script:DetailFile -Detailed | Out-Null
+        Should-Invoke Get-PSCxContributionMap -Times 1 -Exactly
+    }
+
+    It 'gives a decision-free unit an empty list rather than nothing' {
+        # Absent and empty are different answers, and a consumer iterating the property should
+        # not have to tell them apart.
+        $flat = Join-Path $script:work 'flat.ps1'
+        Set-Content $flat 'function Get-Flat { param($x) $x }' -Encoding utf8
+        try {
+            $unit = @(Measure-PSComplexity -Path $flat -Detailed | Where-Object Unit -eq 'Get-Flat')[0]
+            ($unit.PSObject.Properties.Name -contains 'Contributions') | Should-BeTrue
+            @($unit.Contributions).Count | Should-Be 0
+        }
+        finally { Remove-Item $flat -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
Closes #16.
Closes #3.

Two issues on one branch, deliberately: #3 is not an addition on top of #16, it is
the reason #16 exists. The rows #16 introduces are the thing #3 publishes, and
splitting them produces a stacked PR whose first half has no observable behaviour.

## #16 -- every increment says what caused it and where

The amounts used to be summed at emission, so the construct that caused an
increment and the line it was on were gone at the moment the increment was
created rather than at the boundary where the question is asked. All 19 row
emissions across `Cognitive.ps1` and `Cyclomatic.ps1` now carry
`{ Key, Construct, Line, Amount }`, and `Get-PSCxCognitiveRow` composes them.

The maps stay projections over those rows, so the published numbers do not move
and summation still happens exactly once, in the fold. A test pins that: the
summed map for the fixture is unchanged.

## #3 -- `Measure-PSComplexity -Detailed`

`Cognitive = 23` is correct and unactionable -- nothing in it says whether that is
one deeply-nested loop or twenty flat guards, and those call for opposite fixes.
`-Detailed` attaches `Contributions`, a list of `{ Line, Construct, Amount }` in
line order.

Read the amounts, not the count: anything above `+1` is a structure plus the
nesting charged for it, so the same total reached flat and reached nested look
different and mean different things.

**Default output is untouched** -- no switch, no property, the same six fields in
the same order, asserted by a test. A decision-free unit gets an empty list rather
than a missing property.

## What the build forced, and what it caught

**The module refused the change through its own gate, twice.** Inline, the
`-Detailed` branch sits two `foreach` levels deep and costs its nesting depth
rather than one point, taking `Measure-PSComplexity` to cognitive 26 and then 33
against a ceiling of 15. `Get-PSCxFileRecord` ("measure one file") and
`Get-PSCxUnitRecord` ("shape one record") are extractions with their own tests,
not branches relocated to buy a number. The function now scores **6** -- below the
12 it had before this work.

**Tests in the wrong file covered the code and could kill none of its mutants.**
`Get-PSCxContributionMap` lives in `src/Cognitive.ps1`, which the mutation config
maps to `tests/Cognitive.Tests.ps1`; its tests were written beside the `-Detailed`
tests in `Measure.Tests.ps1`, where they read better and were useless. Four of five
survivors. This is the trap the guide already records, hit exactly as written.

**Two PowerShell traps are named in the code**, because each produces a plausible
wrong answer rather than an error: `@($map[$missing])` is an array of *one null*,
and `$x = if (...) { ... } else { @() }` lands on `$null`, because an `if`
expression yields its branch's output and emitting `@()` emits nothing.

**The sum-equals-score test is documented for what it actually buys.** Both sides
are computed from the same rows, so it catches a row dropped or misgrouped on the
way to the list and **cannot** catch a construct scored wrong -- confirmed by
breaking it each way rather than assumed. Scoring correctness stays the
reference-score suite's job. An earlier draft of the README and CHANGELOG claimed
more than that; both are corrected.

**The `-Detailed` guard is asserted, not declared equivalent.** Forcing it true
yields byte-identical records, but costs an extra whole-AST walk per file on the
command CI runs every push, so `Should-NotInvoke`/`Should-Invoke` pins both halves.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 251 passed, 0 failed |
| Coverage | 100% over `src/` |
| Analyzer | clean |
| Self-complexity | passes; `Measure-PSComplexity` cog 6 (was 12) |
| Scoped mutation (`Cognitive.ps1`, `Measure-PSComplexity.ps1`) | **100%, 132/132** |
| Release consistency | consistent at 0.4.0 |

No version bump: 0.4.0 is unreleased, so this folds into that entry.