### PR TITLE
refactor: give measurement a noun, and make the output a projection of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ keys it holds could not distinguish units the tool could.
 
 ### Fixed
 
+- **The gate could describe an unrelated failure as a file that did not parse.**
+  `Test-PSComplexity` rebuilt its list of unreadable files by capturing `Measure-PSComplexity`'s
+  error stream with `-ErrorAction SilentlyContinue`, so *any* error landed in the same variable
+  and was reported as a syntax problem in a file. It now reads what was skipped, and why, as
+  data. The symptom was reproduced during this change: a parameter-binding fault surfaced as
+  "Refusing to vouch for 1 file(s) that did not parse".
+
 - **A relative path now resolves against the root it was given, not against the working
   directory.** `Get-PSCxRelativePath` called `GetFullPath` on its `Path` argument directly, so
   a relative one silently resolved against wherever the shell happened to be standing. It gave
@@ -82,6 +89,15 @@ keys it holds could not distinguish units the tool could.
   #3 needs -- reporting which construct contributed each point asks the pipeline for information
   it used to throw away two layers below where the question is asked, which makes that an
   architectural change rather than an addition.
+
+### Internal
+
+- **Measurement has a noun.** `Get-PSCxScan` returns the complete measurement -- scope, units,
+  and skips with their reasons -- and the two public commands are projections over it. Facts
+  about the run were previously destroyed at emission, which is the same defect as summing an
+  increment before recording what caused it, one layer up. It stays internal until a consumer
+  publishes it; keeping the shape in one place is what stops a report, a changed-files run and
+  a committed baseline each inventing their own.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ under both. Tracked in **#10**.
 src/Ast.ps1                    unit discovery, attribution, nesting depth. Shared.
 src/Cyclomatic.ps1             decision-point counting.
 src/Cognitive.ps1              the SonarSource metric (B1 structural, B2 nesting, B3 level).
