### PR TITLE
docs: record what the number does not say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ keys it holds could not distinguish units the tool could.
   reached flat and reached nested look different and say different things. Default output is
   unchanged: no switch, no property, and the six published fields stay exactly as they were.
 
+- **The README now says what the number does not say.** Two consequences of measuring per unit,
+  written down as decisions rather than left to be discovered from the output and mistaken for
+  bugs. The gate cannot tell decomposition from displacement: splitting identical control flow
+  into helpers drops the maximum from 14/38 to 6/10 and the gate passes, and whether that made
+  the code easier to read is a question the tool cannot answer. This module does the same thing
+  to itself and now says so. And a nested named function contributes nothing to its parent where
+  the same body as a script block contributes 3/5 -- a **deliberate departure from SonarSource**,
+  which increments for nested declarations, recorded rather than left silent.
+
 - **Every reference score is attributed to something outside this project.** The README claims
   the cognitive metric reproduces the SonarSource scores; the suite checked numbers the project
   had chosen itself, so a wrong interpretation would have had the suite agreeing with the bug --

--- a/README.md
+++ b/README.md
@@ -187,6 +187,42 @@ Invoke-ScriptAnalyzer -Path ./src -Recurse -Settings ./PSScriptAnalyzerSettings.
 All gates (lint, reference-score tests, self-complexity gate) run on **Windows and
 Linux** in the required CI job and block the merge.
 
+## What the number does not say
+
+Two things follow from measuring **per unit**, and both are decisions rather than gaps. They
+are written down because a reader who discovers them from the output will reasonably assume
+one of them is a bug.
+
+**The gate cannot tell decomposition from displacement.** A 20-line `Invoke-Deploy` scoring
+14/38 fails at the default ceilings. Split the *identical* control flow into four private
+helpers plus an orchestrator and the maximum drops to 6/10, the gate passes, and the file's
+total cognitive falls from 38 to 21 -- a total that appears nowhere, because the output is
+per unit and the gate is a maximum over units.
+
+Whether that split made the code easier to read is a question the tool cannot answer. Often
+it does; sometimes it only moves the branch somewhere else. Complexity exists per unit, so a
+per-unit measure is the honest one, and this is the price of it. This module does the same
+thing to itself and says so: `Cognitive.ps1`'s row collectors are split into small functions
+partly so the metric clears its own gate, while `Get-PSCxCyclomaticRow` leaves the same shape
+inline and is the joint-highest unit here.
+
+A related consequence worth knowing before trusting a low score: a 60-line function assigning
+sixty fields through a `$global:` accumulator scores **1/0** -- identical to
+`function Get-Flat { $x }`. Neither metric measures length, coupling or state.
+
+**A nested named function contributes nothing to its parent.** The same body written as a
+script block contributes 3/5. That asymmetry is deliberate: a nested named function is
+discovered as its own unit and gets its own row, so its complexity is measured -- just not
+*there*. A script block has no unit of its own, so its complexity must land on the enclosing
+function or vanish.
+
+It is also the cheaper of the two displacement routes, since a hard branch moved into a
+nested named function drops the parent under the ceiling without moving a line out of the
+file. **This is a deliberate departure from SonarSource**, whose specification increments for
+nested function *declarations* in languages that have them, for exactly that reason. Recorded
+here rather than silently: every other reference score in this module matches the spec, and
+the ones that do are attributed in the test suite.
+
 ## Notes / scope
 
 - **PowerShell 7.2+ only** (Core). Windows PowerShell 5.1 is not supported.


### PR DESCRIPTION
Closes #22.
Closes #47.

Two consequences of measuring per unit, written down as **decisions** rather than left to be
discovered from the output and mistaken for bugs. Documentation only -- no code, no gate, no
version bump.

## #22 -- the gate cannot tell decomposition from displacement

Splitting identical control flow into helpers drops the maximum from 14/38 to 6/10 and the
gate passes. Whether that made the code easier to read is a question the tool cannot answer,
because complexity is defined per unit and moving a branch into a new unit moves its cost with
it.

This module does exactly that to itself, and now says so rather than leaving a reader to spot
it. The `-Detailed` work in #93 is a fresh example: adding one branch two `foreach` levels deep
took `Measure-PSComplexity` from cognitive 12 to 26, and the fix was to extract two functions.
That is decomposition -- both extractions are nameable units with their own tests -- but the
metric alone cannot distinguish it from hiding the same branch behind a call.

## #47 -- a nested named function contributes nothing to its parent

The same body as a script block contributes 3/5. That is a **deliberate departure from
SonarSource**, which increments for nested declarations, and it is recorded here rather than
left silent -- an undocumented departure from a specification the README cites is
indistinguishable from a bug in the implementation of it.

## Why this is a PR and not a comment on the issues

Both are permanent properties of a per-unit metric, not defects awaiting a fix. Left only in
the tracker they get rediscovered as surprises; in the README they are part of what the tool
promises and what it does not.

Rebased onto `main` after #93; the CHANGELOG conflict was two `### Added` entries for the same
unreleased version and both are kept.