### PR TITLE
fix: make an analyzer run a verdict, not a return value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,10 @@ jobs:
       - name: Lint (PSScriptAnalyzer)
         shell: pwsh
         run: |
-          $f = ./tools/Invoke-PSCxAnalyzer.ps1
-          if ($f) { $f | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize; throw "$($f.Count) lint finding(s)" }
-          Write-Host 'Lint clean.'
+          # The script throws on its own now. The verdict used to live HERE, in YAML, while
+          # the script exited 0 with findings -- so running it by hand was not the same as
+          # passing it, and this step was the only thing that made it a gate.
+          ./tools/Invoke-PSCxAnalyzer.ps1
 
       - name: Tests (reference scores + self-complexity gate)
         shell: pwsh

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -72,7 +72,11 @@ jobs:
         shell: pwsh
         run: |
           Import-Module ConvertToSARIF -RequiredVersion $env:CONVERTTOSARIF_VERSION
-          ./tools/Invoke-PSCxAnalyzer.ps1 | ConvertTo-SARIF -FilePath results.sarif
+          # -PassThru: this job UPLOADS findings rather than failing on them, and an empty set
+          # is a meaningful upload that clears alerts for rules already fixed. It is the one
+          # caller that wants data; the other two want a verdict, and now get one from the
+          # script rather than from YAML. Everything deciding WHAT is analysed is still shared.
+          ./tools/Invoke-PSCxAnalyzer.ps1 -PassThru | ConvertTo-SARIF -FilePath results.sarif
 
       - name: Upload SARIF to code scanning
         uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,7 @@ jobs:
           # The same committed script ci.yml and code-scanning.yml run. This was a THIRD
           # inline copy, and it carried the severity filter too -- so the release path could
           # publish over a finding the required check was already blocking on.
-          $f = ./tools/Invoke-PSCxAnalyzer.ps1
-          if ($f) { $f | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize; throw "$($f.Count) lint finding(s) -- not publishing" }
+          ./tools/Invoke-PSCxAnalyzer.ps1
           Import-Module ./PSComplexity.psd1 -Force
           Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
           $cfg = New-PesterConfiguration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ keys it holds could not distinguish units the tool could.
 
 ### Fixed
 
+- **Running the analyzer by hand is now the same as passing it.**
+  `tools/Invoke-PSCxAnalyzer.ps1` returned its findings and exited 0 whether or not it found any,
+  so `$?` was not a verdict and the gate was the `if` around it -- in `ci.yml` and again in
+  `publish.yml`, which guards the one irreversible action here. It throws now, like
+  `Measure-PSCxCoverage.ps1` and `Test-PSCxRelease.ps1` beside it. `-PassThru` returns the
+  findings without failing, for code scanning, which uploads them rather than gating on them and
+  where an empty set is a meaningful upload that clears alerts for rules already fixed.
+
 - **The gate could describe an unrelated failure as a file that did not parse.**
   `Test-PSComplexity` rebuilt its list of unreadable files by capturing `Measure-PSComplexity`'s
   error stream with `-ErrorAction SilentlyContinue`, so *any* error landed in the same variable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ CI (`.github/workflows/ci.yml`) runs:
 
 | Gate | What it is |
 |---|---|
-| Lint | PSScriptAnalyzer, `-Severity Error, Warning` |
+| Lint | `tools/Invoke-PSCxAnalyzer.ps1` — **every severity**, and it throws. The same script code scanning and publish run |
 | Unit tests | whole `tests/` directory, 0 failures |
 | Complexity | **its own** `Test-PSComplexity` against `src/`, 15 / 15 per unit |
 | Self-mutation | PSMutant against `psmutant.self.config.json`, break = 100 |
@@ -140,6 +140,25 @@ and expensive to rebuild, and because each one has already earned its keep.
   `System.Collections.Specialized.OrderedDictionary`. `Save-PSCxDocument` now refuses to write a
   document containing such a marker, because raising the depth fixes today's document and the
   next nested field reintroduces it.
+
+- **One committed analyzer script, and running it IS passing it.** All three callers -- the
+  lint step in `ci.yml`, the same check in `publish.yml`, and the required `code-scanning.yml`
+  -- run `tools/Invoke-PSCxAnalyzer.ps1`, so they cannot analyse different paths, different
+  settings or, as they did until #19, different severities. There is **no `-Severity` filter**:
+  rules are excluded by name in `PSScriptAnalyzerSettings.psd1`, with a reason, where a severity
+  filter mutes a whole band nobody decided about.
+
+  **It throws on a finding**, so the exit code is the answer. It did not always: it returned
+  findings and exited 0 either way, the verdict lived in two workflow steps, and running it by
+  hand was therefore not the same as passing it. `-PassThru` returns the findings without
+  failing, for code scanning, which uploads them rather than gating on them -- an empty set
+  there is a meaningful upload that clears alerts for rules already fixed. The decision itself
+  is `Get-PSCxLintFault` in `ReleaseDecisions.ps1`, with tests, like every other gate decision.
+
+  **`Write-Output`, never `Write-Host`, in `tools/`.** `PSAvoidUsingWriteHost` is not excluded
+  here and every other script in `tools/` prints that way. The sibling project made the opposite
+  choice -- it excludes the rule because its gate scripts print for a living -- so this is the
+  one part of its design not to copy across. Porting it failed this gate on its own first run.
 
 - **An acceptance is a checkable claim, and there must never be a plain suppression beside
   it.** `-Accept` names one unit by file AND unit, carries a written argument, and the gate
