### PR TITLE
docs: give the one unpinnable vocabulary entry a reason and a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,20 @@ keys it holds could not distinguish units the tool could.
 
 ### Internal
 
+- **The one entry the vocabulary sweep could not pin now says why.** `FunctionMemberAst` sits in
+  the unit-boundary list and removing it broke nothing -- the single exception in a leave-one-out
+  sweep that fails on 28 of 29 entries. It turns out to be unreachable for a reason rather than
+  by luck: every use of that list walks UP the parent chain, and PowerShell wraps a class member's
+  body in its own `FunctionDefinitionAst`, so the body is always met first. Verified across
+  methods, constructors, static constructors, static and hidden members, overrides and an empty
+  body -- and for a parameter default and a `ValidateScript` attribute, both of which look like
+  they sit on the member and are folded into the body.
+
+  It stays, because the failure modes are not symmetric: keeping it costs nothing, and removing
+  it would silently attribute a method's decisions to the script body. The invariant it leans on
+  is now pinned by tests, so the day it stops holding is a red suite rather than a quiet
+  re-attribution.
+
 - **Every metric increment now records the construct that caused it and the line it is on.**
   Nineteen producers emitted an anonymous `{Key; Amount}` pair and the amounts were folded into
   a total, so *what* caused an increment and *where* were destroyed at the moment the increment

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -51,6 +51,17 @@ $script:PSCxFlowCommands = @(
 )
 
 $script:PSCxUnitBoundaryTypes = @(
+    # FunctionMemberAst is unreachable TODAY and kept on purpose. Every usage of this list walks
+    # UP the parent chain, and PowerShell wraps a class member's body in its own
+    # FunctionDefinitionAst -- verified across methods, constructors, static constructors, static
+    # and hidden members, overrides, and an empty body. So the body is always met first, and
+    # Resolve-PSCxUnitBoundary maps it back to the member without consulting this list at all.
+    #
+    # It stays because the failure modes are not symmetric. If PowerShell ever produced a member
+    # without that inner node, keeping the entry costs nothing and removing it would silently
+    # attribute the member's decisions to the script body -- a wrong number, which is the one
+    # thing this module must not produce. The invariant it leans on is pinned by a test, so the
+    # day it stops holding is a red suite rather than a quiet re-attribution.
     'FunctionDefinitionAst', 'FunctionMemberAst', 'PropertyMemberAst'
 )
 

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -361,3 +361,79 @@ function T {
         $map[$unit] | Should-Be 4
     }
 }
