### PR TITLE
feat: let somebody disagree with a number, and make the disagreement checkable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,19 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **A number can be disagreed with: `Test-PSComplexity -Accept`.** The whole policy surface was
+  two ceilings and a path, so the only answers to a unit that is genuinely, irreducibly complex
+  were to lower the ceiling for everyone or stop measuring the file -- and the second is
+  indistinguishable from never having looked. An acceptance names one unit, by file and unit
+  together, and carries the argument for it.
+
+  It is a **checkable claim, not a suppression**: the gate throws when one stops describing the
+  run -- the unit was not measured, or is back within both ceilings, or carries no reason. A
+  suppression that stops applying sits there excusing nothing while the next breach passes
+  unnoticed; this fails the build that relies on it, on the run where it stopped being true.
+  Every fault is reported at once rather than the first, and an accepted unit is still measured,
+  because this is gate policy and not a measurement filter.
+
 - **A score can say where it came from: `Measure-PSComplexity -Detailed`.** A unit reported as
   `Cognitive = 23` was correct and unactionable -- nothing distinguished one deeply-nested loop
   from twenty flat guards, and those call for opposite fixes. `-Detailed` attaches a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,24 @@ Two subtleties worth knowing before touching `Ast.ps1`:
 Habits this repo already has. They are written down because they are cheap to lose in a hurry
 and expensive to rebuild, and because each one has already earned its keep.
 
+- **An acceptance is a checkable claim, and there must never be a plain suppression beside
+  it.** `-Accept` names one unit by file AND unit, carries a written argument, and the gate
+  THROWS when the claim stops describing the run: no such unit measured, the unit back within
+  both ceilings, or no reason given. The value is entirely in the failure -- a suppression that
+  stops applying sits there excusing nothing while the next breach of that unit passes
+  unnoticed, which is how every suppression list ages into a mute button nobody dares delete.
+
+  Two design points that are easy to undo. The gate **throws** rather than returning `$false`,
+  because a stale acceptance is a fault in the policy and not a complaint about the code --
+  returning `$false` sends someone to refactor a unit that is fine. And an accepted unit is
+  still **measured**: this is gate policy, not a measurement filter, so a report or a baseline
+  built on the same records still sees the unit and its number.
+
+  There is deliberately no ambiguity arm, unlike the sibling project's equivalence
+  declarations. A unit identity is unique within a file, so an exact File+Unit match is one or
+  none by construction, and a rule that cannot fire looks exactly like a rule that passes. If
+  unit identity ever stops being unique, that is the moment to add one.
+
 - **The scan is the measurement; the published output is a projection of it.** `Get-PSCxScan`
   returns what was asked for, which units were found, and which files were skipped and why.
   `Measure-PSComplexity` renders the units to the pipeline and each skip to the error stream;

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ nested loop-in-loop-in-`if` grows fast — mirroring how hard it is to follow.
 | Command | Returns | Purpose |
 |---|---|---|
 | `Measure-PSComplexity -Path <files/dirs> [-Recurse] [-Detailed]` | per-unit records | inspect / report |
-| `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15]` | `[bool]` | CI gate (warns per offender) |
+| `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15] [-Accept <declarations>]` | `[bool]` | CI gate (warns per offender) |
 
 ### The record is the API
 
@@ -162,6 +162,54 @@ and its total is already its own explanation.
 
 Nothing changes without the switch. The six fields above are what a default run emits, in that
 order, and CI consumers that parse it are unaffected.
