### PR TITLE
feat: let a run leave the process, as JSON and as SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,19 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     # A wedged runner otherwise holds a REQUIRED check pending for the six-hour default,
-    # blocking every merge behind it. The full matrix runs in about two minutes.
-    timeout-minutes: 20
+    # blocking every merge behind it.
+    #
+    # Set for the LINUX leg, which is the only one that self-mutates and is therefore the only
+    # one this number is about: Windows finishes in about two minutes, Linux in tens of them.
+    # The budget is the mutant count times the per-mutant cost, and the mutant count grows
+    # whenever src/ does -- adding one file took the set from roughly 195 mutants to 300 and
+    # walked straight through a 20-minute limit, which GitHub reports as a CANCELLED job rather
+    # than a failed one, so it reads like somebody stopped the run.
+    #
+    # Raising this is the stopgap, not the answer: per-mutant cost here is 4.3s against the
+    # sibling project's 1.8s, because src/Ast.ps1 is mapped to two covering suites and pays for
+    # both on every one of its mutants (#96).
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,7 +173,7 @@ jobs:
           if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
           New-Item -ItemType Directory -Path $stage -Force | Out-Null
           # Publish-Module requires the folder to be named exactly like the module.
-          Copy-Item ./PSComplexity.psd1, ./PSComplexity.psm1, ./src, ./LICENSE, ./README.md -Destination $stage -Recurse -Force
+          Copy-Item ./PSComplexity.psd1, ./PSComplexity.psm1, ./src, ./schemas, ./LICENSE, ./README.md -Destination $stage -Recurse -Force
           "STAGE_DIR=$stage" | Out-File -FilePath $env:GITHUB_ENV -Append
           Get-ChildItem $stage | ForEach-Object { Write-Host "  staged: $($_.Name)" }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,24 @@ keys it holds could not distinguish units the tool could.
 
 ### Added
 
+- **A run can leave the process: `-ReportPath` and `-SarifPath`.** The gate gave a build one bit
+  and the records were PowerShell objects, so anything that was not PowerShell -- a dashboard, a
+  trend, a pull request annotation -- had to re-implement the serialisation. `Measure-PSComplexity
+  -ReportPath` and `Test-PSComplexity -ReportPath` write a JSON report described by
+  `schemas/v1/report.schema.json`, which now ships with the module; `Test-PSComplexity -SarifPath`
+  writes a SARIF 2.1.0 log that GitHub code scanning renders against the diff.
+
+  The report is the scan serialised, not a new shape. Two forms: a measurement report, and a gate
+  report that adds the ceilings, the verdict, the breaches and every acceptance with its argument.
+  A measurement report **cannot** carry a verdict -- the schema forbids `passed` without
+  `thresholds`, because a command that applied no ceilings has no verdict to give. `metricVersion`,
+  `scope` and `skipped` are required for the same reason: no number in the file can be read
+  without what produced it and what it left out.
+
+  SARIF raises one result per breached ceiling under two independently suppressible rule ids, and
+  fingerprints on file and unit rather than on the line, which moves. An accepted unit raises
+  nothing -- the gate excused it, and the JSON report is where that argument is recorded.
+
 - **A number can be disagreed with: `Test-PSComplexity -Accept`.** The whole policy surface was
   two ceilings and a path, so the only answers to a unit that is genuinely, irreducibly complex
   were to lower the ceiling for everyone or stop measuring the file -- and the second is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ src/Cyclomatic.ps1             decision-point counting.
 src/Cognitive.ps1              the SonarSource metric (B1 structural, B2 nesting, B3 level).
 src/Measure-PSComplexity.ps1   the scan -- measurement as data -- and the two public
                                projections over it: Measure-PSComplexity, Test-PSComplexity.