-src/Measure-PSComplexity.ps1   public API: Measure-PSComplexity, Test-PSComplexity.
+src/Measure-PSComplexity.ps1   the scan -- measurement as data -- and the two public
+                               projections over it: Measure-PSComplexity, Test-PSComplexity.
 ```
 
 **The mutation config maps each source file to specific test files.** `src/Cyclomatic.ps1`
@@ -109,6 +110,26 @@ Two subtleties worth knowing before touching `Ast.ps1`:
 
 Habits this repo already has. They are written down because they are cheap to lose in a hurry
 and expensive to rebuild, and because each one has already earned its keep.
+
+- **The scan is the measurement; the published output is a projection of it.** `Get-PSCxScan`
+  returns what was asked for, which units were found, and which files were skipped and why.
+  `Measure-PSComplexity` renders the units to the pipeline and each skip to the error stream;
+  `Test-PSComplexity` reads the skips as data. Both walk once, through `Get-PSCxPathScan`,
+  which streams per-file scans so the streaming command does not have to buffer a tree to
+  share the aggregate.
+
+  Facts about the RUN have nowhere else to live, and a fact that exists only on the error
+  stream has to be rebuilt by whoever needs it. The gate used to capture its own module's
+  errors with `-ErrorAction SilentlyContinue` -- which swallowed every OTHER error into the
+  same variable, so a parameter-binding failure reached the user described as a file that did
+  not parse. That was observed during the change that introduced this, not imagined.
+
+  It is the same shape as the rows underneath: emit the rich thing once, project it. A
+  consumer that needs run-level facts extends the scan rather than inventing a second shape,
+  which is what stops the first one shipped becoming the contract by accident. It is
+  deliberately **internal** until something publishes it; when that happens, the cost to weigh
+  is that one command would then have two output shapes, and a `| Where-Object` written
+  against the record stream returns nothing under the other one.
 
 - **The reference scores are the contract, not examples.** `tests/Cognitive.Tests.ps1` pins the
   SonarSource cases -- prime sieve 7, plain switch 1, recursive fibonacci 3,

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -121,14 +121,13 @@ function Get-PSCxUnitRecord {
     return $record
 }
 
-function Get-PSCxFileRecord {
-    # Every unit in ONE file, in source order. The caller owns which files and whether one
-    # has been seen already; this owns what a file yields.
+function Get-PSCxFileScan {
+    # One file's measurement AS DATA: the units it produced, or the reason it produced none.
     #
-    # Separate from the caller because the caller is two foreach levels deep before it does
-    # anything: everything here would start at +3 inside it, and the parse-error guard and the
-    # emit loop together are enough to put Measure-PSComplexity over the ceiling this module
-    # gates itself on. Keeping it here is also what makes "measure one file" testable alone.
+    # Nothing is written to the error stream here, and that is the point. A skip that exists
+    # only as an error is a fact the caller has to rebuild by capturing the stream and reading
+    # message text -- which is what the gate did, with -ErrorAction SilentlyContinue, so any
+    # unrelated failure reached the user described as a parse error.
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
@@ -137,24 +136,26 @@ function Get-PSCxFileRecord {
     )
     $errors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($File, [ref]$null, [ref]$errors)
+    # Relative to where the caller is standing, which for a repo-scoped run is the repo. Not a
+    # parameter: a root nobody passes is a root nobody gets wrong. Resolved for BOTH arms, so a
+    # skipped file is named the same way a measured one is.
+    $relative = Get-PSCxRelativePath -Path $File -Root (Get-Location).Path
     if ($errors) {
-        # Write-Error, not Write-Warning: non-terminating, so measuring a tree with one bad
-        # file still returns every other file's units -- but it lands on a stream that
-        # -ErrorVariable can capture and CI does not swallow. Test-PSComplexity captures
-        # exactly this and refuses.
-        Write-Error "Skipped '$File' -- parse error: $($errors[0].Message)"
-        return
+        # The FIRST error. Later ones are usually cascade from it, and a skip that does not say
+        # why is the one thing the reason string exists to prevent.
+        return [pscustomobject]@{
+            File       = $relative
+            Units      = @()
+            SkipReason = "parse error: $($errors[0].Message)"
+        }
     }
 
-    # Relative to where the caller is standing, which for a repo-scoped run is the repo.
-    # Not a parameter: a root nobody passes is a root nobody gets wrong.
-    $relative = Get-PSCxRelativePath -Path $File -Root (Get-Location).Path
     $cyc = Get-PSCxCyclomaticMap -Ast $ast
     $cog = Get-PSCxCognitiveMap -Ast $ast
     $lines = Get-PSCxUnitTable -Ast $ast
-    # Source order, not hashtable order. .NET enumerates a hashtable by bucket layout, which
-    # is neither insertion nor line order and is not required to be stable -- so two runs over
-    # one unchanged file could emit the same rows in different sequences. Nothing noticed,
+    # Source order, not hashtable order. .NET enumerates a hashtable by bucket layout, which is
+    # neither insertion nor line order and is not required to be stable -- so two runs over one
+    # unchanged file could emit the same rows in different sequences. Nothing here noticed,
     # because the gate takes a max and a human reads a table; a committed baseline or a diffed
     # report would have.
     #
@@ -170,22 +171,99 @@ function Get-PSCxFileRecord {
     # would re-walk the tree for every function in the file.
     $byUnit = @{}
     if ($Detailed) { $byUnit = Get-PSCxContributionMap -Ast $ast }
-    foreach ($k in $ordered) {
+    $units = foreach ($k in $ordered) {
         # Two traps stacked here, and the empty list has to survive BOTH.
         #
-        # A decision-free unit has no entry, and @($byUnit[$k]) on a missing key gives an
-        # array of ONE null rather than an empty one -- a contribution with no line, no
-        # construct and no amount, which is worse than the absent property this exists to
-        # avoid because it survives a count check.
+        # A decision-free unit has no entry, and @($byUnit[$k]) on a missing key gives an array
+        # of ONE null rather than an empty one -- a contribution with no line, no construct and
+        # no amount, which is worse than the absent property this exists to avoid because it
+        # survives a count check.
         #
-        # And the fix cannot be written as `$c = if (...) { ... } else { @() }`: an if used
-        # as an expression yields its branch's OUTPUT, and emitting @() emits nothing, so
-        # the variable lands back on $null. Assign first, then overwrite.
+        # And the fix cannot be written as `$c = if (...) { ... } else { @() }`: an if used as
+        # an expression yields its branch's OUTPUT, and emitting @() emits nothing, so the
+        # variable lands back on $null. Assign first, then overwrite.
         $contrib = @()
         if ($byUnit.ContainsKey($k)) { $contrib = $byUnit[$k] }
         Get-PSCxUnitRecord -File $relative -Unit $display[$k] -Line $lines[$k] `
             -Cyclomatic $cyc[$k] -Cognitive $cog[$k] -MetricVersion $script:PSCxMetricVersion `
             -Contributions $contrib -Detailed:$Detailed
+    }
+    return [pscustomobject]@{ File = $relative; Units = @($units); SkipReason = $null }
+}
+
+function Get-PSCxPathScan {
+    # Every file under Path, measured, ONE per-file scan at a time.
+    #
+    # Streaming on purpose. Measure-PSComplexity emits units as it walks, and the aggregate
+    # below is a fold over this -- so both public commands share one walk without forcing the
+    # streaming one to buffer a whole tree to get it.
+    #
+    # -Seen belongs to the caller, because dedup has to span pipeline input: paths arrive one
+    # invocation at a time, and a set created here would forget the previous one.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string[]]$Path,
+        # AllowEmptyCollection, because an empty set is the NORMAL starting point and
+        # Mandatory alone rejects it. Without this the binding failure surfaces wherever the
+        # caller happens to report errors -- the gate described it as a file that did not
+        # parse, which is the same class of misdiagnosis this scan exists to end.
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [System.Collections.Generic.HashSet[string]]$Seen,
+        [switch]$Recurse,
+        [switch]$Detailed
+    )
+    foreach ($p in $Path) {
+        foreach ($file in (Get-PSCxSourceFile -Path $p -Recurse:$Recurse)) {
+            # OrdinalIgnoreCase: Windows and macOS resolve the same file under different
+            # casing, and a case-sensitive check would let those through as two files.
+            if (-not $Seen.Add($file)) { continue }
+            # BEFORE the parse, not after. A line written afterwards names files that are
+            # already done, so a scan stuck on one file looks exactly like a scan that has
+            # finished -- which is the whole complaint. Named here, the last line printed IS
+            # the file being read.
+            #
+            # Verbose rather than a progress bar or a default-on line: this is the command a
+            # CI gate calls, and a gate that chatters gets its output filtered, which takes
+            # the parse errors with it.
+            Write-Verbose "Measuring $file"
+            Get-PSCxFileScan -File $file -Detailed:$Detailed
+        }
+    }
+}
+
+function Get-PSCxScan {
+    # The complete measurement: what was asked for, what was measured, and what was not.
+    #
+    # The record stream Measure-PSComplexity publishes is a PROJECTION of this -- the same
+    # relationship a cognitive map has to its rows. Facts about the RUN, which files were
+    # skipped and why and what was in scope, have nowhere else to live: without this they are
+    # destroyed at emission and every consumer rebuilds them from whatever leaked out.
+    #
+    # Internal deliberately. This is the shape a report, a changed-files run and a committed
+    # baseline all need, and settling it in one place is what stops each inventing a private
+    # version and the first one shipped becoming the contract by accident.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string[]]$Path,
+        [switch]$Recurse,
+        [switch]$Detailed
+    )
+    $units = [System.Collections.Generic.List[object]]::new()
+    $skipped = [System.Collections.Generic.List[object]]::new()
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($fileScan in (Get-PSCxPathScan -Path $Path -Seen $seen -Recurse:$Recurse -Detailed:$Detailed)) {
+        if ($fileScan.SkipReason) {
+            $skipped.Add([pscustomobject]@{ File = $fileScan.File; Reason = $fileScan.SkipReason })
+            continue
+        }
+        $units.AddRange([object[]]$fileScan.Units)
+    }
+    return [pscustomobject]@{
+        Units         = @($units)
+        Skipped       = @($skipped)
+        Scope         = [pscustomobject]@{ Path = @($Path); Recurse = [bool]$Recurse; Root = (Get-Location).Path }
+        MetricVersion = $script:PSCxMetricVersion
     }
 }
 
@@ -202,8 +280,9 @@ function Measure-PSComplexity {
         extends it for PowerShell constructs the specification does not cover:
         ForEach-Object and Where-Object score as the loop and conditional they stand in for,
         && and || as a boolean run, ?? and ??= as a ternary. Cyclomatic is the classic
-        decision-point count, over the same set of constructs. Files that fail to parse are
-        skipped with a warning.
+        decision-point count, over the same set of constructs. A file that fails to parse is
+        skipped and reported on the error stream, naming the file and the parse error;
+        measurement continues over every other file rather than stopping.
 
     .PARAMETER Path
         One or more files or directories to measure.
@@ -211,14 +290,33 @@ function Measure-PSComplexity {
     .PARAMETER Recurse
         Recurse into subdirectories when a directory is given.
 
-    .OUTPUTS
-        [pscustomobject] with File, Unit, Line, Cyclomatic, Cognitive -- one per unit.
+    .PARAMETER Detailed
+        Add a Contributions list to each record: one entry per cognitive increment, carrying
+        the Line it sits on, the Construct that caused it and the Amount it added, in line
+        order. The amounts sum to Cognitive.
 
-        These five names, their order and their types are the module's public contract
+        Read the amounts rather than the count. Anything above +1 is a structure plus the
+        nesting charged for it, so four +1 rows and one +4 row reach the same total and mean
+        different things -- points spread flat say the unit does too many things, points
+        concentrated in one deep row say extract.
+
+        A unit with no increments gets an empty list, not a missing property. Without the
+        switch the record is exactly as documented below.
+
+    .OUTPUTS
+        [pscustomobject] with File, Unit, Line, Cyclomatic, Cognitive, MetricVersion -- one
+        per unit, plus Contributions when -Detailed is given.
+
+        These six names, their order and their types are the module's public contract
         alongside the two command names, and a test asserts them exactly: widening the
         record fails that test, so it is a decision rather than a side effect of an
-        internal change. File and Unit are [string]; Line, Cyclomatic and Cognitive are
-        [int] -- Line as a string would silently turn a numeric sort into a lexical one.
+        internal change. File and Unit are [string]; Line, Cyclomatic, Cognitive and
+        MetricVersion are [int] -- Line as a string would silently turn a numeric sort into
+        a lexical one.
+
+        MetricVersion says which metric produced the numbers, and increments only when a
+        score can change for source that did not. Anything that stores or compares scores
+        should refuse to compare across two different values rather than mix them.
 
         Unit identifies one unit: a class member reads Class.Member, a nested function
         reads Outer/Inner, and units sharing a name in one scope carry an ordinal on every
@@ -255,22 +353,18 @@ function Measure-PSComplexity {
         $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     }
     process {
-        foreach ($p in $Path) {
-            foreach ($file in (Get-PSCxSourceFile -Path $p -Recurse:$Recurse)) {
-                # OrdinalIgnoreCase: Windows and macOS resolve the same file under different
-                # casing, and a case-sensitive check would let those through as two files.
-                if (-not $seen.Add($file)) { continue }
-                # BEFORE the parse, not after. A line written afterwards names files that are
-                # already done, so a scan stuck on one file looks exactly like a scan that has
-                # finished -- which is the whole complaint. Named here, the last line printed
-                # IS the file being read.
-                #
-                # Verbose rather than a progress bar or a default-on line: this is the command
-                # a CI gate calls, and a gate that chatters gets its output filtered, which
-                # takes the parse errors with it.
-                Write-Verbose "Measuring $file"
-                Get-PSCxFileRecord -File $file -Detailed:$Detailed
+        foreach ($fileScan in (Get-PSCxPathScan -Path $Path -Seen $seen -Recurse:$Recurse -Detailed:$Detailed)) {
+            # The projection: units to the output stream, a skip to the error stream.
+            #
+            # Write-Error rather than a warning: CI logs routinely swallow warnings, and this
+            # is the module admitting it did not measure something it was asked to. It is a
+            # RENDERING of $fileScan.SkipReason, not the only place that fact exists -- which
+            # is what lets the gate read the reason as data instead of capturing this stream.
+            if ($fileScan.SkipReason) {
+                Write-Error "Skipped '$($fileScan.File)' -- $($fileScan.SkipReason)"
+                continue
             }
+            $fileScan.Units
         }
     }
 }
@@ -319,17 +413,21 @@ function Test-PSComplexity {
         $collected.AddRange([string[]]$Path)
     }
     end {
-        # Parse failures are captured rather than allowed past. A file the gate could not
-        # read is a file it cannot vouch for, and "no unit exceeded a ceiling" is trivially
-        # true of a file that produced no units -- the same shape as passing over an empty
-        # selection.
         $paths = $collected.ToArray()
-        $units = @(Measure-PSComplexity -Path $paths -Recurse:$Recurse -ErrorVariable parseErrors -ErrorAction SilentlyContinue)
-        if ($parseErrors.Count -gt 0) {
-            throw ("Refusing to vouch for $($parseErrors.Count) file(s) that did not parse: " +
-                (($parseErrors | ForEach-Object { $_.Exception.Message }) -join '; ') +
+        # The scan, not the record stream. What was skipped is a fact the measurement already
+        # holds; reading it back off the error stream required -ErrorAction SilentlyContinue,
+        # which swallowed every OTHER error into the same variable and then described it to
+        # the caller as a file that did not parse.
+        $scan = Get-PSCxScan -Path $paths -Recurse:$Recurse
+        # Parse failures are refused rather than allowed past. A file the gate could not read
+        # is a file it cannot vouch for, and "no unit exceeded a ceiling" is trivially true of
+        # a file that produced no units -- the same shape as passing over an empty selection.
+        if ($scan.Skipped.Count -gt 0) {
+            throw ("Refusing to vouch for $($scan.Skipped.Count) file(s) that did not parse: " +
+                (($scan.Skipped | ForEach-Object { "$($_.File) -- $($_.Reason)" }) -join '; ') +
                 ". Fix the syntax, or exclude the file from the path you gate on.")
         }
+        $units = $scan.Units
 
         # Refuse rather than pass. "No unit breached a ceiling" and "no unit was measured"
         # are the same $true, so a gate pointed at the wrong place reports clean -- which is

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -289,6 +289,47 @@ Describe 'the shipped help' {
         }
     }
 
+    It 'documents every parameter it accepts' {
+        # Every parameter must carry SOME description. This does not police where the text
+        # comes from: PowerShell synthesises a description from a comment sitting immediately
+        # above a parameter as readily as from a .PARAMETER block, and -Detailed shipped
+        # documented that way -- by an argument written for a maintainer rather than guidance
+        # written for a caller, which is a different complaint and not one a test can make.
+        #
+        # What it does catch is a parameter with neither, where Get-Help shows a bare name.
+        # Confirmed by adding one; an earlier version of this test asserted on parameter NAMES
+        # and passed against exactly that.
+        $common = @([System.Management.Automation.Cmdlet]::CommonParameters) +
+                  @([System.Management.Automation.Cmdlet]::OptionalCommonParameters)
+        foreach ($cmd in 'Measure-PSComplexity', 'Test-PSComplexity') {
+            # Filtered on DESCRIPTION, not on name. PowerShell synthesises a parameter entry
+            # from the param block whether or not a .PARAMETER block exists, so a name check
+            # passes against exactly the undocumented switch this test was written to catch --
+            # it did, before this line.
+            $documented = @((Get-Help $cmd).parameters.parameter |
+                    Where-Object { ($_.Description | Out-String).Trim() } |
+                    ForEach-Object { $_.Name })
+            $declared = @((Get-Command $cmd).Parameters.Keys | Where-Object { $_ -notin $common })
+            $missing = @($declared | Where-Object { $_ -notin $documented })
+            ($missing -join ',') | Should-Be '' -Because "$cmd does not document $($missing -join ', ')"
+        }
+    }
+
+    It 'names every field the record actually carries in its .OUTPUTS' {
+        # The .OUTPUTS block said "these five names" and listed five, from the release that
+        # made it six. The record contract is pinned by a test; the prose describing it to
+        # consumers was not, so the two could disagree indefinitely.
+        #
+        # The expected list is read off a REAL record rather than written out here, so a field
+        # added to the record fails this until the help mentions it.
+        $fields = @((Measure-PSComplexity -Path (Join-Path $script:work 'a.ps1') -Detailed)[0].PSObject.Properties.Name)
+        $fields.Count | Should-Be 7 -Because 'six published fields plus Contributions under -Detailed'
+        $outputs = ((Get-Help Measure-PSComplexity).returnValues | Out-String) -replace '\s+', ' '
+        foreach ($f in $fields) {
+            $outputs | Should-BeLikeString "*$f*" -Because "the .OUTPUTS block never names $f"
+        }
+    }
+
     It 'resolves to the command help, not to a file header' {
         # A <# #> block immediately before `function` becomes that function's help, so a file
         # header written that way silently shadows the documentation meant for users. Paired
@@ -822,5 +863,105 @@ function Invoke-Thing {
             @($unit.Contributions).Count | Should-Be 0
         }
         finally { Remove-Item $flat -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'the scan is the measurement; the record stream is a projection of it' {
+    # Facts about the RUN -- which files were skipped and why, what was in scope -- used to be
+    # destroyed at emission, exactly as construct and line used to be destroyed when amounts
+    # were summed at emission. The gate then rebuilt the skip list by capturing its own
+    # module's error stream, which is the shape this pins shut.
+
+    BeforeAll {
+        $script:scanDir = Join-Path ([System.IO.Path]::GetTempPath()) "cxscan-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:scanDir -Force | Out-Null
+        # One good file and one broken one in the SAME directory. A fixture with only the
+        # broken file proves a skip was recorded but not that measuring carried on around it,
+        # and a fixture with only the good file proves nothing about skips at all.
+        Set-Content (Join-Path $script:scanDir 'good.ps1') 'function Get-Good { param($x) if ($x) { 1 } }' -Encoding utf8
+        Set-Content (Join-Path $script:scanDir 'bad.ps1') 'function Oops { param(' -Encoding utf8
+        New-Item -ItemType Directory -Path (Join-Path $script:scanDir 'nested') -Force | Out-Null
+        Set-Content (Join-Path $script:scanDir 'nested/deep.ps1') 'function Get-Deep { param($x) if ($x) { 1 } }' -Encoding utf8
+    }
+
+    AfterAll { Remove-Item $script:scanDir -Recurse -Force -ErrorAction SilentlyContinue }
+
+    It 'records a skip as data, writing nothing to the error stream' {
+        # The purity claim, and the reason the gate can stop capturing errors. A scan that
+        # announced skips on the error stream would leave the caller reconstructing text.
+        $ev = $null
+        $scan = Get-PSCxScan -Path $script:scanDir -ErrorVariable ev -ErrorAction SilentlyContinue
+        @($ev).Count | Should-Be 0
+        $scan.Skipped.Count | Should-Be 1
+    }
+
+    It 'keeps measuring around a file it had to skip' {
+        # The kept half. One broken file must not cost the other results, and asserting only
+        # the skip would pass just as well against a scan that stopped at the first failure.
+        $scan = Get-PSCxScan -Path $script:scanDir
+        (@($scan.Units | Where-Object Unit -eq 'Get-Good')).Count | Should-Be 1
+    }
+
+    It 'names the file and the reason for every skip' {
+        # A skip that does not say which file or why is the fact this type exists to carry.
+        $scan = Get-PSCxScan -Path $script:scanDir
+        $scan.Skipped[0].File | Should-BeLikeString '*bad.ps1'
+        $scan.Skipped[0].Reason | Should-BeLikeString '*parse error*'
+    }
+
+    It 'projects exactly the units the record stream emits' {
+        # The projection claim. If these two ever disagree there are two measurements, which
+        # is the thing having one noun is for.
+        $scan = Get-PSCxScan -Path $script:scanDir
+        $streamed = @(Measure-PSComplexity -Path $script:scanDir -ErrorAction SilentlyContinue)
+        (@($scan.Units | ForEach-Object { $_.Unit }) -join ',') |
+            Should-Be (@($streamed | ForEach-Object { $_.Unit }) -join ',')
+    }
+
+    It 'records what it was asked for, not just what it found' {
+        # Scope is what a changed-files run and a committed baseline both need: "these units"
+        # means nothing without "under this path, recursively or not".
+        $scan = Get-PSCxScan -Path $script:scanDir -Recurse
+        $scan.Scope.Recurse | Should-BeTrue
+        (@($scan.Scope.Path) -join ',') | Should-Be $script:scanDir
+        (Get-PSCxScan -Path $script:scanDir).Scope.Recurse | Should-BeFalse
+    }
+
+    It 'accepts an empty seen set, which is the normal starting point' {
+        # Mandatory alone rejects an empty collection, and the binding failure then surfaces
+        # wherever the caller reports errors -- the gate announced it as a file that did not
+        # parse. A test because the fix is one attribute that reads like decoration.
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $scans = @(Get-PSCxPathScan -Path (Join-Path $script:scanDir 'good.ps1') -Seen $seen)
+        $scans.Count | Should-Be 1
+        $scans[0].SkipReason | Should-BeNull
+    }
+
+    It 'honours -Recurse when collecting, not only when recording it' {
+        # Scope saying Recurse=$true while the walk stayed flat is a scan that lies about
+        # itself, and the gate reads this and nothing else. Both halves: asserting only that
+        # the nested unit IS found passes just as well against a walk that always recurses.
+        $flat = Get-PSCxScan -Path $script:scanDir
+        $deep = Get-PSCxScan -Path $script:scanDir -Recurse
+        (@($flat.Units | Where-Object Unit -eq 'Get-Deep')).Count | Should-Be 0
+        (@($deep.Units | Where-Object Unit -eq 'Get-Deep')).Count | Should-Be 1
+    }
+
+    It 'passes -Detailed through to the units it collects, and withholds it otherwise' {
+        # The switch travels two hops to reach a record, and nothing about the gate's own
+        # output changes if it is dropped or forced -- so only an assertion on both shapes
+        # keeps the pass-through honest.
+        $with = Get-PSCxScan -Path $script:scanDir -Detailed
+        $without = Get-PSCxScan -Path $script:scanDir
+        ($with.Units[0].PSObject.Properties.Name -contains 'Contributions') | Should-BeTrue
+        ($without.Units[0].PSObject.Properties.Name -contains 'Contributions') | Should-BeFalse
+    }
+
+    It 'tells the gate which file it could not read' {
+        # The gate used to join Exception.Message from a captured error stream. It now reads
+        # File and Reason off the scan, so the message names the file as data rather than as
+        # whatever text happened to be in an error record.
+        { Test-PSComplexity -Path $script:scanDir } |
+            Should-Throw -ExceptionMessage '*bad.ps1*'
     }
 }


### PR DESCRIPTION
Closes #17.

## The reframe

`Measure-PSComplexity` emitted a flat stream of per-unit records, so every fact that was not
about a unit had nowhere to live and was discarded at emission -- which files were skipped and
why, and what was in scope. That is the same defect as summing an increment before recording
what caused it, one layer up.

The scan is **not a second kind of measurement**. It is the complete one, and today's record
stream is a lossy projection of it. So this does not add a second measuring command; it names
what measurement produces and makes both public commands views over it.

| | |
|---|---|
| `Get-PSCxFileScan` | one file as data: its units, or the reason there are none |
| `Get-PSCxPathScan` | streams per-file scans, so one walk serves both callers |
| `Get-PSCxScan` | the aggregate: `Units`, `Skipped`, `Scope`, `MetricVersion` |

`Measure-PSComplexity` renders units to the pipeline and each skip to the error stream. **It
still streams** -- the aggregate is a fold over the same per-file scans, so sharing it does not
force the streaming command to buffer a tree.

## The bug this fixes, demonstrated on itself

`Test-PSComplexity` rebuilt its skip list by capturing its own module's error stream with
`-ErrorAction SilentlyContinue`, so *any* error landed in the same variable and was reported
as a syntax problem in a file. It now reads `.Skipped` as data.

The refactor reproduced the exact symptom while it was being written: a parameter-binding
fault surfaced as

```
Refusing to vouch for 1 file(s) that did not parse:
  Cannot bind argument to parameter 'Seen' because it is an empty collection.