+
+### Disagreeing with a number
+
+Every complexity gate eventually meets a unit that is genuinely, irreducibly complex -- a
+parser, a dispatch table, a state machine -- where the honest answer is "yes, and here is why
+that is correct". Without a way to say so the only options are lowering the ceiling for
+everyone or not measuring the file, and the second is indistinguishable from never having
+looked.
+
+`-Accept` is the third answer. Each entry names one unit and carries the argument for it:
+
+```powershell
+$accept = @(
+    @{ File   = 'src/Parser.ps1'
+       Unit   = 'Read-Token'
+       Reason = 'table-driven lexer; splitting the table across helpers hides it' }
+)
+
+if (-not (Test-PSComplexity ./src -Recurse -Accept $accept)) { throw 'Complexity gate failed' }
+```
+
+**It is a checkable claim, not a suppression.** The gate **throws** when an acceptance stops
+describing the run:
+
+| The claim | What happened |
+|---|---|
+| no unit of that `File` + `Unit` was measured | renamed, moved, or outside the path being gated |
+| the unit is within both ceilings | somebody fixed it and left the note behind |
+| `Reason` is empty or whitespace | a declaration with no argument is a mute button |
+| `File` or `Unit` missing | the claim does not say what it is about |
+
+That is the whole difference from a suppression list. A suppression that stops applying goes
+on sitting in the file, excusing nothing, and the next breach of that unit passes unnoticed --
+so the list ages into a mute button nobody dares delete. An acceptance fails the build that
+relies on it instead, on the run where it stopped being true.
+
+Three properties worth relying on:
+
+- **Every fault is reported at once**, not the first, so fixing a stale list costs one CI round
+  trip rather than one per entry.
+- **The key is `File` *and* `Unit`.** A gate keyed on the symbol alone would excuse every
+  like-named unit in the tree, which is how suppression lists usually leak.
+- **An accepted unit is still measured.** This is gate policy, not a measurement filter, so the
+  unit keeps its record and its number -- a report or a baseline built on the same records still
+  sees it. Hiding it would take the argument away along with the number it is about.
+
+`File` must match the record's `File` exactly: relative to the working directory with forward
+slashes, or the full path for a file outside it.
 
 ## Use it in CI
 

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -369,6 +369,87 @@ function Measure-PSComplexity {
     }
 }
 