+src/Report.ps1                 the two published formats -- our JSON report and SARIF -- and
+                               the one function that writes a file.
+schemas/v1/report.schema.json  the report format. Ships in the package; a consumer validates
+                               against it without reading this repo.
 ```
 
 **The mutation config maps each source file to specific test files.** `src/Cyclomatic.ps1`
@@ -110,6 +114,32 @@ Two subtleties worth knowing before touching `Ast.ps1`:
 
 Habits this repo already has. They are written down because they are cheap to lose in a hurry
 and expensive to rebuild, and because each one has already earned its keep.
+
+- **A published format makes the dangerous shape unrepresentable, not merely undocumented.**
+  `schemas/v1/report.schema.json` forbids `passed` unless `thresholds` are present, so a
+  measurement report cannot carry a verdict nobody computed; and it requires `metricVersion`,
+  `scope` and `skipped`, so no number in it can be read without what it excluded. Copied from
+  the sibling project, which forbids a mutation score in a recheck report for the same reason.
+
+  Four traps come with it, all already paid for elsewhere. **Validate the FILE, not a parsed
+  object** -- `ConvertFrom-Json` re-types the ISO-8601 `generatedAt` into a `[datetime]`.
+  **`Test-Json` silently ignores `not`**, so a forbidden property is written as
+  `"passed": false` in a `properties` block; the obvious spelling is a rule that can never
+  fire. **Prefer a type union to `oneOf`**, which reports a failure in every branch. And
+  **`additionalProperties` stays true** for the report, because `schemaVersion` moves only when
+  a field changes meaning or disappears -- the exact field list is pinned in a test instead, so
+  widening is a decision rather than a side effect.
+
+  **A data file the tests read must be in `sandboxSubtrees`.** The mutation sandbox copies only
+  what that list names, so `schemas` is there beside `src` and `tests`. Leave it out and the
+  baseline goes red before a single mutant is tried, with an error naming a missing path rather
+  than the missing subtree -- which is a long way from the cause.
+
+  **`ConvertTo-Json` truncates past its depth SILENTLY**, leaving valid JSON with a .NET type
+  name where a value belongs. That shipped here once: every SARIF location read
+  `System.Collections.Specialized.OrderedDictionary`. `Save-PSCxDocument` now refuses to write a
+  document containing such a marker, because raising the depth fixes today's document and the
+  next nested field reintroduces it.
 
 - **An acceptance is a checkable claim, and there must never be a plain suppression beside
   it.** `-Accept` names one unit by file AND unit, carries a written argument, and the gate

--- a/PSComplexity.psm1
+++ b/PSComplexity.psm1
@@ -9,7 +9,7 @@
 # on the strength of it.
 
 $src = Join-Path $PSScriptRoot 'src'
-foreach ($file in @('Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1')) {
+foreach ($file in @('Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1')) {
     . (Join-Path $src $file)
 }
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ nested loop-in-loop-in-`if` grows fast — mirroring how hard it is to follow.
 
 | Command | Returns | Purpose |
 |---|---|---|
-| `Measure-PSComplexity -Path <files/dirs> [-Recurse] [-Detailed]` | per-unit records | inspect / report |
-| `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15] [-Accept <declarations>]` | `[bool]` | CI gate (warns per offender) |
+| `Measure-PSComplexity -Path <files/dirs> [-Recurse] [-Detailed] [-ReportPath <file>]` | per-unit records | inspect / report |
+| `Test-PSComplexity -Path <files/dirs> [-Recurse] [-MaxCyclomatic 15] [-MaxCognitive 15] [-Accept <declarations>] [-ReportPath <file>] [-SarifPath <file>]` | `[bool]` | CI gate (warns per offender) |
 
 ### The record is the API
 
@@ -210,6 +210,68 @@ Three properties worth relying on:
 
 `File` must match the record's `File` exactly: relative to the working directory with forward
 slashes, or the full path for a file outside it.
+
+### A report something else can read
+
+Objects are right for a shell and awkward for everything else. `-ReportPath` writes the same
+run as JSON, described by `schemas/v1/report.schema.json`, which ships with the module so a
+consumer can validate a report without reading this repo's tests.
+
+```powershell
+Measure-PSComplexity ./src -Recurse -ReportPath ./reports/complexity.json
+Test-PSComplexity   ./src -Recurse -ReportPath ./reports/gate.json -SarifPath ./reports/gate.sarif
+```
+
+The record stream is unchanged -- the report is written alongside it, never instead of it.
+
+**Two shapes, and the difference is load-bearing.** A measurement report carries the units, the
+scope that was asked for, the files that were skipped and why, a summary, and the metric version
+that produced the numbers. A gate report adds the ceilings that applied, the verdict, the units
+that breached, and every acceptance with its argument.
+
+A measurement report **cannot** carry a verdict, and the schema is what makes that true rather
+than a promise: `passed` is forbidden unless `thresholds` are present. `Measure-PSComplexity`
+applies no ceilings, so a verdict beside its numbers would be an answer nobody computed.
+
+Three fields are required for the same reason the summary exists at all:
+
+| Required | Because |
+|---|---|
+| `metricVersion` | the metric has moved twice for source that did not change; a stored number that cannot be checked for comparability is a trend chart waiting to mislead |
+| `scope` | an aggregate that cannot say what it covered is not an aggregate anyone can act on |
+| `skipped` | a report that omits what it could not read describes a smaller job than the one it was asked to do |
+
+`schemaVersion` changes when a field changes meaning or disappears, **never** when one is added
+-- so the schema permits properties it has never seen, and a consumer validating against it
+survives a release that records more.
+
+### Inline on a pull request
+
+`-SarifPath` writes a SARIF 2.1.0 log, which GitHub code scanning renders against the diff:
+
+```yaml
+- name: Complexity gate
+  shell: pwsh
+  run: |
+      $ok = Test-PSComplexity ./src -Recurse -SarifPath ./complexity.sarif
+      if (-not $ok) { Write-Host '::warning::complexity gate failed' }
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+      sarif_file: ./complexity.sarif
+```
+
+One result per breached ceiling, under two rule ids -- `PSCxCyclomatic` and `PSCxCognitive` --
+so a unit over both produces two, and a team can suppress one metric without silencing the
+other. Findings are fingerprinted on **file and unit, never on the line**: a line moves whenever
+anything above the unit is edited, and a fingerprint built on it would close and reopen the same
+finding on an unrelated change.
+
+**An accepted unit produces no SARIF result.** The gate excused it, and asking a reviewer to act
+on something already argued is noise. The argument is not lost -- the JSON report carries it
+under `accepted`, which is where "what did this run excuse" is answered.
+
+Only the gate writes SARIF. Without ceilings there is no such thing as a finding, so a SARIF file
+from `Measure-PSComplexity` would be an empty results array claiming a clean bill of health.
 
 ## Use it in CI
 

--- a/psmutant.self.config.json
+++ b/psmutant.self.config.json
@@ -1,21 +1,51 @@
 {
   "_comment": "PSComplexity self-assessment: PSMutant mutation-tests PSComplexity's own metric logic against its reference-score test suite. Complements the self-complexity gate (how complex is our code?) with a self-mutation gate (how good are our tests?). Run: Invoke-PSMutation -ConfigFile ./psmutant.self.config.json -SourceRoot .",
-  "sandboxSubtrees": ["src", "tests"],
+  "sandboxSubtrees": [
+    "src",
+    "tests",
+    "schemas"
+  ],
+  "_sandboxSubtrees_comment": "schemas is copied for the same reason src and tests are: tests/Report.Tests.ps1 reads schemas/v1/report.schema.json to validate what a real run wrote. Without it the sandboxed suite cannot find the file and the BASELINE goes red -- before a single mutant is tried, and with an error that names a missing path rather than the missing subtree.",
   "mutate": [
     "src/Ast.ps1",
     "src/Cognitive.ps1",
     "src/Cyclomatic.ps1",
-    "src/Measure-PSComplexity.ps1"
+    "src/Measure-PSComplexity.ps1",
+    "src/Report.ps1"
   ],
   "tests": {
-    "src/Ast.ps1": ["tests/Cognitive.Tests.ps1", "tests/Measure.Tests.ps1"],
-    "src/Cognitive.ps1": ["tests/Cognitive.Tests.ps1"],
-    "src/Cyclomatic.ps1": ["tests/Cyclomatic.Tests.ps1"],
-    "src/Measure-PSComplexity.ps1": ["tests/Measure.Tests.ps1"]
+    "src/Ast.ps1": [
+      "tests/Cognitive.Tests.ps1",
+      "tests/Measure.Tests.ps1"
+    ],
+    "src/Cognitive.ps1": [
+      "tests/Cognitive.Tests.ps1"
+    ],
+    "src/Cyclomatic.ps1": [
+      "tests/Cyclomatic.Tests.ps1"
+    ],
+    "src/Measure-PSComplexity.ps1": [
+      "tests/Measure.Tests.ps1"
+    ],
+    "src/Report.ps1": [
+      "tests/Report.Tests.ps1"
+    ]
   },
   "coveredLinesOnly": true,
   "_operators_comment": "The three opt-in operators PSMutant itself runs. Without them the gate sees only expressions, so structural logic -- a guard, an early return, a fencepost -- scores a vacuous 100%. StringLiteral stays off: high volume, low signal.",
-  "operators": ["BinaryOperator", "BooleanLiteral", "NumberLiteral", "NegationRemoval", "ConditionalBoundary", "ConditionForcing", "ReturnValue"],
-  "thresholds": { "high": 90, "low": 75, "break": 100 },
+  "operators": [
+    "BinaryOperator",
+    "BooleanLiteral",
+    "NumberLiteral",
+    "NegationRemoval",
+    "ConditionalBoundary",
+    "ConditionForcing",
+    "ReturnValue"
+  ],
+  "thresholds": {
+    "high": 90,
+    "low": 75,
+    "break": 100
+  },
   "reportPath": "reports/ps-mutation-self.json"
 }

--- a/schemas/v1/report.schema.json
+++ b/schemas/v1/report.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Fortigi/PSComplexity/main/schemas/v1/report.schema.json",
+  "title": "PSComplexity report",
+  "description": "The machine-readable form of one PSComplexity run. Two shapes: a measurement report, written by Measure-PSComplexity, and a gate report, written by Test-PSComplexity, which additionally carries the thresholds that applied and the verdict they produced. The version lives in this file's PATH rather than in the $id's git ref, so a v2 goes in schemas/v2/ beside this one and a document naming this URL keeps resolving to the format it was written against.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "generatedFrom",
+    "schemaVersion",
+    "producedBy",
+    "generatedAt",
+    "mode",
+    "metricVersion",
+    "scope",
+    "skipped",
+    "summary",
+    "units"
+  ],
+  "properties": {
+    "generatedFrom": {
+      "const": "PSComplexity",
+      "description": "What wrote this. A consumer pointed at a directory of reports can tell ours from anything else before it reads a number."
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Changes when a field changes meaning or disappears, NEVER when one is added. That is why additionalProperties is true here: a consumer validating against this survives a release that records more."
+    },
+    "producedBy": {
+      "type": "object",
+      "required": ["module", "version"],
+      "properties": {
+        "module": { "type": "string" },
+        "version": { "type": "string", "description": "The ModuleVersion that produced the report." }
+      }
+    },
+    "generatedAt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+      "description": "UTC, ISO-8601, second precision. A STRING in the file: PowerShell's ConvertFrom-Json recognises the format and hands a caller a [datetime] instead, so a PowerShell reader never sees this text and a validator handed a round-tripped object is checking something that no longer exists. Validate the FILE."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["Measure", "Gate"],
+      "description": "Which command wrote it. A measurement applied no thresholds and reached no verdict; see the conditional at the end of this schema, which makes a verdict unrepresentable in a measurement report."
+    },
+    "metricVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Which metric produced these numbers. REQUIRED, and that is the point: the metric has already moved twice for source that did not change, so a stored report whose numbers cannot be checked for comparability is a trend chart waiting to mislead. Anything comparing two reports must refuse to compare across two different values rather than mix them."
+    },
+    "scope": {
+      "type": "object",
+      "required": ["path", "recurse", "root"],
+      "description": "What was asked for. REQUIRED alongside the summary: an aggregate that cannot say what it covered is the failure this project exists to find in other people's code.",
+      "properties": {
+        "path": { "type": "array", "items": { "type": "string" } },
+        "recurse": { "type": "boolean" },
+        "root": { "type": "string", "description": "The working directory the File fields are relative to." }
+      }
+    },
+    "skipped": {
+      "type": "array",
+      "description": "Files that were asked for and not measured, with the reason. REQUIRED, and an empty array is the normal case -- absent and empty are different answers, and a consumer must not have to tell them apart to know whether everything was read.",
+      "items": {
+        "type": "object",
+        "required": ["file", "reason"],
+        "properties": {
+          "file": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["fileCount", "unitCount", "maxCyclomatic", "maxCognitive", "averageCyclomatic", "averageCognitive"],
+      "description": "Aggregates over `units`. Every one of them is reconcilable against that array; none of them is the only place a fact lives.",
+      "properties": {
+        "fileCount": { "type": "integer", "minimum": 0 },
+        "unitCount": { "type": "integer", "minimum": 0 },
+        "maxCyclomatic": { "type": "integer", "minimum": 0 },
+        "maxCognitive": { "type": "integer", "minimum": 0 },
+        "averageCyclomatic": { "type": "number", "minimum": 0 },
+        "averageCognitive": { "type": "number", "minimum": 0 }
+      }
+    },
+    "units": {
+      "type": "array",
+      "description": "Every unit measured. PascalCase field names, unlike this envelope, because these ARE the records Measure-PSComplexity emits -- one vocabulary for the object and its serialisation, so a consumer reading the JSON sees the field names the README documents.",
+      "items": { "$ref": "#/definitions/unit" }
+    },
+    "thresholds": {
+      "type": "object",
+      "required": ["cyclomatic", "cognitive"],
+      "description": "The ceilings that applied. Present only in a gate report.",
+      "properties": {
+        "cyclomatic": { "type": "integer", "minimum": 1 },
+        "cognitive": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "passed": {
+      "type": "boolean",
+      "description": "The verdict. Present only in a gate report, and forbidden elsewhere -- see the conditional below."
+    },
+    "violations": {
+      "type": "array",
+      "description": "Units over a ceiling that no acceptance covered. A subset of `units`, repeated rather than referenced so a consumer needs one pass.",
+      "items": { "$ref": "#/definitions/unit" }
+    },
+    "accepted": {
+      "type": "array",
+      "description": "Units allowed over a ceiling, each with the argument for it. A report that hides these would report a pass without saying what it excused.",
+      "items": {
+        "type": "object",
+        "required": ["file", "unit", "reason"],
+        "properties": {
+          "file": { "type": "string" },
+          "unit": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "unit": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["File", "Unit", "Line", "Cyclomatic", "Cognitive", "MetricVersion"],
+      "properties": {
+        "File": { "type": "string", "description": "Relative to scope.root with forward slashes; a full path for a file outside it." },
+        "Unit": { "type": "string", "description": "Class.Member, Outer/Inner, <script-body>, or a name with an ordinal when several share one scope." },
+        "Line": { "type": "integer", "minimum": 1, "description": "Where the unit starts. NOT an identity: it moves whenever anything above the unit is edited." },
+        "Cyclomatic": { "type": "integer", "minimum": 1 },
+        "Cognitive": { "type": "integer", "minimum": 0 },
+        "MetricVersion": { "type": "integer", "minimum": 1 },
+        "Contributions": {
+          "type": "array",
+          "description": "Present only when the run used -Detailed. The increments that produced Cognitive, in line order; the amounts sum to it.",
+          "items": {
+            "type": "object",
+            "required": ["Line", "Construct", "Amount"],
+            "properties": {
+              "Line": { "type": "integer", "minimum": 1 },
+              "Construct": { "type": "string" },
+              "Amount": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "description": "A measurement report reaches no verdict, and the format makes one impossible rather than merely undocumented. Measure-PSComplexity applies no thresholds, so a 'passed' beside its numbers is an answer nobody computed -- the same shape of lie as a partial score quoted as a real one. Written as boolean-false property schemas rather than as 'not': PowerShell's Test-Json silently IGNORES the 'not' keyword, so the obvious spelling of this rule is a clause that can never fail, which looks exactly like one that passes.",
+      "if": {
+        "required": ["thresholds"]
+      },
+      "then": {
+        "required": ["thresholds", "passed", "violations", "accepted"]
+      },
+      "else": {
+        "properties": {
+          "passed": false,
+          "violations": false,
+          "accepted": false
+        }
+      }
+    }
+  ]
+}

--- a/src/Measure-PSComplexity.ps1
+++ b/src/Measure-PSComplexity.ps1
@@ -290,6 +290,20 @@ function Measure-PSComplexity {
     .PARAMETER Recurse
         Recurse into subdirectories when a directory is given.
 
+    .PARAMETER ReportPath
+        Also write a machine-readable JSON report to this path, described by
+        schemas/v1/report.schema.json, which ships with the module.
+
+        The record stream is unchanged -- the report is written alongside it, not instead of it.
+        It carries the units, the scope that was asked for, the files that were skipped and why,
+        a summary, and the metric version that produced the numbers.
+
+        A report from this command reaches no verdict, because this command applies no
+        thresholds. The published schema makes that unrepresentable rather than merely
+        undocumented: a `passed` field is forbidden unless `thresholds` are present, so a
+        measurement report cannot carry an answer nobody computed. Use Test-PSComplexity when
+        the artefact needs a verdict.
+
     .PARAMETER Detailed
         Add a Contributions list to each record: one entry per cognitive increment, carrying
         the Line it sits on, the Construct that caused it and the Amount it added, in line
@@ -339,11 +353,12 @@ function Measure-PSComplexity {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline, Position = 0)] [ValidateNotNullOrEmpty()] [string[]]$Path,
-        [switch]$Recurse
-        ,
+        [switch]$Recurse,
+        [string]$ReportPath,
         # Off by default because the DEFAULT SHAPE IS A CONTRACT: CI consumers parse these
         # records, and a field that appears unbidden is a breaking change dressed as a feature.
-        [switch]$Detailed    )
+        [switch]$Detailed
+    )
     begin {
         # Resolved paths already emitted. Two inputs can name one file -- a directory and
         # something inside it, or a wildcard and a literal -- and measuring it twice put
@@ -351,8 +366,17 @@ function Measure-PSComplexity {
         # counts. In `begin` rather than `process` so it also spans pipeline input, where
         # each item arrives as its own invocation of the block below.
         $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        # Always collected, unguarded, because these are strings the caller already holds: the
+        # cost is nil, and a guard here would be a branch nothing could observe. The report has
+        # to say what the WHOLE run was asked for, and paths arrive one invocation at a time.
+        $asked = [System.Collections.Generic.List[string]]::new()
     }
     process {
+        $asked.AddRange([string[]]$Path)
+        # With a report, the whole run is emitted from `end` instead, out of a single scan.
+        # Accumulating per file here would need three guards that only save memory -- and a
+        # branch that changes no output cannot be told from its own absence by any test.
+        if ($ReportPath) { return }
         foreach ($fileScan in (Get-PSCxPathScan -Path $Path -Seen $seen -Recurse:$Recurse -Detailed:$Detailed)) {
             # The projection: units to the output stream, a skip to the error stream.
             #
@@ -366,6 +390,22 @@ function Measure-PSComplexity {
             }
             $fileScan.Units
         }
+    }
+    end {
+        if (-not $ReportPath) { return }
+        # One scan over everything the run was asked for, walking each file once exactly as the
+        # streaming path does. What it gives up is emitting as it goes, which is the price of a
+        # report that has to describe the whole run at once.
+        $scan = Get-PSCxScan -Path $asked.ToArray() -Recurse:$Recurse -Detailed:$Detailed
+        # The same projection the streaming path makes: units out, a skip to the error stream.
+        # Rendered here too, so -ReportPath does not quietly silence the one thing the command
+        # says when it could not read a file.
+        foreach ($skip in $scan.Skipped) {
+            Write-Error "Skipped '$($skip.File)' -- $($skip.Reason)"
+        }
+        $scan.Units
+        Save-PSCxDocument -Path $ReportPath -Document (Get-PSCxReportDocument -Scan $scan `
+                -ModuleVersion (Get-PSCxModuleVersion) -GeneratedAt (Get-Date))
     }
 }
 