```

That is why `$Seen` carries `AllowEmptyCollection` and has a test of its own.

## Why it stays internal

This is the shape a machine-readable report (#5), a changed-files run (#7) and a committed
baseline (#2) all need. Settling it in one place is what stops each inventing a private
version and the first one shipped becoming the contract by accident -- which is the failure
#17 was filed to prevent.

Publishing it later costs one decision this deliberately does not take now: a command with two
output shapes, where a pipeline written against the record stream returns nothing under the
other one. Nothing about the public surface changes here.

## Shipped help, corrected

Three claims had drifted from the code:

- parse failures were documented as producing a **warning**; they produce an **error**
- `.OUTPUTS` said "these five names" and listed five, from the release that made it **six** --
  the record contract was pinned by a test, the prose describing it was not
- `-Detailed` had no `.PARAMETER` block, so `Get-Help` served the argument written above the
  parameter *for a maintainer* instead of guidance written for a caller

Two tests now hold that: every parameter must carry a description, and the `.OUTPUTS` block
must name every field a real record carries -- the expected list is read off a record rather
than written out, so a new field fails until the help mentions it.

Worth stating plainly: the first version of the parameter test asserted on parameter **names**
and passed against an undocumented switch, because PowerShell synthesises an entry for every
parameter regardless. Both tests were then checked against the defect they describe, and the
`-Detailed` claim was corrected -- it was never invisible to `Get-Help`, it was documented by
the wrong text.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 262 passed, 0 failed |
| Coverage | 100% over `src/` (449 commands, up from 408) |
| Analyzer | clean |
| Self-complexity | passes |
| Scoped mutation (`Measure-PSComplexity.ps1`) | **100%, 62/62** |
| Release consistency | consistent at 0.4.0 |

No version bump: 0.4.0 is unreleased, so this folds into that entry.