+
+Describe 'the invariant the unit-boundary list leans on' {
+    # FunctionMemberAst sits in $script:PSCxUnitBoundaryTypes and no test could be made to fail
+    # by removing it -- the leave-one-out sweep pins 28 of 29 entries, and this was the one.
+    #
+    # The reason is a PowerShell invariant rather than luck: a class member's body is its own
+    # FunctionDefinitionAst, nested inside the member, so every walk up the parent chain meets
+    # the body first and never needs the member's own type. That makes the entry defence against
+    # a shape the parser does not currently produce.
+    #
+    # This is what makes that negative checkable. If the invariant ever stops holding, these fail
+    # and the entry becomes load-bearing -- rather than the module quietly attributing a method's
+    # decisions to the script body, which is a wrong number in the output.
+
+    It 'wraps every class member body in its own FunctionDefinitionAst' -ForEach @(
+        @{ Shape = 'instance method'; Code = 'class C { [int] M() { return 1 } }' }
+        @{ Shape = 'empty method'; Code = 'class C { [void] M() { } }' }
+        @{ Shape = 'constructor'; Code = 'class C { C() { } }' }
+        @{ Shape = 'static constructor'; Code = 'class C { static C() { } }' }
+        @{ Shape = 'static method'; Code = 'class C { static [int] M() { return 1 } }' }
+        @{ Shape = 'hidden method'; Code = 'class C { hidden [int] M() { return 1 } }' }
+        @{ Shape = 'override'; Code = 'class B { [int] M() { return 1 } } class D : B { [int] M() { return 2 } }' }
+    ) {
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($Code, [ref]$null, [ref]$null)
+        $members = @($ast.FindAll({ param($n)
+                    $n -is [System.Management.Automation.Language.FunctionMemberAst] }, $true))
+        $members.Count | Should-BeGreaterThan 0
+        foreach ($m in $members) {
+            @($m.FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)).Count |
+                Should-BeGreaterThan 0 -Because "$Shape must carry its body as a FunctionDefinitionAst"
+        }
+    }
+
+    It 'reaches the body before the member from anywhere a decision can sit' {
+        # Not only inside the body. A parameter default and a ValidateScript attribute look like
+        # they live on the member rather than in it -- both were candidates for the case that
+        # would make the entry load-bearing, and PowerShell folds both into the body scriptblock.
+        $codes = @(
+            'class C { [int] M([int]$a) { if ($a) { return 1 } return 2 } }'
+            'class C { [int] M([int]$a = ($true ? 1 : 2)) { return $a } }'
+            'class C { [int] M([ValidateScript({ if ($_) { $true } else { $false } })][int]$a) { return $a } }'
+        )
+        foreach ($code in $codes) {
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput($code, [ref]$null, [ref]$null)
+            $nodes = @($ast.FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.IfStatementAst] -or
+                        $n -is [System.Management.Automation.Language.TernaryExpressionAst] }, $true))
+            $nodes.Count | Should-BeGreaterThan 0
+            foreach ($n in $nodes) {
+                $p = $n.Parent
+                $first = '<none>'
+                while ($p) {
+                    $tn = $p.GetType().Name
+                    if ($tn -in 'FunctionDefinitionAst', 'FunctionMemberAst', 'PropertyMemberAst') { $first = $tn; break }
+                    $p = $p.Parent
+                }
+                $first | Should-Be 'FunctionDefinitionAst' -Because "reaching $first first would make the FunctionMemberAst entry load-bearing"
+            }
+        }
+    }
+
+    It 'still attributes a class method to the member, which is what the entry protects' {
+        # The behaviour the invariant serves. A method's decisions belong to C.M, not to the
+        # script body -- that is the answer that would silently change if the boundary handling
+        # were wrong.
+        $f = Join-Path ([System.IO.Path]::GetTempPath()) "cxb-$([System.Guid]::NewGuid().ToString('N')).ps1"
+        Set-Content $f 'class C { [int] M([int]$a) { if ($a) { return 1 } return 2 } }' -Encoding utf8
+        try {
+            $u = @(Measure-PSComplexity -Path $f | Where-Object Unit -eq 'C.M')
+            $u.Count | Should-Be 1
+            $u[0].Cyclomatic | Should-Be 2
+        }
+        finally { Remove-Item $f -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
Closes #83.

`FunctionMemberAst` sits in `$script:PSCxUnitBoundaryTypes` and removing it breaks nothing —
**the single exception** in a leave-one-out sweep that fails on 28 of 29 entries. The issue
recorded that rather than acting on it, and refused to delete on the strength of a negative that
could not vacuity-check itself.

That was the right call, and the answer turns out to be a fourth option rather than the three it
listed.

## It is unreachable for a reason, not by luck

Every use of that list walks **up** the parent chain, and PowerShell wraps a class member's body
in its own `FunctionDefinitionAst`. So the body is always met first, and
`Resolve-PSCxUnitBoundary` maps it back to the member without consulting the list at all.

Verified across seven shapes: instance methods, empty bodies, constructors, static constructors,
static members, hidden members, and overrides.

The two shapes the issue suspected would discriminate were checked too — a ternary in a
**parameter default**, and a **`ValidateScript`** scriptblock on a parameter. Both look like they
live on the member rather than in it. PowerShell folds both into the body scriptblock.

## It stays, because the failure modes are not symmetric

If PowerShell ever produced a member without that inner node, keeping the entry costs nothing;
removing it would silently attribute a method's decisions to the script body — a wrong number,
which is the one thing this module must not produce.

## What makes this a resolution rather than a shrug

**The invariant is now pinned by tests**, so the day it stops holding is a red suite instead of a
quiet re-attribution. Three of them: that every member shape carries a `FunctionDefinitionAst`
body, that a decision anywhere in a member reaches the body first, and that a class method is
still attributed to `C.M`.

And the assertion **vacuity-checks itself**. Feeding it a property initialiser, whose first
boundary is `PropertyMemberAst`, fails it exactly as intended:

```
Expected 'FunctionDefinitionAst', because reaching PropertyMemberAst first would
make the FunctionMemberAst entry load-bearing, but got 'PropertyMemberAst'.
```

That is the check the issue asked for and could not construct — not "I removed it and nothing
broke", but "here is a case that *should* break it, and it does".

## Gates

| Gate | Result |
|---|---|
| Unit tests | 328 passed, 0 failed, all containers built |
| Coverage | 100% over `src/` |
| Analyzer | clean |
| Complexity | passes |
| Scoped mutation (`src/Ast.ps1`) | **100%, 57/57** |

`src/` changed in **comments only** — 0 non-comment lines added — so the mutation result cannot
move. The gate was run rather than assumed.