@@ -468,6 +508,34 @@ function Test-PSComplexity {
     .PARAMETER Recurse
         Recurse into subdirectories when a directory is given.
 
+    .PARAMETER ReportPath
+        Also write a machine-readable JSON report to this path, described by
+        schemas/v1/report.schema.json, which ships with the module.
+
+        A gate report carries everything a measurement report does -- units, scope, skipped
+        files, summary, metric version -- plus the ceilings that applied, the verdict, the units
+        that breached, and every acceptance with its argument. That last part is deliberate: a
+        report that said "passed" without saying what it excused would be the mute button the
+        acceptance concept exists instead of.
+
+        Written only when a verdict is reached. The refusals above -- a file that did not parse,
+        nothing measured, an acceptance that no longer applies -- throw before a report exists,
+        because each means the run cannot vouch for anything worth recording.
+
+    .PARAMETER SarifPath
+        Also write a SARIF 2.1.0 log to this path, for code scanning to render inline on a pull
+        request. SARIF has its own published schema; this module writes it and validates nothing
+        of its own.
+
+        One result per breached ceiling, so a unit over both produces two, under two rule ids
+        (PSCxCyclomatic, PSCxCognitive) that can be suppressed independently. An accepted unit
+        produces no result at all: the gate excused it, and the argument for it lives in the JSON
+        report rather than being repeated as a finding nobody should act on.
+
+        Only the gate writes SARIF. Without ceilings there is no such thing as a finding, so a
+        SARIF file from Measure-PSComplexity would be an empty results array claiming a clean
+        bill of health.
+
     .PARAMETER Accept
         Units that are allowed to exceed a ceiling, each carrying the argument for why. One
         entry per unit, with File, Unit and Reason -- for example
@@ -495,6 +563,8 @@ function Test-PSComplexity {
         [int]$MaxCyclomatic = 15,
         [int]$MaxCognitive = 15,
         [switch]$Recurse,
+        [string]$ReportPath,
+        [string]$SarifPath,
         # Empty is the normal case, and an empty array must bind rather than be rejected.
         [AllowEmptyCollection()] [object[]]$Accept = @()
     )
@@ -552,6 +622,10 @@ function Test-PSComplexity {
             Write-Warning ("{0}:{1} {2} -- cyclomatic {3} (max {4}), cognitive {5} (max {6})" -f `
                     $v.File, $v.Line, $v.Unit, $v.Cyclomatic, $MaxCyclomatic, $v.Cognitive, $MaxCognitive)
         }
-        return $violations.Count -eq 0
+        $passed = $violations.Count -eq 0
+        Write-PSCxGateArtifact -Scan $scan -Passed $passed -Violation $violations -Accept $Accept `
+            -MaxCyclomatic $MaxCyclomatic -MaxCognitive $MaxCognitive `
+            -ReportPath $ReportPath -SarifPath $SarifPath
+        return $passed
     }
 }

--- a/src/Report.ps1
+++ b/src/Report.ps1
@@ -1,0 +1,315 @@
+# The machine-readable forms of a run, and the one place that writes a file.
+#
+# Two published formats leave this module: our own report, defined by
+# schemas/v1/report.schema.json and shipped beside the code, and SARIF 2.1.0, which has its own
+# published schema and needs none of ours. Both are built as pure documents and written by a
+# single function, so what a report SAYS can be tested without touching a disk.
+#
+# A report is not a new shape. It is the scan serialised -- Get-PSCxScan already answers what was
+# in scope, what was measured and what was skipped -- so nothing here decides anything the
+# measurement did not already know.
+
+$script:PSCxSchemaVersion = 1
+
+function Get-PSCxModuleVersion {
+    # What goes in the report's producedBy. Prefers the loaded module and falls back to the
+    # manifest beside src/, because the suite dot-sources these files without importing a module
+    # and a report written from there must still say which version shaped it.
+    #
+    # Returns the literal 'unknown' when it can find neither, rather than throwing or inventing
+    # something plausible. Three options, and the middle one is the trap:
+    #
+    #   throw     -- refuses to write the report at all, and "neither" is a REAL configuration:
+    #                a mutation sandbox copies src/ and tests/ and no manifest, and so does a
+    #                consumer who dot-sources src/ directly. This function threw, and it turned
+    #                the sandboxed baseline red before a single mutant ran.
+    #   '0.0.0'   -- worst of the three. It looks like an answer, so every report from every
+    #                such run claims to come from one release nobody published.
+    #   'unknown' -- cannot be mistaken for a version by a reader or by a comparison, and the
+    #                report still gets written.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param()
+    $loaded = @(Get-Module -Name PSComplexity)
+    if ($loaded.Count -gt 0) { return "$($loaded[0].Version)" }
+    $manifest = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'PSComplexity.psd1'
+    if (-not (Test-Path -LiteralPath $manifest)) { return 'unknown' }
+    return "$((Import-PowerShellDataFile -LiteralPath $manifest).ModuleVersion)"
+}
+
+function Get-PSCxReportSummary {
+    # The aggregates, over the units actually measured.
+    #
+    # Every one is reconcilable against the units array in the same document. None of them is the
+    # only place a fact lives, which is what lets a consumer disagree with a number rather than
+    # take it on trust.
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Unit)
+    # An empty scan is a real outcome -- a path that matched no PowerShell -- and
+    # Measure-PSComplexity does not refuse it the way the gate does. It needs no special case:
+    # Measure-Object over nothing yields $null, and both the [int] cast and [math]::Round turn
+    # that into 0, so every field below is already correct for an empty list.
+    #
+    # There WAS a special case here, an early return of six zeros. It was deleted because it is
+    # indistinguishable from its own absence, which is precisely what the mutation gate reported
+    # -- six mutants inside a branch whose removal changes no answer. The counts beside the
+    # maxima are what tell "zero complexity" from "nothing measured".
+    $cyc = @($Unit | ForEach-Object { $_.Cyclomatic })
+    $cog = @($Unit | ForEach-Object { $_.Cognitive })
+    return [ordered]@{
+        fileCount         = @($Unit | ForEach-Object { $_.File } | Sort-Object -Unique).Count
+        unitCount         = $Unit.Count
+        # Cast, because Measure-Object returns a double and ConvertTo-Json then writes 9.0
+        # where the schema and every reader expect 9. The averages stay real numbers.
+        maxCyclomatic     = [int]($cyc | Measure-Object -Maximum).Maximum
+        maxCognitive      = [int]($cog | Measure-Object -Maximum).Maximum
+        averageCyclomatic = [math]::Round(($cyc | Measure-Object -Average).Average, 2)
+        averageCognitive  = [math]::Round(($cog | Measure-Object -Average).Average, 2)
+    }
+}
+
+function Get-PSCxReportDocument {
+    # The report as a document. Pure: the version and the timestamp arrive as parameters rather
+    # than being read here, so the whole shape is testable without a clock or a manifest.
+    #
+    # -Gate is what separates the two published shapes. Absent, this is a measurement and the
+    # document carries no verdict -- and the schema FORBIDS one, because Measure-PSComplexity
+    # applies no thresholds and a `passed` beside its numbers would be an answer nobody computed.
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Scan,
+        [Parameter(Mandatory)] [string]$ModuleVersion,
+        [Parameter(Mandatory)] [datetime]$GeneratedAt,
+        $Gate
+    )
+    $mode = 'Measure'
+    if ($Gate) { $mode = 'Gate' }
+    $document = [ordered]@{
+        # Provenance first, so a reader opening the file sees what produced it before what it says.
+        generatedFrom = 'PSComplexity'
+        schemaVersion = $script:PSCxSchemaVersion
+        producedBy    = [ordered]@{ module = 'PSComplexity'; version = "$ModuleVersion" }
+        # Round-trippable and sortable as text, and UTC so reports from two machines compare
+        # without knowing where either ran.
+        generatedAt   = $GeneratedAt.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        mode          = $mode
+        # Required by the schema, and the reason is the whole point: the metric has already moved
+        # twice for source that did not change, so a stored number that cannot be checked for
+        # comparability is a trend chart waiting to mislead.
+        metricVersion = $Scan.MetricVersion
+        scope         = [ordered]@{
+            path    = @($Scan.Scope.Path)
+            recurse = [bool]$Scan.Scope.Recurse
+            # Forward slashes, like every File in the same document. A published format that
+            # spells one path two ways makes a consumer guess which one it is holding.
+            root    = ([string]$Scan.Scope.Root).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+        }
+        # Beside the summary, never instead of it: an aggregate that cannot say what it excluded
+        # is the failure this project exists to find in other people's code.
+        skipped       = @($Scan.Skipped | ForEach-Object { [ordered]@{ file = $_.File; reason = $_.Reason } })
+        summary       = Get-PSCxReportSummary -Unit @($Scan.Units)
+        units         = @($Scan.Units)
+    }
+    if ($Gate) {
+        $document['thresholds'] = [ordered]@{
+            cyclomatic = $Gate.MaxCyclomatic
+            cognitive  = $Gate.MaxCognitive
+        }
+        $document['passed'] = [bool]$Gate.Passed
+        $document['violations'] = @($Gate.Violations)
+        # What the run EXCUSED, with the argument for each. A gate report that reported a pass
+        # without saying what it excused would be the mute button the acceptance concept exists
+        # instead of.
+        $document['accepted'] = @($Gate.Accepted | ForEach-Object {
+                [ordered]@{ file = [string]$_.File; unit = [string]$_.Unit; reason = [string]$_.Reason }
+            })
+    }
+    return $document
+}
+
+function Get-PSCxSarifRule {
+    # One SARIF rule per metric, so a unit over both produces two results.
+    #
+    # Two rules rather than one: they render against the same line but suppress independently,
+    # and a team that has decided cyclomatic is not their problem should not have to silence
+    # cognitive to say so.
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param()
+    return @(
+        [ordered]@{
+            id               = 'PSCxCyclomatic'
+            name             = 'CyclomaticComplexity'
+            shortDescription = [ordered]@{ text = 'Cyclomatic complexity exceeds the configured ceiling.' }
+            fullDescription  = [ordered]@{ text = 'Cyclomatic complexity counts decision points: each if/elseif, switch clause, loop, catch, trap, ternary and each -and/-or. It is a count of paths, not of how hard the code is to follow.' }
+            helpUri          = 'https://github.com/Fortigi/PSComplexity#the-two-metrics'
+        }
+        [ordered]@{
+            id               = 'PSCxCognitive'
+            name             = 'CognitiveComplexity'
+            shortDescription = [ordered]@{ text = 'Cognitive complexity exceeds the configured ceiling.' }
+            fullDescription  = [ordered]@{ text = 'Cognitive complexity follows the SonarSource rules: structures score one each, and nesting adds its depth on top. It tracks how hard code is to follow rather than how many paths it has.' }
+            helpUri          = 'https://github.com/Fortigi/PSComplexity#the-two-metrics'
+        }
+    )
+}
+
+function Get-PSCxSarifResult {
+    # One result per breached ceiling for one unit: none, one, or two.
+    #
+    # Declares what a caller RECEIVES -- individual results, streamed -- rather than an array of
+    # them, which is a single return value this never produces.
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Unit,
+        [Parameter(Mandatory)] [int]$MaxCyclomatic,
+        [Parameter(Mandatory)] [int]$MaxCognitive
+    )
+    $breaches = @()
+    if ($Unit.Cyclomatic -gt $MaxCyclomatic) {
+        $breaches += , @('PSCxCyclomatic', 0, 'cyclomatic', $Unit.Cyclomatic, $MaxCyclomatic)
+    }
+    if ($Unit.Cognitive -gt $MaxCognitive) {
+        $breaches += , @('PSCxCognitive', 1, 'cognitive', $Unit.Cognitive, $MaxCognitive)
+    }
+    foreach ($b in $breaches) {
+        [ordered]@{
+            ruleId              = $b[0]
+            ruleIndex           = $b[1]
+            # error, not warning: this run failed a gate on it. A finding that renders as advice
+            # while the build goes red says two different things about one fact.
+            level               = 'error'
+            message             = [ordered]@{ text = "$($Unit.Unit) has $($b[2]) complexity $($b[3]), over the ceiling of $($b[4])." }
+            locations           = @(
+                [ordered]@{
+                    physicalLocation = [ordered]@{
+                        # Forward slashes and relative to the repo, which is what code scanning
+                        # matches against the checkout. Measure-PSComplexity already produces
+                        # File in exactly that form.
+                        artifactLocation = [ordered]@{ uri = $Unit.File }
+                        region           = [ordered]@{ startLine = $Unit.Line }
+                    }
+                }
+            )
+            # File and Unit, never Line. Line is explicitly not an identity in this project -- it
+            # moves whenever anything above the unit is edited -- and a fingerprint built on it
+            # would close and reopen the same finding on an unrelated edit above it.
+            partialFingerprints = [ordered]@{ psComplexityUnit = "$($Unit.File)|$($Unit.Unit)" }
+        }
+    }
+}
+
+function Get-PSCxSarifDocument {
+    # A SARIF 2.1.0 log for the units this run failed on.
+    #
+    # Written by the gate and not by measurement: without thresholds there is no such thing as a
+    # finding, and a SARIF file from a run that applied no ceilings would be an empty results
+    # array claiming a clean bill of health.
+    #
+    # An accepted unit produces no result. The gate excused it, and the argument is not lost --
+    # the JSON report carries it under `accepted`, which is where "what did this run excuse"
+    # is answered.
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Violation,
+        [Parameter(Mandatory)] [string]$ModuleVersion,
+        [Parameter(Mandatory)] [int]$MaxCyclomatic,
+        [Parameter(Mandatory)] [int]$MaxCognitive
+    )
+    $results = @(foreach ($u in $Violation) {
+            Get-PSCxSarifResult -Unit $u -MaxCyclomatic $MaxCyclomatic -MaxCognitive $MaxCognitive
+        })
+    return [ordered]@{
+        '$schema' = 'https://json.schemastore.org/sarif-2.1.0.json'
+        version   = '2.1.0'
+        runs      = @(
+            [ordered]@{
+                tool    = [ordered]@{
+                    driver = [ordered]@{
+                        name           = 'PSComplexity'
+                        version        = "$ModuleVersion"
+                        informationUri = 'https://github.com/Fortigi/PSComplexity'
+                        rules          = Get-PSCxSarifRule
+                    }
+                }
+                results = $results
+            }
+        )
+    }
+}
+
+function Write-PSCxGateArtifact {
+    # The gate's optional files, decided in one place so Test-PSComplexity stays a thin
+    # predicate: two more branches in its end block would push it toward the ceiling this
+    # module gates itself on, for wiring rather than for a decision.
+    #
+    # Both paths are optional and independent -- a team may want the SARIF for its pull requests
+    # and no JSON, or the JSON for a trend and no SARIF.
+    [OutputType([void])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Scan,
+        [Parameter(Mandatory)] [bool]$Passed,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Violation,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Accept,
+        [Parameter(Mandatory)] [int]$MaxCyclomatic,
+        [Parameter(Mandatory)] [int]$MaxCognitive,
+        [AllowEmptyString()] [string]$ReportPath,
+        [AllowEmptyString()] [string]$SarifPath
+    )
+    if ($ReportPath) {
+        $gate = [pscustomobject]@{
+            MaxCyclomatic = $MaxCyclomatic
+            MaxCognitive  = $MaxCognitive
+            Passed        = $Passed
+            Violations    = $Violation
+            Accepted      = $Accept
+        }
+        Save-PSCxDocument -Path $ReportPath -Document (Get-PSCxReportDocument -Scan $Scan `
+                -ModuleVersion (Get-PSCxModuleVersion) -GeneratedAt (Get-Date) -Gate $gate)
+    }
+    if ($SarifPath) {
+        Save-PSCxDocument -Path $SarifPath -Document (Get-PSCxSarifDocument -Violation $Violation `
+                -ModuleVersion (Get-PSCxModuleVersion) -MaxCyclomatic $MaxCyclomatic -MaxCognitive $MaxCognitive)
+    }
+}
+
+function Save-PSCxDocument {
+    # The only function here that touches a disk, so everything above stays testable without one.
+    [OutputType([void])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Document,
+        [Parameter(Mandatory)] [string]$Path
+    )
+    $parent = Split-Path -Parent $Path
+    # A report path pointing into a directory that does not exist yet is an ordinary thing to
+    # ask for -- reports/ on a fresh clone, or an artifacts directory a CI step has not made.
+    if ($parent) { [System.IO.Directory]::CreateDirectory($parent) | Out-Null }
+    # Deep enough for SARIF, which is the deeper of the two formats by a long way: a result
+    # reaches root > runs > run > results > result > locations > location > physicalLocation >
+    # artifactLocation > uri, nine levels down. Our own report needs six.
+    #
+    # ConvertTo-Json truncates past its depth SILENTLY, replacing the tail with the .NET type
+    # name -- so the file stays valid JSON and stops matching its schema, which is the shape of
+    # bug this module exists to find. Depth 6 shipped exactly that here: every SARIF location
+    # was the string "System.Collections.Specialized.OrderedDictionary".
+    # WarningAction, because PowerShell's own truncation warning is redundant beside the
+    # throw below and far less actionable -- it names a depth, not the file it ruined.
+    $json = $Document | ConvertTo-Json -Depth 12 -WarningAction SilentlyContinue
+    # Asserted rather than trusted, because raising the depth fixes today's document and the
+    # next nested field silently reintroduces it. A type name where a value belongs is never
+    # something this module means to write.
+    foreach ($marker in 'System.Collections.Specialized.OrderedDictionary', 'System.Object[]', 'System.Collections.Hashtable') {
+        if ($json.Contains($marker)) {
+            throw "Refusing to write $Path : ConvertTo-Json truncated the document and left '$marker' where a value belongs. Raise the depth in Save-PSCxDocument."
+        }
+    }
+    # ErrorAction Stop because Set-Content fails non-terminatingly by default: an unwritable
+    # path would otherwise leave the run green and the artefact absent.
+    $json | Set-Content -LiteralPath $Path -Encoding utf8 -ErrorAction Stop
+}

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -81,7 +81,7 @@ function Get-Fib { param($n) if ($n -le 1) { return $n }; return (Get-Fib ($n - 
 
 BeforeAll {
     $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
-    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $src $f) }
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1') { . (Join-Path $src $f) }
     function script:Get-CognitiveOf {
         param([string]$Code)
         $file = Join-Path ([System.IO.Path]::GetTempPath()) "cxcog-$([System.Guid]::NewGuid().ToString('N')).ps1"

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -43,7 +43,7 @@ $script:CyclomaticCases = @(
 
 BeforeAll {
     $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
-    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $src $f) }
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1') { . (Join-Path $src $f) }
     function script:Get-CyclomaticOf {
         param([string]$Code)
         $file = Join-Path ([System.IO.Path]::GetTempPath()) "cxcyc-$([System.Guid]::NewGuid().ToString('N')).ps1"

--- a/tests/Measure.Tests.ps1
+++ b/tests/Measure.Tests.ps1
@@ -3,7 +3,7 @@
 
 BeforeAll {
     $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
-    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $src $f) }
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1') { . (Join-Path $src $f) }
 
     $script:work = Join-Path ([System.IO.Path]::GetTempPath()) "cxmeasure-$([System.Guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Path (Join-Path $script:work 'nested') -Force | Out-Null
@@ -1120,5 +1120,62 @@ function Invoke-Hot {
                 -WarningAction SilentlyContinue | Should-BeFalse
         }
         finally { Remove-Item $other -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'a run can be written down' {
+    # The wiring lives in Measure-PSComplexity.ps1, so it is tested HERE: the mutation config
+    # maps that file to this suite, and the same assertions written in Report.Tests.ps1 cover
+    # the code without being able to kill a single one of its mutants.
+    #
+    # What the report SAYS is Report.Tests.ps1's business. This is only about the switch.
+
+    BeforeAll {
+        $script:rpDir = Join-Path ([System.IO.Path]::GetTempPath()) "cxrp-$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:rpDir -Force | Out-Null
+        Set-Content (Join-Path $script:rpDir 'one.ps1') 'function Get-One { param($x) if ($x) { 1 } }' -Encoding utf8
+    }
+
+    AfterAll { Remove-Item $script:rpDir -Recurse -Force -ErrorAction SilentlyContinue }
+
+    It 'writes a report where it was asked to' {
+        $p = Join-Path $script:rpDir 'r.json'
+        Measure-PSComplexity -Path (Join-Path $script:rpDir 'one.ps1') -ReportPath $p | Out-Null
+        Should-BeTrue -Actual (Test-Path -LiteralPath $p)
+    }
+
+    It 'writes nothing when no report was asked for' {
+        # The paired half. Without it the test above passes against a command that writes a
+        # report unbidden, which would litter every consumer's working tree.
+        $before = @(Get-ChildItem $script:rpDir -File -Filter *.json).Count
+        Measure-PSComplexity -Path (Join-Path $script:rpDir 'one.ps1') | Out-Null
+        @(Get-ChildItem $script:rpDir -File -Filter *.json).Count | Should-Be $before
+    }
+
+    It 'emits each unit exactly once while also writing a report' {
+        # With -ReportPath the whole run is emitted from `end`, out of one scan, and the
+        # per-item streaming path returns early. Drop that early return and every unit is
+        # emitted TWICE -- once streamed, once from the scan -- which reads as a doubled
+        # codebase to anything counting, and no assertion on the report file would show it.
+        $p = Join-Path $script:rpDir 'r2.json'
+        $units = @(Measure-PSComplexity -Path (Join-Path $script:rpDir 'one.ps1') -ReportPath $p)
+        @($units | Where-Object Unit -eq 'Get-One').Count | Should-Be 1
+        $units.Count | Should-Be 2
+    }
+
+    It 'still reports a file it could not read while writing a report' {
+        # The error stream is the same projection either way. A report must not quietly buy
+        # silence about a file the run could not measure.
+        $bad = Join-Path $script:rpDir 'broken'
+        New-Item -ItemType Directory -Path $bad -Force | Out-Null
+        Set-Content (Join-Path $bad 'bad.ps1') 'function Oops { param(' -Encoding utf8
+        try {
+            $ev = $null
+            Measure-PSComplexity -Path $bad -ReportPath (Join-Path $script:rpDir 'r3.json') `
+                -ErrorVariable ev -ErrorAction SilentlyContinue | Out-Null
+            @($ev).Count | Should-Be 1
+            ($ev[0].Exception.Message) | Should-BeLikeString '*parse error*'
+        }
+        finally { Remove-Item $bad -Recurse -Force -ErrorAction SilentlyContinue }
     }
 }