+function Get-PSCxAcceptanceKey {
+    # The identity an acceptance is written against. Two fields, never one joined string: a
+    # File outside the measured root keeps its full path, and on Windows that starts "C:", so
+    # any single-separator key is ambiguous the first time somebody gates outside their repo.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$File,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$Unit
+    )
+    return "$File`u{241F}$Unit"
+}
+
+function Get-PSCxAcceptanceFault {
+    # Why ONE acceptance fails to describe this run, as text. Nothing when it holds.
+    #
+    # An acceptance is a CHECKABLE CLAIM and not a mute button. It carries a written argument,
+    # and the run fails when the claim stops being true -- the unit was renamed away, or it came
+    # back under the ceilings and nobody deleted the note. A declaration that silently stops
+    # applying is indistinguishable from one nobody has read in a year, and a gate full of those
+    # is the thing this module exists to find in other people's code.
+    #
+    # One acceptance at a time, over the pipeline, so the four rules sit at the top level of a
+    # process block rather than inside a loop. Written as a foreach over the list they cost
+    # their nesting depth each and the function scored 14 against a ceiling of 15 -- passing,
+    # and one rule away from not passing, in the function most likely to grow another rule.
+    #
+    # There is deliberately NO ambiguity arm. A unit identity is unique within a file, so an
+    # exact File+Unit match is one or none by construction -- and a rule that cannot fire looks
+    # exactly like a rule that passes. If unit identity ever stops being unique, this is the
+    # comment that has to change with it.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)] [AllowNull()] $Acceptance,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Unit,
+        [Parameter(Mandatory)] [int]$MaxCyclomatic,
+        [Parameter(Mandatory)] [int]$MaxCognitive
+    )
+    process {
+        $file = [string]$Acceptance.File
+        $name = [string]$Acceptance.Unit
+        $reason = [string]$Acceptance.Reason
+        if (-not $file -or -not $name) {
+            return "an acceptance needs both File and Unit, got File='$file' Unit='$name'"
+        }
+        if (-not $reason.Trim()) {
+            return "$file $name is accepted with no reason -- an acceptance carries the argument for it, or it is a mute button"
+        }
+        $found = @($Unit | Where-Object { $_.File -eq $file -and $_.Unit -eq $name })
+        if ($found.Count -eq 0) {
+            return "$file $name is accepted but no such unit was measured -- it was renamed, moved, or is outside the path being gated"
+        }
+        if ($found[0].Cyclomatic -le $MaxCyclomatic -and $found[0].Cognitive -le $MaxCognitive) {
+            return "$file $name is accepted but is within both ceilings -- delete the acceptance, it is no longer an argument about anything"
+        }
+    }
+}
+
+function Get-PSCxUnacceptedUnit {
+    # The units that breach a ceiling and that nobody has argued for. Separate from the gate
+    # because the gate is a thin predicate and this is the whole of what it decides.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Unit,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Accept,
+        [Parameter(Mandatory)] [int]$MaxCyclomatic,
+        [Parameter(Mandatory)] [int]$MaxCognitive
+    )
+    $accepted = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($a in $Accept) { [void]$accepted.Add((Get-PSCxAcceptanceKey -File ([string]$a.File) -Unit ([string]$a.Unit))) }
+    # Emitted rather than returned as an array, so the declared OutputType describes what a
+    # caller actually receives -- one record at a time. The gate wraps the result in @() and
+    # gets an empty array when nothing breaches, which is the same answer either way.
+    $Unit | Where-Object {
+        ($_.Cyclomatic -gt $MaxCyclomatic -or $_.Cognitive -gt $MaxCognitive) -and
+        -not $accepted.Contains((Get-PSCxAcceptanceKey -File $_.File -Unit $_.Unit))
+    }
+}
+
 function Test-PSComplexity {
     <#
     .SYNOPSIS
@@ -387,6 +468,20 @@ function Test-PSComplexity {
     .PARAMETER Recurse
         Recurse into subdirectories when a directory is given.
 
+    .PARAMETER Accept
+        Units that are allowed to exceed a ceiling, each carrying the argument for why. One
+        entry per unit, with File, Unit and Reason -- for example
+        @{ File = 'src/Parser.ps1'; Unit = 'Read-Token'; Reason = 'table-driven lexer; splitting it hides the table' }.
+
+        An acceptance is a checkable claim, not a suppression. The gate THROWS, rather than
+        quietly ignoring it, when one stops describing the run: no unit of that name was
+        measured, the unit is now within both ceilings, or no reason was given. So a stale
+        acceptance fails the build that relies on it instead of ageing silently into a mute
+        button, which is what a plain suppression list becomes.
+
+        File must match the record's File exactly -- relative to the working directory with
+        forward slashes, or the full path for a file outside it.
+
     .OUTPUTS
         [bool]
 
@@ -399,7 +494,9 @@ function Test-PSComplexity {
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
         [int]$MaxCyclomatic = 15,
         [int]$MaxCognitive = 15,
-        [switch]$Recurse
+        [switch]$Recurse,
+        # Empty is the normal case, and an empty array must bind rather than be rejected.
+        [AllowEmptyCollection()] [object[]]$Accept = @()
     )
     # ValueFromPipeline needs begin/process/end, not a bare body. A bare body IS the `end`
     # block, so it would run once with $Path holding only the LAST item piped in -- and the
@@ -439,8 +536,18 @@ function Test-PSComplexity {
                 ".ps1 or .psm1 files" + $hint + '.')
         }
 
-        $violations = @($units |
-                Where-Object { $_.Cyclomatic -gt $MaxCyclomatic -or $_.Cognitive -gt $MaxCognitive })
+        # Checked BEFORE the verdict, and thrown rather than returned as $false. A stale
+        # acceptance is a fault in the policy, not a complaint about the code -- reporting it
+        # as a failing gate would send someone to refactor a unit that is fine.
+        $faults = @($Accept | Get-PSCxAcceptanceFault -Unit $units `
+                -MaxCyclomatic $MaxCyclomatic -MaxCognitive $MaxCognitive)
+        if ($faults.Count -gt 0) {
+            throw ("The acceptance list does not describe this run: " + ($faults -join '; ') +
+                ". An acceptance that no longer applies is a mute button, so it fails here rather than ageing quietly.")
+        }
+
+        $violations = @(Get-PSCxUnacceptedUnit -Unit $units -Accept $Accept `
+                -MaxCyclomatic $MaxCyclomatic -MaxCognitive $MaxCognitive)
         foreach ($v in $violations) {
             Write-Warning ("{0}:{1} {2} -- cyclomatic {3} (max {4}), cognitive {5} (max {6})" -f `
                     $v.File, $v.Line, $v.Unit, $v.Cyclomatic, $MaxCyclomatic, $v.Cognitive, $MaxCognitive)

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -965,3 +965,160 @@ Describe 'the scan is the measurement; the record stream is a projection of it' 
             Should-Throw -ExceptionMessage '*bad.ps1*'
     }
 }
+
+Describe 'an acceptance is a checkable claim, not a mute button' {
+    # Every complexity gate meets a unit that is genuinely, irreducibly complex. The only
+    # answers used to be lower the ceiling for everyone or stop measuring the file, and the
+    # second is what this repo does to its own tests. An acceptance is the third answer -- and
+    # it fails when it stops being true, which is the whole difference between it and a
+    # suppression list.
+
+    BeforeAll {
+        $script:accDir = Join-Path ([System.IO.Path]::GetTempPath()) "cxacc-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:accDir -Force | Out-Null
+        # One unit that breaches a low ceiling and one that cannot: an acceptance test needs
+        # both, or "accepted" is indistinguishable from "nothing breached".
+        Set-Content (Join-Path $script:accDir 'hot.ps1') @'
+function Invoke-Hot {
+    param($a, $b, $c)
+    if ($a) { if ($b) { if ($c) { 1 } } }
+}
+function Get-Cool { param($x) $x }
+'@ -Encoding utf8
+        $script:accFile = (Measure-PSComplexity -Path (Join-Path $script:accDir 'hot.ps1') |
+                Where-Object Unit -eq 'Invoke-Hot').File
+        $script:accPath = Join-Path $script:accDir 'hot.ps1'
+    }
+
+    AfterAll { Remove-Item $script:accDir -Recurse -Force -ErrorAction SilentlyContinue }
+
+    It 'lets a breaching unit pass when it carries an argument' {
+        $ok = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'a deliberately nested fixture' })
+        Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $ok `
+            -WarningAction SilentlyContinue | Should-BeTrue
+    }
+
+    It 'still fails the same unit when nobody argued for it' {
+        # The kept half. Without this the test above passes just as well against a gate that
+        # stopped checking ceilings altogether.
+        Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 `
+            -WarningAction SilentlyContinue | Should-BeFalse
+    }
+
+    It 'accepts only the unit named, not every unit in the file' {
+        # Accepting Get-Cool must not excuse Invoke-Hot. A key compared too loosely -- on file
+        # alone -- passes the first test and silently mutes the whole file.
+        $wrong = @(@{ File = $script:accFile; Unit = 'Get-Cool'; Reason = 'r' })
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $wrong `
+                -WarningAction SilentlyContinue } | Should-Throw -ExceptionMessage '*within both ceilings*'
+    }
+
+    It 'throws when the acceptance names a unit that was not measured' {
+        # The stale case, and the reason this is a claim rather than a suppression: a unit that
+        # was renamed away takes its argument with it, and nothing else would say so.
+        $ghost = @(@{ File = $script:accFile; Unit = 'Invoke-Ghost'; Reason = 'r' })
+        # Asserted on the TAIL of the message, past the last concatenation. Break the `+` that
+        # builds it and PowerShell raises a conversion error QUOTING its left operand -- which
+        # contains every earlier phrase, so an assertion on one of those matches the very
+        # failure it exists to detect. Only text from after the break tells them apart.
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $ghost `
+                -WarningAction SilentlyContinue } |
+            Should-Throw -ExceptionMessage '*no such unit was measured*ageing quietly*'
+    }
+
+    It 'throws when the accepted unit is back within both ceilings' {
+        # Somebody fixed it and left the note. Left alone, the note goes on excusing a unit
+        # that no longer needs excusing, and the next breach of it passes unnoticed.
+        $fixed = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'r' })
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 15 -MaxCognitive 15 -Accept $fixed `
+                -WarningAction SilentlyContinue } | Should-Throw -ExceptionMessage '*within both ceilings*'
+    }
+
+    It 'throws when an acceptance carries no argument' {
+        # Whitespace, not absence: a Reason of spaces is the shape a copied template arrives in,
+        # and it is exactly the mute button this concept exists instead of.
+        $bare = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = '   ' })
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $bare `
+                -WarningAction SilentlyContinue } | Should-Throw -ExceptionMessage '*with no reason*'
+    }
+
+    It 'throws when an acceptance does not say which unit it is about' {
+        $vague = @(@{ File = $script:accFile; Reason = 'r' })
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $vague `
+                -WarningAction SilentlyContinue } | Should-Throw -ExceptionMessage '*needs both File and Unit*'
+    }
+
+    It 'reports every fault at once rather than the first' {
+        # A gate that fixes one acceptance per run costs a CI round trip each time.
+        $many = @(
+            @{ File = $script:accFile; Unit = 'Invoke-Ghost'; Reason = 'r' }
+            @{ File = $script:accFile; Unit = 'Get-Cool'; Reason = 'r' }
+        )
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $many `
+                -WarningAction SilentlyContinue } |
+            Should-Throw -ExceptionMessage '*no such unit was measured*within both ceilings*'
+    }
+
+    It 'accepts a unit that breaches only the cyclomatic ceiling' {
+        # Invoke-Hot is cyclomatic 4, cognitive 6. Ceilings 3/6 put it over one and inside the
+        # other, which is the only shape that tells "within BOTH ceilings" from "within either".
+        # Every earlier test had a unit over both or under both, where -and and -or agree and
+        # the first comparison never decides anything.
+        $ok = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'over on cyclomatic only' })
+        Test-PSComplexity -Path $script:accPath -MaxCyclomatic 3 -MaxCognitive 6 -Accept $ok `
+            -WarningAction SilentlyContinue | Should-BeTrue
+    }
+
+    It 'accepts a unit that breaches only the cognitive ceiling' {
+        # The mirror image, ceilings 4/5, so the SECOND comparison is the one that decides.
+        # Both halves are needed: each comparison is read separately, and a fault in one is
+        # invisible while the other still guards the result.
+        $ok = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'over on cognitive only' })
+        Test-PSComplexity -Path $script:accPath -MaxCyclomatic 4 -MaxCognitive 5 -Accept $ok `
+            -WarningAction SilentlyContinue | Should-BeTrue
+    }
+
+    It 'treats a unit sitting exactly ON both ceilings as within them' {
+        # At or under, not under. Ceilings 4/6 against cyclomatic 4 and cognitive 6: the unit is
+        # inside, so the acceptance is the one that should be deleted. Read as strictly-less
+        # this reports nothing and the stale acceptance survives -- and a fencepost here is
+        # silent, because it only ever shows up for a unit that lands exactly on the line.
+        $fixed = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'r' })
+        { Test-PSComplexity -Path $script:accPath -MaxCyclomatic 4 -MaxCognitive 6 -Accept $fixed `
+                -WarningAction SilentlyContinue } |
+            Should-Throw -ExceptionMessage '*within both ceilings*ageing quietly*'
+    }
+
+    It 'still measures a unit it accepts' {
+        # An acceptance is gate POLICY, not a measurement filter. Hiding the unit from
+        # Measure-PSComplexity would take it out of any report or baseline built on the same
+        # records, so the argument would disappear along with the number it is about.
+        $ok = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'r' })
+        Test-PSComplexity -Path $script:accPath -MaxCyclomatic 1 -MaxCognitive 1 -Accept $ok `
+            -WarningAction SilentlyContinue | Out-Null
+        (@(Measure-PSComplexity -Path $script:accPath | Where-Object Unit -eq 'Invoke-Hot')).Count |
+            Should-Be 1
+    }
+
+    It 'keys on file AND unit, so the same name in another file is a different claim' {
+        # File is half the identity. Compared on unit name alone, one acceptance excuses every
+        # like-named unit in the tree -- which is the failure mode of every suppression list
+        # that keys on a symbol.
+        $other = Join-Path $script:accDir 'other.ps1'
+        Set-Content $other @'
+function Invoke-Hot {
+    param($a, $b, $c)
+    if ($a) { if ($b) { if ($c) { 1 } } }
+}
+'@ -Encoding utf8
+        try {
+            # BOTH files in one run, so the acceptance describes this run and the only question
+            # left is which unit it excuses. Gating other.ps1 alone would throw instead --
+            # correctly, but for the different reason that the claim names a unit not measured.
+            $ok = @(@{ File = $script:accFile; Unit = 'Invoke-Hot'; Reason = 'r' })
+            Test-PSComplexity -Path $script:accDir -MaxCyclomatic 1 -MaxCognitive 1 -Accept $ok `
+                -WarningAction SilentlyContinue | Should-BeFalse
+        }
+        finally { Remove-Item $other -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
Closes #21.

The whole policy surface was two ceilings and a path. Every complexity gate eventually meets a
unit that is genuinely, irreducibly complex -- a parser, a dispatch table, a state machine --
where the honest answer is "yes, and here is why that is correct". The only available answers
were to lower the ceiling for everyone, or to stop measuring the file, and the second is
indistinguishable from never having looked. This repo does exactly that to its own tests.

```powershell
$accept = @(
    @{ File   = 'src/Parser.ps1'
       Unit   = 'Read-Token'
       Reason = 'table-driven lexer; splitting the table across helpers hides it' }
)
Test-PSComplexity ./src -Recurse -Accept $accept
```

## What makes it a claim and not a suppression

The gate **throws** when an acceptance stops describing the run:

| The claim | What happened |
|---|---|
| no unit of that `File` + `Unit` was measured | renamed, moved, or outside the path being gated |
| the unit is within both ceilings | somebody fixed it and left the note behind |
| `Reason` is empty or whitespace | a declaration with no argument is a mute button |
| `File` or `Unit` missing | the claim does not say what it is about |

That failure *is* the feature. A suppression that stops applying sits in the file excusing
nothing while the next breach of that unit passes unnoticed -- which is how a suppression list
ages into a mute button nobody dares delete. Every fault is reported at once rather than the
first, because a gate that fixes one entry per run costs a CI round trip each time.

## Four decisions, and why

**A parameter, not a config file.** A committed baseline (#2) will want a file format and should
own that decision; inventing one here would pre-empt it. `-Accept (Get-Content accept.json |
ConvertFrom-Json)` works today.

**Throws rather than returning `$false`.** A stale acceptance is a fault in the policy, not a
complaint about the code -- a false verdict would send someone to refactor a unit that is fine.

**No ambiguity arm**, unlike the sibling project's equivalence declarations. A unit identity is
unique within a file, so an exact File+Unit match is one or none *by construction*, and a rule
that cannot fire looks exactly like a rule that passes. The comment says what has to change if
identity ever stops being unique.

**An accepted unit is still measured.** This is gate policy, not a measurement filter: a report
or a baseline built on the same records still sees the unit and its number, where hiding it
would take the argument away along with the number it is about.

## What the gates caught

`Get-PSCxAcceptanceFault` first scored **cognitive 14** against a ceiling of 15 -- passing, and
one rule away from not passing, in the function most likely to grow another rule. Taking one
acceptance over the pipeline instead of looping the list puts its four rules at the top of a
`process` block rather than inside a loop: **cog 8**. The analyzer separately caught
`Get-PSCxUnacceptedUnit` declaring a single object while returning an array.

The self-mutation gate came back **95%, five survivors**, and every one was a real gap:

- `-le -> -lt` -- no fixture sat **exactly on** a ceiling
- `-and -> -or` -- no fixture breached **exactly one** ceiling
- `$found[0] -> $found[1]` (twice) -- the same gap. `$null.Cyclomatic -le 1` is `$true` (null
  coerces to 0), but with a unit over *both* ceilings the surviving operand short-circuits to the
  same answer, so the mutant is only visible for a unit over exactly one.
- `+ -> -` -- **the assertion was vacuous.** Breaking the concatenation raises a conversion error
  that *quotes its left operand*, which contains every earlier phrase, so
  `Should-Throw -ExceptionMessage '*no such unit was measured*'` matched the mutant's own
  failure. The assertions now end `*ageing quietly*`, past the last `+`.

One missing fixture shape accounted for four of the five. Four tests added; all five killed.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 275 passed, 0 failed |
| Coverage | 100% over `src/` |
| Analyzer | clean |
| Self-complexity | passes |
| Scoped mutation (`Measure-PSComplexity.ps1`) | **100%, 100/100** |
| Release consistency | consistent at 0.4.0 |

Rebased onto `main` after #94 and #95; `src/` verified byte-identical across the rebase, so the
100/100 above describes this tree and not the pre-rebase one.

No version bump: 0.4.0 is unreleased, so this folds into that entry.

---

With this, **Wave B is finished** -- the increment, the record, the scan and the exception
concept all exist. Next is #5, which carries the decision #17 deliberately deferred: whether the
scan becomes public, and in what serialised shape.