@@ -260,11 +279,6 @@ list above in the PR that closes it.
   at 100% in this file and measured by nobody -- the recipe lives in prose, so measuring by
   hand and measuring in CI cannot even be compared. Hand-maintained figures in this repo have
   already drifted.
-
-- **One analyzer invocation, called by both gates** (#19). The failing lint gate filters to
-  Error and Warning over four paths; the required code-scanning check has no filter and scans
-  everything. A finding in the gap is invisible to the gate that fails and visible to the one
-  that blocks.
 
 - **Anything the module says about itself is a claim someone should be able to check** (#28).
   Five statements in the docs are not true of the code, two of them provably: load order is

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -217,6 +217,24 @@ Describe 'the pins file itself' {
     }
 }
 
+Describe 'Get-PSCxLintFault' {
+    It 'passes a run that found nothing' {
+        Should-BeNull -Actual (Get-PSCxLintFault -FindingCount 0)
+    }
+
+    It 'fails on a single finding' {
+        # One, not many. No -Severity filter reaches the analyzer and rules are excluded by name
+        # with a reason, so anything reported at all is a rule somebody decided to keep -- a gate
+        # needing two would let every lone Information-severity finding through.
+        Get-PSCxLintFault -FindingCount 1 | Should-BeLikeString '*lint gate failed*'
+    }
+
+    It 'says how many it found' {
+        # A failure without a number sends the reader back to run it again to size the work.
+        Get-PSCxLintFault -FindingCount 4 | Should-BeLikeString '*4 PSScriptAnalyzer finding*'
+    }
+}
+
 Describe 'Get-PSCxTestRunFault' {
     It 'says nothing about a run where every container passed' {
         Get-PSCxTestRunFault -FailedCount 0 -ContainerResult @('Passed', 'Passed') -ContainerName @('a', 'b') |

--- a/tools/Invoke-PSCxAnalyzer.ps1
+++ b/tools/Invoke-PSCxAnalyzer.ps1
@@ -1,7 +1,8 @@
-# Run PSScriptAnalyzer the one way this project runs it, and return the findings.
+# Run PSScriptAnalyzer the one way this project runs it, and FAIL when it finds anything.
 #
-# Two gates analyse this repo: the lint step in ci.yml, which FAILS the build, and
-# code-scanning.yml, which uploads SARIF and is a REQUIRED check. They each spelled the
+# THREE callers analyse this repo, not two: the lint step in ci.yml, the same check in
+# publish.yml guarding the one irreversible action here, and code-scanning.yml, which uploads
+# SARIF and is a REQUIRED check. They each spelled the
 # invocation out inline and disagreed about both scope and severity -- ci.yml passed
 # `-Severity Error, Warning` over four paths, code scanning passed no filter over everything.
 #
@@ -22,7 +23,17 @@ param(
     # Defaults to PSSA_VERSION. The exact version matters: rules and their inference change
     # between releases, so an unpinned analyzer can report a finding CI does not, or miss one
     # it does.
-    [string]$AnalyzerVersion
+    [string]$AnalyzerVersion,
+
+    # Return the findings as data instead of failing on them. For the one caller that has its
+    # own use for them -- code-scanning.yml converts them to SARIF, where an EMPTY set is a
+    # meaningful upload that clears alerts for rules already fixed, so that consumer must never
+    # be failed.
+    #
+    # Opt-out rather than opt-in, deliberately. The dangerous shape is a human running this and
+    # reading exit 0 as a pass, so the safe behaviour has to be what you get without thinking
+    # about it.
+    [switch]$PassThru
 )
 
 $ErrorActionPreference = 'Stop'
@@ -72,8 +83,29 @@ $settings = Join-Path -Path $repoRoot -ChildPath 'PSScriptAnalyzerSettings.psd1'
 #
 # -Path takes a single item, so the loop is required rather than stylistic: passing the array
 # fails with "Cannot convert 'System.Object[]' to the type 'System.String'".
-$findings = $Path | ForEach-Object { Invoke-ScriptAnalyzer -Path $_ -Recurse -Settings $settings }
-
 # @() so a single finding is still a collection and callers can count it. No comma-wrap:
 # callers pipe this, and `, $array` would enter the pipeline as one item.
-return [object[]]@($findings)
+$findings = [object[]]@($Path | ForEach-Object { Invoke-ScriptAnalyzer -Path $_ -Recurse -Settings $settings })
+
+if ($PassThru) { return $findings }
+
+# Otherwise this script IS the gate, like Measure-PSCxCoverage.ps1 and Test-PSCxRelease.ps1
+# beside it. It used to return findings and exit 0 whether or not it found any, so $? was not a
+# verdict: a person who ran it by hand and checked the exit code got a confident wrong answer,
+# and the verdict lived in THREE workflow steps instead -- ci.yml, publish.yml and nowhere at
+# all for code scanning. Two of the three committed gate scripts failed loudly and this one did
+# not, which is the inconsistency that made the trap invisible.
+#
+# Printed before the throw, because a gate that says how many findings there are without saying
+# what they were sends the reader back to run it again.
+. (Join-Path -Path $PSScriptRoot -ChildPath 'ReleaseDecisions.ps1')
+$fault = Get-PSCxLintFault -FindingCount $findings.Count
+if ($fault) {
+    # Write-Output, not Write-Host: PSAvoidUsingWriteHost is NOT excluded in this repo and every
+    # other script in tools/ prints this way. The sibling project excludes the rule and uses
+    # Write-Host throughout, so this is the one line of that design that must not be copied
+    # across -- and the gate this change creates caught it immediately, on itself.
+    Write-Output ($findings | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize | Out-String)
+    throw $fault
+}
+Write-Output 'Lint clean.'

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -260,6 +260,30 @@ function Get-PSCxPinValue {
     return $null
 }
 
+function Get-PSCxLintFault {
+    <#
+    .SYNOPSIS
+        Why the lint gate should fail, or $null if it should pass.
+    .DESCRIPTION
+        One finding is enough. No -Severity filter reaches the analyzer: rules are excluded by
+        NAME in PSScriptAnalyzerSettings.psd1, each with a reason, so anything still reported is
+        a rule somebody decided to keep. A gate needing two would let every lone
+        Information-severity finding through.
+
+        A count rather than the findings themselves, because the decision is arithmetic and the
+        rendering is the caller's business.
+    .OUTPUTS
+        [string] the reason, or $null.
+    #>
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [int]$FindingCount)
+    if ($FindingCount -gt 0) {
+        return "$FindingCount PSScriptAnalyzer finding(s) - lint gate failed"
+    }
+    return $null
+}
+
 function Get-PSCxTestRunFault {
     # Why a Pester run must not be treated as green, or $null when it may be.
     #


### PR DESCRIPTION
Closes #85. The sibling fix is PSMutant #142, merged — the two repos should not disagree about
whether their analyzer is a gate.

```bash
pwsh -NoProfile -File ./tools/Invoke-PSCxAnalyzer.ps1 >/dev/null 2>&1; echo "exit=$?"
# exit=0     <- with findings, and without them
```

The script returned its findings and exited 0 either way, so `$?` was not a verdict. The gate was
the `if` around it — in `ci.yml`, and **again in `publish.yml`**, which guards the one
irreversible action in this project. Running the script was not the same as passing it.

Two of the three committed gate scripts already threw. That inconsistency is what made the trap
invisible: nothing about this one looked different from `Measure-PSCxCoverage.ps1` or
`Test-PSCxRelease.ps1`.

## What changed

| | |
|---|---|
| `Get-PSCxLintFault` | the verdict, in `ReleaseDecisions.ps1`, with tests — per the rule that a pass/fail decision in `tools/` lives behind a pure function |
| `Invoke-PSCxAnalyzer.ps1` | prints the findings, then throws; `-PassThru` returns them instead |
| `ci.yml`, `publish.yml` | drop their `if`/`throw` — the verdict left YAML |
| `code-scanning.yml` | asks for data with `-PassThru` |

`-PassThru` is an **opt-out, not an opt-in**: the person the trap catches is the one not thinking
about it. Code scanning needs it because it uploads findings rather than failing on them, and an
empty set there is a meaningful upload that clears alerts for rules already fixed.

## The gate's first act was to fail on itself

`PSAvoidUsingWriteHost` is excluded repo-wide in the sibling project, because its gate scripts
print for a living. It is **not** excluded here, and every script in this repo's `tools/` uses
`Write-Output`. I ported the sibling's habit across and the new gate rejected it immediately —
which is a fair demonstration that it works, and a reminder that the sibling is a pattern to
copy from selectively. Recorded in `CLAUDE.md` so the next port does not repeat it.

## Three stale claims, fixed in passing

- the script's own header said **two** callers analyse this repo; there are three
- the gates table in `CLAUDE.md` still advertised `-Severity Error, Warning`, which #19 removed
- **#19's rule was still under "Practices to adopt"**, describing the broken state, months after
  it was closed — which makes finished work read as owed. It moves to "Practices to preserve" in
  the same change that finishes it, per the repo's own convention

## Verified in both directions

Not assumed. With a planted violation:

```
planted finding, THREW: 2 PSScriptAnalyzer finding(s) - lint gate failed
with -PassThru: 2 returned, no throw
```

## Gates

| Gate | Result |
|---|---|
| Unit tests | 278 passed, 0 failed |
| Analyzer (now a gate) | clean |
| Release consistency | consistent at 0.4.0 |

Coverage and self-mutation are unaffected: they measure `src/`, and `tools/` is outside
`sandboxSubtrees` — which is exactly why gate decisions live in `ReleaseDecisions.ps1` behind
tested pure functions.

Branched from `main`, so it does not depend on #98. It touches `ci.yml`'s lint step where #98
touches the job timeout; if both land, the merge is trivial.