--- a/tests/Report.Tests.ps1
+++ b/tests/Report.Tests.ps1
@@ -1,0 +1,477 @@
+# The two published formats: our own report, defined by schemas/v1/report.schema.json, and
+# SARIF 2.1.0. Both leave the process, so both are contracts.
+#
+# The schema is validated against reports a REAL run just wrote, not against hand-built
+# documents. A schema that has drifted from the writer is worse than none: it invites a consumer
+# to code against a shape they will not receive.
+
+BeforeAll {
+    $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1') {
+        . (Join-Path $src $f)
+    }
+
+    $script:repo = Split-Path -Parent $PSScriptRoot
+    $script:schemaText = Get-Content (Join-Path $script:repo 'schemas/v1/report.schema.json') -Raw
+
+    $script:work = Join-Path ([System.IO.Path]::GetTempPath()) "cxreport-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $script:work -Force | Out-Null
+    # One unit over both ceilings, one clean, one file that will not parse. All three matter:
+    # the report has to carry units, a verdict and a skip, and a fixture missing any of them
+    # leaves that part of the document untested.
+    Set-Content (Join-Path $script:work 'hot.ps1') @'
+function Invoke-Hot {
+    param($a, $b, $c)
+    if ($a) { if ($b) { if ($c) { 1 } } }
+}
+function Get-Cool { param($x) $x }
+'@ -Encoding utf8
+
+    $script:out = Join-Path $script:work 'out'
+    New-Item -ItemType Directory -Path $script:out -Force | Out-Null
+
+    # Written once by real runs, then asserted against. Both shapes, because they travel
+    # different call paths and a field wired into one writer and not the other is invisible
+    # until somebody opens the file.
+    $script:measurePath = Join-Path $script:out 'measure.json'
+    Measure-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -ReportPath $script:measurePath | Out-Null
+
+    $script:gatePath = Join-Path $script:out 'gate.json'
+    $script:sarifPath = Join-Path $script:out 'gate.sarif'
+    Test-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -MaxCyclomatic 1 -MaxCognitive 1 `
+        -ReportPath $script:gatePath -SarifPath $script:sarifPath -WarningAction SilentlyContinue | Out-Null
+
+    # Read as TEXT. ConvertFrom-Json recognises the ISO-8601 generatedAt and hands back a
+    # [datetime], so a round-tripped object no longer holds the string the schema describes.
+    # The file is the contract.
+    $script:measureText = [System.IO.File]::ReadAllText($script:measurePath)
+    $script:gateText = [System.IO.File]::ReadAllText($script:gatePath)
+
+    function Test-AgainstSchema {
+        param([string]$Json)
+        try { Test-Json -Json $Json -Schema $script:schemaText -ErrorAction Stop | Out-Null; return $true }
+        catch { return $false }
+    }
+
+    function Get-NestedDocument {
+        # A document nested exactly $Levels deep, for the two depth assertions below.
+        #
+        # Get-, not New-, although it builds something: New- is a state-changing verb, so
+        # PSUseShouldProcessForStateChangingFunctions asks for -WhatIf support a test helper has
+        # no use for. Same reason Get-PSCxUnitRecord is spelled that way.
+        param([int]$Levels)
+        $root = [ordered]@{ a = $null }
+        $node = $root
+        foreach ($i in 1..$Levels) {
+            $child = [ordered]@{ a = $null }
+            $node['a'] = $child
+            $node = $child
+        }
+        return $root
+    }
+}
+
+AfterAll { Remove-Item $script:work -Recurse -Force -ErrorAction SilentlyContinue }
+
+Describe 'the published report schema' {
+
+    It 'accepts the measurement report a real run just wrote' {
+        Should-BeTrue -Actual (Test-AgainstSchema -Json $script:measureText)
+    }
+
+    It 'accepts the gate report a real run just wrote' {
+        Should-BeTrue -Actual (Test-AgainstSchema -Json $script:gateText)
+    }
+
+    It 'refuses a measurement report that carries a verdict' {
+        # The safety property, and the reason this schema is worth shipping rather than merely
+        # writing down. Measure-PSComplexity applies no thresholds, so a `passed` beside its
+        # numbers is an answer nobody computed. Making it unrepresentable beats a caveat.
+        #
+        # Written as a boolean-false property schema, because Test-Json silently IGNORES `not`
+        # -- the obvious spelling of this rule is a clause that can never fire, which looks
+        # exactly like one that passes.
+        $tampered = $script:measureText -replace '("mode"\s*:\s*"Measure")', '$1, "passed": true'
+        # Asserted first: a -replace that matched nothing leaves the document untouched, and
+        # this test would then pass while proving nothing about the schema.
+        $tampered | Should-NotBe $script:measureText
+        Should-BeFalse -Actual (Test-AgainstSchema -Json $tampered)
+    }
+
+    It 'refuses a report with no metricVersion' {
+        # Required on purpose. The metric has moved twice for source that did not change, so a
+        # stored number that cannot be checked for comparability is a trend chart waiting to
+        # mislead.
+        $stripped = $script:measureText -replace '"metricVersion"\s*:\s*[0-9]+,', ''
+        $stripped | Should-NotBe $script:measureText
+        Should-BeFalse -Actual (Test-AgainstSchema -Json $stripped)
+    }
+
+    It 'refuses a report whose summary cannot say what it excluded' {
+        # scope and skipped are required BESIDE the summary. An aggregate that cannot say what
+        # it covered is the failure this project exists to find in other people's code.
+        $stripped = $script:measureText -replace '"skipped"\s*:\s*\[[^\]]*\],', ''
+        $stripped | Should-NotBe $script:measureText
+        Should-BeFalse -Actual (Test-AgainstSchema -Json $stripped)
+    }
+
+    It 'still accepts a report carrying a field it has never seen' {
+        # The additive promise, in the other direction: schemaVersion changes when a field
+        # changes meaning or disappears, NEVER when one is added. So the schema must permit
+        # extra properties, or every consumer validating against it breaks on the next release
+        # that records one more thing.
+        $widened = $script:measureText -replace '("generatedFrom"\s*:\s*"PSComplexity")', '$1, "somethingAddedLater": 42'
+        $widened | Should-NotBe $script:measureText
+        Should-BeTrue -Actual (Test-AgainstSchema -Json $widened)
+    }
+
+    It 'ships the schema the module validates against' {
+        # A schema left behind in the repo is no use to the consumer it exists for, and that
+        # failure is invisible from inside the repo. The package smoke test asserts it travels;
+        # this asserts it is here and parses.
+        $path = Join-Path $script:repo 'schemas/v1/report.schema.json'
+        Should-BeTrue -Actual (Test-Path -LiteralPath $path)
+        # Parsed and identified, not merely present. There is no Should-NotThrow in Pester 6
+        # and that is deliberate -- an unhandled exception fails the test on its own, so the
+        # assertion worth making is about what the document IS.
+        ($script:schemaText | ConvertFrom-Json).title | Should-Be 'PSComplexity report'
+    }
+}
+
+Describe 'what a report says' {
+
+    It 'stamps the schema version the shipped schema describes' {
+        # Nothing else pins this. A consumer branches on it, so a bump nobody meant is a silent
+        # promise that a field changed meaning.
+        $d = Get-Content $script:measurePath -Raw | ConvertFrom-Json
+        $d.schemaVersion | Should-Be 1
+    }
+
+    It 'says which command produced it' {
+        # mode is what a consumer reads to know whether a verdict was even possible. The
+        # conditional in the schema keys on `thresholds`, so a wrong mode still validates --
+        # only an assertion catches it.
+        (Get-Content $script:measurePath -Raw | ConvertFrom-Json).mode | Should-Be 'Measure'
+        (Get-Content $script:gatePath -Raw | ConvertFrom-Json).mode | Should-Be 'Gate'
+    }
+
+    It 'rounds an average to two decimals, not to one and not to none' {
+        # Needs a fixture whose average does NOT divide evenly, or every precision agrees and
+        # the assertion passes whatever the code does. Three units scoring 0, 1 and 2 average
+        # 1, which proves nothing; these four average 1.75, where two decimals, one decimal and
+        # a whole number are three different published answers.
+        # THREE units, and totals not divisible by three, so both averages are 2.333... A
+        # fixture averaging 1.75 is no good: it is exact at two decimals, so rounding to three
+        # gives the same answer and the assertion passes against either. The denominator has to
+        # be a number that does not divide the total.
+        $p = Join-Path $script:work 'round.ps1'
+        Set-Content $p @'
+function Get-R1 { param($a) if ($a) { 1 } }
+function Get-R2 { param($a, $b, $c) if ($a) { if ($b) { if ($c) { 1 } } } }
+'@ -Encoding utf8
+        $out = Join-Path $script:out 'round.json'
+        Measure-PSComplexity -Path $p -ReportPath $out | Out-Null
+        $d = Get-Content $out -Raw | ConvertFrom-Json
+        # Both averages, because they are two separate roundings and a change to one is
+        # invisible in the other.
+        foreach ($metric in 'Cyclomatic', 'Cognitive') {
+            $values = @($d.units | ForEach-Object { $_.$metric })
+            $exact = ($values | Measure-Object -Average).Average
+            # The fixture has to discriminate, asserted out loud rather than hoped for: an
+            # average that terminates at two decimals rounds identically at three, and the
+            # test then passes whatever precision the code uses.
+            [math]::Round($exact, 2) | Should-NotBe ([math]::Round($exact, 3))
+            $d.summary."average$metric" | Should-Be ([math]::Round($exact, 2))
+        }
+    }
+
+    It 'names the exact top-level fields of a measurement report' {
+        # The schema states the guaranteed MINIMUM and permits more. This pins the actual list,
+        # so widening it stays a decision rather than a side effect of an internal rename. Two
+        # assertions, two different claims.
+        $d = Get-Content $script:measurePath -Raw | ConvertFrom-Json
+        ($d.PSObject.Properties.Name -join ',') |
+            Should-Be 'generatedFrom,schemaVersion,producedBy,generatedAt,mode,metricVersion,scope,skipped,summary,units'
+    }
+
+    It 'adds exactly the gate fields to a gate report' {
+        $d = Get-Content $script:gatePath -Raw | ConvertFrom-Json
+        ($d.PSObject.Properties.Name -join ',') |
+            Should-Be 'generatedFrom,schemaVersion,producedBy,generatedAt,mode,metricVersion,scope,skipped,summary,units,thresholds,passed,violations,accepted'
+    }
+
+    It 'reconciles its summary against the units it carries' {
+        # Every aggregate is checkable against the array in the same document. A summary that is
+        # the only place a fact lives has to be taken on trust, which is the opposite of what
+        # this report is for.
+        $d = Get-Content $script:measurePath -Raw | ConvertFrom-Json
+        $d.summary.unitCount | Should-Be $d.units.Count
+        $d.summary.maxCyclomatic | Should-Be (@($d.units | ForEach-Object { $_.Cyclomatic }) | Measure-Object -Maximum).Maximum
+        $d.summary.maxCognitive | Should-Be (@($d.units | ForEach-Object { $_.Cognitive }) | Measure-Object -Maximum).Maximum
+    }
+
+    It 'records a skipped file with its reason' {
+        # A report that omits what it could not read describes a smaller job than the one it was
+        # asked to do, and nothing in the numbers says so.
+        $broken = Join-Path $script:work 'broken'
+        New-Item -ItemType Directory -Path $broken -Force | Out-Null
+        Set-Content (Join-Path $broken 'bad.ps1') 'function Oops { param(' -Encoding utf8
+        Set-Content (Join-Path $broken 'fine.ps1') 'function Get-Fine { 1 }' -Encoding utf8
+        $p = Join-Path $script:out 'skip.json'
+        Measure-PSComplexity -Path $broken -ReportPath $p -ErrorAction SilentlyContinue | Out-Null
+        $d = Get-Content $p -Raw | ConvertFrom-Json
+        # Both halves: one file skipped AND one measured, so this cannot pass against a run that
+        # skipped everything or recorded nothing.
+        $d.skipped.Count | Should-Be 1
+        $d.skipped[0].reason | Should-BeLikeString '*parse error*'
+        @($d.units | Where-Object Unit -eq 'Get-Fine').Count | Should-Be 1
+    }
+
+    It 'records what the run was asked for, not only what it found' {
+        $d = Get-Content $script:measurePath -Raw | ConvertFrom-Json
+        $d.scope.path.Count | Should-Be 1
+        $d.scope.recurse | Should-BeFalse
+    }
+
+    It 'carries every acceptance with its argument' {
+        # A gate report that said "passed" without saying what it excused would be the mute
+        # button the acceptance concept exists instead of.
+        $p = Join-Path $script:out 'accepted.json'
+        $hot = Measure-PSComplexity -Path (Join-Path $script:work 'hot.ps1') | Where-Object Unit -eq 'Invoke-Hot'
+        $ok = @(@{ File = $hot.File; Unit = 'Invoke-Hot'; Reason = 'a deliberately nested fixture' })
+        Test-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -MaxCyclomatic 1 -MaxCognitive 1 `
+            -Accept $ok -ReportPath $p -WarningAction SilentlyContinue | Out-Null
+        $d = Get-Content $p -Raw | ConvertFrom-Json
+        $d.passed | Should-BeTrue
+        $d.accepted.Count | Should-Be 1
+        $d.accepted[0].reason | Should-Be 'a deliberately nested fixture'
+        # And the excused unit is NOT reported as a violation, which is the pair to the above.
+        $d.violations.Count | Should-Be 0
+    }
+
+    It 'reports zero rather than nothing when it measured no units' {
+        # A path that matched no PowerShell is a real outcome for Measure-PSComplexity, which
+        # does not refuse it the way the gate does. Measure-Object over an empty set yields
+        # $null, and a null maximum in the file reads as "zero complexity" rather than as
+        # "nothing measured" -- the counts beside it are what tell those apart.
+        $empty = Join-Path $script:work 'nosource'
+        New-Item -ItemType Directory -Path $empty -Force | Out-Null
+        Set-Content (Join-Path $empty 'notes.txt') 'not powershell' -Encoding utf8
+        $p = Join-Path $script:out 'empty.json'
+        Measure-PSComplexity -Path $empty -ReportPath $p | Out-Null
+        $d = Get-Content $p -Raw | ConvertFrom-Json
+        $d.summary.unitCount | Should-Be 0
+        $d.summary.maxCognitive | Should-Be 0
+        Should-BeTrue -Actual (Test-AgainstSchema -Json ([System.IO.File]::ReadAllText($p)))
+    }
+
+    It 'writes no report when none was asked for' {
+        # The switch has to be the only thing that creates a file. A command that writes an
+        # artefact unbidden litters every consumer's working tree.
+        $before = @(Get-ChildItem $script:out -File).Count
+        Measure-PSComplexity -Path (Join-Path $script:work 'hot.ps1') | Out-Null
+        @(Get-ChildItem $script:out -File).Count | Should-Be $before
+    }
+}
+
+Describe 'the SARIF log' {
+
+    BeforeAll {
+        $script:sarif = Get-Content $script:sarifPath -Raw | ConvertFrom-Json
+    }
+
+    It 'is a SARIF 2.1.0 log naming this tool' {
+        $script:sarif.version | Should-Be '2.1.0'
+        $script:sarif.runs[0].tool.driver.name | Should-Be 'PSComplexity'
+    }
+
+    It 'declares one rule per metric so they suppress independently' {
+        # A single rule would mean silencing cyclomatic silences cognitive, which is not a
+        # decision anyone asked to make.
+        (@($script:sarif.runs[0].tool.driver.rules | ForEach-Object { $_.id }) -join ',') |
+            Should-Be 'PSCxCyclomatic,PSCxCognitive'
+    }
+
+    It 'raises one result per breached ceiling, so a unit over both appears twice' {
+        # Invoke-Hot is over both ceilings at 1/1. One result would render against one metric
+        # and silently drop the other.
+        @($script:sarif.runs[0].results | Where-Object {
+                $_.partialFingerprints.psComplexityUnit -like '*Invoke-Hot'
+            }).Count | Should-Be 2
+    }
+
+    It 'raises nothing for a unit that is within its ceilings' {
+        # The kept half. Without it, the count above passes just as well against a log that
+        # reports every unit it measured.
+        @($script:sarif.runs[0].results | Where-Object {
+                $_.partialFingerprints.psComplexityUnit -like '*Get-Cool'
+            }).Count | Should-Be 0
+    }
+
+    It 'raises nothing for an accepted unit' {
+        # The gate excused it, and repeating it as a finding asks a reviewer to act on something
+        # already argued. The argument is not lost: the JSON report carries it under `accepted`.
+        $p = Join-Path $script:out 'accepted.sarif'
+        $hot = Measure-PSComplexity -Path (Join-Path $script:work 'hot.ps1') | Where-Object Unit -eq 'Invoke-Hot'
+        $ok = @(@{ File = $hot.File; Unit = 'Invoke-Hot'; Reason = 'r' })
+        Test-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -MaxCyclomatic 1 -MaxCognitive 1 `
+            -Accept $ok -SarifPath $p -WarningAction SilentlyContinue | Out-Null
+        (Get-Content $p -Raw | ConvertFrom-Json).runs[0].results.Count | Should-Be 0
+    }
+
+    It 'keeps every result pointing at the rule it names' {
+        # ruleIndex is an offset into the rules array, and ruleId is the name. They are built
+        # from one tuple, so a shifted index or a swapped field makes them disagree -- which a
+        # reader would never notice and a SARIF consumer resolves to the wrong rule.
+        $rules = @($script:sarif.runs[0].tool.driver.rules)
+        foreach ($r in @($script:sarif.runs[0].results)) {
+            $rules[$r.ruleIndex].id | Should-Be $r.ruleId
+        }
+    }
+
+    It 'says which metric, which value and which ceiling' {
+        # The message is what a reviewer reads on the diff. Built from the same tuple as the
+        # rule, so an index off by one silently reports the wrong number or the wrong metric
+        # while still rendering a plausible sentence.
+        $r = @($script:sarif.runs[0].results |
+                Where-Object { $_.ruleId -eq 'PSCxCognitive' -and $_.partialFingerprints.psComplexityUnit -like '*Invoke-Hot' })[0]
+        $r.message.text | Should-Be 'Invoke-Hot has cognitive complexity 6, over the ceiling of 1.'
+    }
+
+    It 'raises nothing for a metric sitting exactly ON its ceiling' {
+        # At or under is within. Invoke-Hot is cyclomatic 4 and cognitive 6; ceilings 4/1 put it
+        # over on one metric and exactly ON the other, so the unit IS a violation and only the
+        # cognitive result belongs. Read as at-or-over, an extra cyclomatic finding appears for a
+        # unit that is inside that ceiling -- and every earlier fixture had it over both, where
+        # the two readings agree.
+        $p = Join-Path $script:out 'boundary.sarif'
+        Test-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -MaxCyclomatic 4 -MaxCognitive 1 `
+            -SarifPath $p -WarningAction SilentlyContinue | Out-Null
+        $r = @((Get-Content $p -Raw | ConvertFrom-Json).runs[0].results |
+                Where-Object { $_.partialFingerprints.psComplexityUnit -like '*Invoke-Hot' })
+        $r.Count | Should-Be 1
+        $r[0].ruleId | Should-Be 'PSCxCognitive'
+    }
+
+    It 'raises nothing for a COGNITIVE metric sitting exactly on its ceiling' {
+        # The mirror of the case above, and needed separately: the two ceilings are two
+        # comparisons, and a fixture that only ever lands on one boundary leaves the other
+        # reading at-or-over with nothing to notice. Invoke-Hot is cyclomatic 4, cognitive 6;
+        # ceilings 1/6 put it over on cyclomatic and exactly ON cognitive.
+        $p = Join-Path $script:out 'boundary-cog.sarif'
+        Test-PSComplexity -Path (Join-Path $script:work 'hot.ps1') -MaxCyclomatic 1 -MaxCognitive 6 `
+            -SarifPath $p -WarningAction SilentlyContinue | Out-Null
+        $r = @((Get-Content $p -Raw | ConvertFrom-Json).runs[0].results |
+                Where-Object { $_.partialFingerprints.psComplexityUnit -like '*Invoke-Hot' })
+        $r.Count | Should-Be 1
+        $r[0].ruleId | Should-Be 'PSCxCyclomatic'
+    }
+
+    It 'points at a file and a line code scanning can resolve' {
+        $r = @($script:sarif.runs[0].results)[0]
+        $r.locations[0].physicalLocation.artifactLocation.uri | Should-BeLikeString '*hot.ps1'
+        $r.locations[0].physicalLocation.artifactLocation.uri | Should-NotBeLikeString '*\*'
+        $r.locations[0].physicalLocation.region.startLine | Should-BeGreaterThan 0
+    }
+
+    It 'fingerprints a finding on identity, never on the line it sits at' {
+        # Line moves whenever anything above the unit is edited. A fingerprint built on it would
+        # close and reopen the same finding on an unrelated edit above -- which is exactly the
+        # noise partialFingerprints exists to prevent.
+        # Asserted as an EXACT composition rather than as "does not contain the line number":
+        # the file path is a temp directory full of digits, so a wildcard for the line matches
+        # by accident and the test passes whatever the fingerprint is built from.
+        $r = @($script:sarif.runs[0].results |
+                Where-Object { $_.partialFingerprints.psComplexityUnit -like '*Invoke-Hot' })[0]
+        $r.partialFingerprints.psComplexityUnit |
+            Should-Be "$($r.locations[0].physicalLocation.artifactLocation.uri)|Invoke-Hot"
+    }
+
+    It 'reports at error level, matching the build it just failed' {
+        # A finding that renders as advice while the gate goes red says two different things
+        # about one fact.
+        (@($script:sarif.runs[0].results | ForEach-Object { $_.level } | Sort-Object -Unique) -join ',') |
+            Should-Be 'error'
+    }
+}
+
+Describe 'the version a report claims it came from' {
+
+    It 'takes the version from the loaded module when there is one' {
+        # The normal path for a consumer, and the one the suite never exercises on its own:
+        # these tests dot-source src/ rather than importing a module, so without a mock this
+        # branch is unreachable from here and ships unmeasured.
+        Mock Get-Module { [pscustomobject]@{ Version = '9.9.9' } }
+        Get-PSCxModuleVersion | Should-Be '9.9.9'
+    }
+
+    It 'falls back to the manifest beside src when nothing is loaded' {
+        # Mocked rather than reading the real manifest, because a covering suite has to be
+        # SELF-CONTAINED: the mutation sandbox copies src/, tests/ and schemas/ and no manifest,
+        # so a test that reaches the repo root fails there while passing everywhere else.
+        # It did, and it turned the baseline red.
+        Mock Get-Module { @() }
+        Mock Test-Path { $true }
+        Mock Import-PowerShellDataFile { @{ ModuleVersion = '1.2.3' } }
+        Get-PSCxModuleVersion | Should-Be '1.2.3'
+    }
+
+    It 'says unknown rather than inventing a plausible version' {
+        # Neither an installed module nor a manifest is a REAL configuration, not a broken one:
+        # a mutation sandbox copies src/ and tests/ and no manifest, and so does a consumer who
+        # dot-sources src/ directly. An earlier version threw here, which turned the sandboxed
+        # baseline red before a mutant ran.
+        #
+        # 'unknown' rather than '0.0.0' because a plausible-looking version is the worse
+        # failure: it sits in a stored artefact claiming every such run came from one release.
+        Mock Get-Module { @() }
+        # A default mock as well as the filtered one: Pester 6 removed fall-through, so a call
+        # matching no filter throws rather than reaching the real command.
+        Mock Test-Path { $true }
+        Mock Test-Path { $false } -ParameterFilter { "$LiteralPath" -like '*PSComplexity.psd1' }
+        Get-PSCxModuleVersion | Should-Be 'unknown'
+    }
+}
+
+Describe 'writing a document' {
+
+    It 'creates the directory a report is asked for' {
+        # reports/ on a fresh clone, or an artifacts directory a CI step has not made yet.
+        $deep = Join-Path $script:out 'a/b/c/report.json'
+        Save-PSCxDocument -Path $deep -Document ([ordered]@{ x = 1 })
+        Should-BeTrue -Actual (Test-Path -LiteralPath $deep)
+    }
+
+    It 'writes a report named without any directory at all' {
+        # A bare filename has no parent, and asking for the parent yields an empty string.
+        # Creating a directory from that throws, so the guard has to be a real test rather than
+        # a formality -- and every other test here passes a full path, where it never fires.
+        Push-Location $script:out
+        try {
+            Save-PSCxDocument -Path 'bare.json' -Document ([ordered]@{ x = 1 })
+            Should-BeTrue -Actual (Test-Path -LiteralPath (Join-Path $script:out 'bare.json'))
+        }
+        finally { Pop-Location }
+    }
+
+    It 'serialises a document nested as deeply as SARIF goes' {
+        # Twelve levels is what a SARIF result needs. This is the deepest document the writer
+        # must handle intact, and it is one level away from the case below -- a depth chosen a
+        # little too small produces a valid file that quietly lost its tail.
+        $p = Join-Path $script:out 'deep-ok.json'
+        Save-PSCxDocument -Path $p -Document (Get-NestedDocument -Levels 12)
+        (Get-Content $p -Raw) | Should-NotMatchString 'System\.Collections'
+    }
+
+    It 'refuses to write a document ConvertTo-Json truncated' {
+        # Silent truncation leaves a VALID JSON file that no longer matches its schema, with a
+        # .NET type name where a value belongs. It shipped here once: every SARIF location read
+        # "System.Collections.Specialized.OrderedDictionary". Raising the depth fixed that
+        # document; this is what stops the next nested field reintroducing it.
+        # Thirteen levels, not twenty: the boundary is where the assertion has to sit, because a
+        # wildly over-deep document fails at any plausible setting and proves nothing about the
+        # one this writer uses.
+        { Save-PSCxDocument -Path (Join-Path $script:out 'deep.json') -Document (Get-NestedDocument -Levels 13) } |
+            Should-Throw -ExceptionMessage '*truncated*'
+    }
+}

--- a/tests/SelfComplexity.Tests.ps1
+++ b/tests/SelfComplexity.Tests.ps1
@@ -3,7 +3,7 @@
 
 BeforeAll {
     $script:src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
-    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1') { . (Join-Path $script:src $f) }
+    foreach ($f in 'Ast.ps1', 'Cyclomatic.ps1', 'Cognitive.ps1', 'Measure-PSComplexity.ps1', 'Report.ps1') { . (Join-Path $script:src $f) }
     $script:units = @(Measure-PSComplexity -Path $script:src -Recurse)
 }
 

--- a/tools/Test-PSCxPackage.ps1
+++ b/tools/Test-PSCxPackage.ps1
@@ -36,6 +36,18 @@ if ($orphans) {
 }
 Write-Output "  all $((Get-ChildItem -LiteralPath (Join-Path $stage 'src') -Filter *.ps1).Count) shipped src files are dot-sourced"
 
+# --- 2b. the report schema ships, and parses ----------------------------------------------
+# It is a public artifact: the format a consumer validates our report against. Left behind in
+# the repo it is no use to the person it exists for, and that failure is invisible from inside
+# the repo -- everything here can read it whether or not it travels.
+$schemaPath = Join-Path $stage 'schemas' -AdditionalChildPath 'v1', 'report.schema.json'
+if (-not (Test-Path -LiteralPath $schemaPath)) {
+    throw "The report schema did not ship: expected it at $schemaPath. Check the staging Copy-Item in publish.yml."
+}
+try { Get-Content -LiteralPath $schemaPath -Raw | ConvertFrom-Json | Out-Null }
+catch { throw "The shipped report schema is not valid JSON: $($_.Exception.Message)" }
+Write-Output "  the report schema ships and parses"
+
 # --- 3 and 4. import in a FRESH process and measure for real ------------------------------
 # A fresh process, because importing here is indistinguishable from the repo copy already
 # loaded in this session -- and "it worked on my machine, where the real one was loaded" is


### PR DESCRIPTION
Closes #5. Both halves -- JSON and SARIF.

```powershell
Measure-PSComplexity ./src -Recurse -ReportPath ./reports/complexity.json
Test-PSComplexity   ./src -Recurse -ReportPath ./reports/gate.json -SarifPath ./reports/gate.sarif
```

The gate gave a build one bit and the records were PowerShell objects, so anything that was not
PowerShell had to re-implement the serialisation.

**The report is the scan serialised, not a new shape.** `Get-PSCxScan` (#17) already answered
what was in scope, what was measured and what was skipped. That is why the scan was built and
left internal: this is the consumer that turns its shape into a contract, via
`schemas/v1/report.schema.json`, which now ships with the module.

## What the format makes impossible

Copied from the sibling project, which forbids a mutation score in a recheck report for the
same reason -- a dangerous shape is better unrepresentable than documented.

| Rule | Why |
|---|---|
| `passed` forbidden without `thresholds` | `Measure-PSComplexity` applies no ceilings, so a verdict beside its numbers is an answer nobody computed |
| `metricVersion` required | the metric has moved twice for source that did not change; a stored number that cannot be checked for comparability is a trend chart waiting to mislead |
| `scope` and `skipped` required | an aggregate that cannot say what it excluded is not one anyone can act on |

`schemaVersion` moves when a field changes meaning or disappears, **never** when one is added,
so the schema permits unknown properties and the exact field list is pinned in a test instead.

## SARIF

One result per breached ceiling, under two independently suppressible rule ids, fingerprinted on
**file and unit rather than the line** -- a line moves whenever anything above the unit is
edited, and a fingerprint built on it would close and reopen the same finding on an unrelated
change. An accepted unit raises nothing: the gate excused it, and the JSON report carries the
argument under `accepted`.

Only the gate writes SARIF. Without ceilings there is no such thing as a finding.

## Two places the gates changed the code, not the tests

**A branch indistinguishable from its own absence.** `Get-PSCxReportSummary` had an early return
of six zeros for an empty unit list, and six mutants survived inside it. The `[int]` cast and
`[math]::Round` already turn a null maximum into `0`, so the general path was always correct for
an empty list -- verified directly rather than inferred. Deleted, because a test for it would
only have kept dead code alive.

**Three guards no test could kill.** `Measure-PSComplexity` collected units and skips per file
behind three `-ReportPath` guards; forcing any of them true changes no output, since they only
save memory. Rather than declare three equivalents, `-ReportPath` now defers to a single
`Get-PSCxScan` in `end` -- which removed the guards, removed a second place that decided what a
unit is, and dropped the function clear of the complexity ceiling.

## What only the sandbox could find

Neither of these is reachable from the suite, coverage, the analyzer, the complexity gate or the
package smoke test. The sandbox is the only thing that runs the tests somewhere other than the
repo.

- `schemas/` had to join `sandboxSubtrees`, or the baseline goes red before a mutant runs, with
  an error naming a missing path rather than a missing subtree. The reason is recorded beside
  the list, because a bare `"schemas"` there looks removable.
- `Get-PSCxModuleVersion` **threw** when it found neither a loaded module nor a manifest. That
  is a real configuration, not a broken one -- a sandbox copies `src/`, `tests/` and `schemas/`
  and no manifest, and so does a consumer who dot-sources `src/`. It returns the literal
  `'unknown'`, which cannot be mistaken for a version, where `'0.0.0'` would have every such run
  claim one release nobody published.

## The trap I wrote a comment about and then shipped

`ConvertTo-Json` truncates past its depth **silently**, leaving valid JSON with a .NET type name
where a value belongs. SARIF nests nine levels; the depth was six, so every location in the
first SARIF file read `"System.Collections.Specialized.OrderedDictionary"`.

`Save-PSCxDocument` now refuses to write a document containing such a marker. Raising the depth
fixes today's document; the next nested field would reintroduce it. Pinned at the boundary --
12 levels writes, 13 throws -- because a wildly over-deep fixture fails at any setting and
proves nothing about the one this writer uses.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 316 passed, 0 failed |
| Sandboxed mapped suites | 128/128 |
| Coverage | 100% over `src/` (670 commands) |
| Analyzer | clean |
| Self-complexity | passes |
| Package smoke test | schema ships and parses |
| Scoped mutation (`Report.ps1`, `Measure-PSComplexity.ps1`) | **100%, 152/152** |
| Release consistency | consistent at 0.4.0 |

Rebased onto `main` after #97; `src/` and `schemas/` verified byte-identical across the rebase,
so the 152/152 describes this tree.

No version bump: 0.4.0 is unreleased, so this folds into that entry.

---

With this, Wave D's first item is done and the deferred decision from #17 is settled: the scan's
shape is a published contract, while `Get-PSCxScan` itself stays internal. Next in the roadmap
order is #2, the committed baseline -- whose four prerequisites (identity, `MetricVersion`, an
exception concept, a scan) now all exist.
