### PR TITLE
test: make a new dependency edge in src/ a decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ keys it holds could not distinguish units the tool could.
 
 ### Internal
 
+- **A new dependency edge between files in `src/` now has to be declared.** Every other gate is
+  blind to direction -- a shortcut call reaches full coverage and survives self-mutation exactly
+  as a well-layered one does -- so the graph was acyclic by habit rather than by check. An
+  allowlist of file-to-file relationships now fails in both directions, asserts the graph is
+  acyclic, and holds `Report.ps1` as a sink so a serialiser cannot start deciding what a number
+  means. Each of its five assertions was checked by making it fail.
+
 - **The one entry the vocabulary sweep could not pin now says why.** `FunctionMemberAst` sits in
   the unit-boundary list and removing it broke nothing -- the single exception in a leave-one-out
   sweep that fails on 28 of 29 entries. It turns out to be unreachable for a reason rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,33 @@ and expensive to rebuild, and because each one has already earned its keep.
   document containing such a marker, because raising the depth fixes today's document and the
   next nested field reintroduces it.
 
+- **A new file-to-file edge in `src/` is a decision, and `tests/Layering.Tests.ps1` makes you
+  make it.** Every other gate is blind to DIRECTION: a shortcut call from `Report.ps1` back into
+  `Ast.ps1` reaches full coverage and survives self-mutation exactly as a well-layered one does.
+  The graph is acyclic because nobody has added a shortcut, not because anything caught one.
+
+  The allowlist holds one entry per file-to-file **relationship**, not per call site, so adding a
+  call between files that already have an edge is free and adding the first is deliberate. It
+  fails in **both** directions -- an undeclared edge fails, and so does a declared edge the code
+  no longer has, because a list describing dropped relationships is one nobody can trust and it
+  silently readmits an edge later. It also asserts the graph is **acyclic**, which the allowlist
+  alone cannot give: two edges each reasonable on their own review make a cycle between them, and
+  nobody reviewing the second is looking at the first.
+
+  Two directions are design decisions rather than bookkeeping. `Ast.ps1` is the shared foundation
+  and knows nothing about metrics; `Report.ps1` is a **sink**, asserted separately, because a
+  serialiser that reached back into measurement would be deciding what a number MEANS while
+  claiming only to write it down.
+
+  This file was deliberately not written earlier. With no interior node a cycle was unreachable
+  and an allowlist would have been ceremony; `ROADMAP.md` recorded the condition for revisiting
+  and `src/Report.ps1` met it. Writing it while the edges are few and obviously correct is the
+  cheap moment -- ratifying a graph nobody remembers agreeing to is the expensive one.
+
+  There is no "one Write-Host" assertion like the sibling's, and that is deliberate:
+  `PSAvoidUsingWriteHost` is not excluded here, so PSScriptAnalyzer already fails the build. A
+  second gate over the same property is one more thing to keep in step for no extra coverage.
+
 - **One committed analyzer script, and running it IS passing it.** All three callers -- the
   lint step in `ci.yml`, the same check in `publish.yml`, and the required `code-scanning.yml`
   -- run `tools/Invoke-PSCxAnalyzer.ps1`, so they cannot analyse different paths, different

--- a/tests/Layering.Tests.ps1
+++ b/tests/Layering.Tests.ps1
@@ -1,0 +1,173 @@
+# The dependency direction between files in src/, as a checked allowlist.
+#
+# Every other gate here is blind to DIRECTION. A shortcut call from Report.ps1 back into Ast.ps1,
+# or from Cognitive.ps1 into Measure-PSComplexity.ps1, reaches full coverage and survives
+# self-mutation exactly as a well-layered call does. Nothing fails. The graph is acyclic today
+# because nobody has added a shortcut, not because anything would catch one.
+#
+# This file was deliberately NOT written while the graph had no interior node: with five files
+# and every arrow pointing at a sink, a cycle was not reachable and an allowlist would have been
+# ceremony. ROADMAP.md recorded the condition for revisiting -- a module that both exported
+# commands consume, living in its own file -- and src/Report.ps1 met it.
+#
+# Two things this test does NOT have to work around, unlike the sibling project's version:
+#
+#   - src/ contains no here-strings, so there is no code the parser cannot see.
+#   - src/ dispatches nothing through a variable (`& $fn`), so every callee is resolvable.
+#
+# Both are worth re-checking if either ever appears, because each one hides an edge in a way
+# that looks exactly like not having one.
+
+BeforeAll {
+    $script:srcDir = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
+
+    # One entry per file-to-file RELATIONSHIP, not per call site. Adding a call between two files
+    # that already have an edge is free; adding the first one is a decision.
+    $script:allowedEdges = @(
+        # Ast.ps1 is the shared foundation: which units exist, which one owns a node, how deeply
+        # it is nested. Both metrics ask it those questions and it asks them nothing back. This
+        # arrow must never reverse -- an Ast layer that knew what a cognitive point was would
+        # make the metric impossible to change without changing discovery.
+        'Cognitive.ps1 -> Ast.ps1'
+        'Cyclomatic.ps1 -> Ast.ps1'
+
+        # The composition root. It owns most of the graph on purpose: it is wiring, so it is
+        # allowed to know about everything, and nothing is allowed to know about it.
+        'Measure-PSComplexity.ps1 -> Ast.ps1'
+        'Measure-PSComplexity.ps1 -> Cognitive.ps1'
+        'Measure-PSComplexity.ps1 -> Cyclomatic.ps1'
+
+        # Serialisation is downstream of measurement and must stay a sink. A report layer that
+        # reached back into Ast.ps1 or a metric would be deciding what a number MEANS while
+        # claiming only to write it down -- and the report is the artefact a consumer trusts.
+        'Measure-PSComplexity.ps1 -> Report.ps1'
+    )
+
+    function Get-SrcAst {
+        $out = @{}
+        foreach ($f in Get-ChildItem $script:srcDir -Filter *.ps1) {
+            $out[$f.Name] = [System.Management.Automation.Language.Parser]::ParseFile($f.FullName, [ref]$null, [ref]$null)
+        }
+        return $out
+    }
+
+    function Get-FileEdge {
+        param($Asts)
+        # Which file defines each function, then which file calls it. A call inside the file
+        # that defines it is not an edge.
+        $definedBy = @{}
+        foreach ($name in $Asts.Keys) {
+            foreach ($fn in $Asts[$name].FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+                $definedBy[$fn.Name] = $name
+            }
+        }
+        $edges = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($name in $Asts.Keys) {
+            foreach ($c in $Asts[$name].FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+                $called = $c.GetCommandName()
+                if ($called -and $definedBy.ContainsKey($called) -and $definedBy[$called] -ne $name) {
+                    [void]$edges.Add("$name -> $($definedBy[$called])")
+                }
+            }
+        }
+        return $edges
+    }
+}
+
+Describe 'the dependency graph in src/' {
+    It 'has no file-to-file edge that is not declared' {
+        # The message names the offender rather than reporting a count, because the useful
+        # question on a red build is "which edge did I add", and the answer is either "add it to
+        # the list deliberately" or "that call belongs somewhere else".
+        $undeclared = @((Get-FileEdge -Asts (Get-SrcAst)) | Where-Object { $_ -notin $script:allowedEdges })
+        ($undeclared -join '; ') | Should-Be ''
+    }
+
+    It 'declares no edge that no longer exists' {
+        # The other direction, and it matters for the same reason a stale acceptance does: a list
+        # describing relationships the code dropped is a document nobody can trust, and it
+        # silently readmits an edge later.
+        $actual = Get-FileEdge -Asts (Get-SrcAst)
+        $stale = @($script:allowedEdges | Where-Object { $_ -notin $actual })
+        ($stale -join '; ') | Should-Be ''
+    }
+
+    It 'is acyclic' {
+        # The property the allowlist protects, and one the allowlist alone cannot give: two edges
+        # each reasonable on their own review make a cycle between them, and nobody reviewing the
+        # second is looking at the first.
+        $edges = Get-FileEdge -Asts (Get-SrcAst)
+        $out = @{}
+        foreach ($e in $edges) {
+            $parts = $e -split ' -> '
+            if (-not $out.ContainsKey($parts[0])) { $out[$parts[0]] = [System.Collections.Generic.List[string]]::new() }
+            $out[$parts[0]].Add($parts[1])
+        }
+        # Repeatedly drop files that depend on nothing still present. Anything left when no more
+        # can be dropped is inside a cycle.
+        $remaining = [System.Collections.Generic.List[string]]::new()
+        (Get-SrcAst).Keys | ForEach-Object { $remaining.Add($_) }
+        $progress = $true
+        while ($progress) {
+            $progress = $false
+            foreach ($file in @($remaining)) {
+                $deps = @()
+                if ($out.ContainsKey($file)) { $deps = @($out[$file] | Where-Object { $remaining -contains $_ }) }
+                if ($deps.Count -eq 0) {
+                    [void]$remaining.Remove($file)
+                    $progress = $true
+                }
+            }
+        }
+        ($remaining -join ', ') | Should-Be ''
+    }
+
+    It 'keeps Report.ps1 a sink' {
+        # Stated separately from the allowlist because it is the reason this file exists now. The
+        # allowlist would permit a Report.ps1 edge the moment somebody added one and updated the
+        # list; this says the direction is a design decision, not a bookkeeping entry.
+        #
+        # A serialiser that reached back into measurement would be deciding what a number means
+        # while claiming only to write it down.
+        $fromReport = @((Get-FileEdge -Asts (Get-SrcAst)) | Where-Object { $_ -like 'Report.ps1 -> *' })
+        ($fromReport -join '; ') | Should-Be ''
+    }
+}
+
+Describe 'module state in src/' {
+    It 'never reads a $script: variable from the file that did not write it' {
+        # Locality: a constant one file writes while another reads leaves neither readable on its
+        # own, and it is an edge no call-graph check can see. The sibling project had two such
+        # reads and removed them in opposite directions -- one default moved to its reader, the
+        # other stayed and its resolver came to it. This is what stops a third appearing here.
+        $asts = Get-SrcAst
+        $writtenIn = @{}
+        foreach ($name in $asts.Keys) {
+            foreach ($a in $asts[$name].FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
+                if ($a.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                    $a.Left.VariablePath.UserPath -like 'script:*') {
+                    $writtenIn[$a.Left.VariablePath.UserPath] = $name
+                }
+            }
+        }
+        $foreign = foreach ($name in $asts.Keys) {
+            foreach ($v in $asts[$name].FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)) {
+                $path = $v.VariablePath.UserPath
+                if ($path -like 'script:*' -and $writtenIn.ContainsKey($path) -and $writtenIn[$path] -ne $name) {
+                    "$name reads `$$path from $($writtenIn[$path])"
+                }
+            }
+        }
+        (@($foreign) -join '; ') | Should-Be ''
+    }
+}
+
+# Deliberately not here: a "one Write-Host" assertion like the sibling's. That project excludes
+# PSAvoidUsingWriteHost repo-wide because its gate scripts print for a living, so a test is the
+# only thing that can hold the line. Here the rule is NOT excluded and src/ contains no
+# Write-Host at all, so PSScriptAnalyzer already fails the build -- and a second gate over the
+# same property is one more thing to keep in step for no extra coverage.


### PR DESCRIPTION
Closes #102.

`ROADMAP.md` carried a layering test under "deliberately not doing" with a **condition** rather
than a refusal:

> Reconsider when a module both exported commands consume lives in its **own file** … that move is
> the trigger, not a line count.

`src/Report.ps1` is that file — `Measure-PSComplexity` calls three of its functions,
`Test-PSComplexity` a fourth, and it is a sink. The condition was written down precisely so it
would not need re-arguing, so this acts on it rather than re-deciding.

## What it catches that nothing else does

**Direction.** A shortcut call from `Report.ps1` back into `Ast.ps1` reaches full coverage and
survives self-mutation exactly as a well-layered one does. Nothing fails. The graph was acyclic
because nobody had added a shortcut, not because anything would catch one.

The allowlist holds one entry per file-to-file **relationship**, not per call site, so a call
between files that already have an edge is free and the first one is deliberate. It fails in
**both** directions — a declared edge the code no longer has is a document nobody can trust, and
it silently readmits an edge later.

**Acyclicity is asserted separately**, because the allowlist alone cannot give it: two edges each
reasonable on their own review make a cycle between them, and nobody reviewing the second is
looking at the first.

**`Report.ps1` is held as a sink**, also separately. The allowlist would permit an outbound edge
the moment somebody added one and updated the list; this says the direction is a design decision.
A serialiser that reached back into measurement would be deciding what a number *means* while
claiming only to write it down — and the report is the artefact a consumer trusts.

## Every assertion was checked by making it fail

A layering test that cannot fail is worse than none, so each one was sabotaged and watched:

| Sabotage | |
|---|---|
| undeclared edge `Report.ps1 -> Ast.ps1` | **CAUGHT** |
| the same edge, seen by the sink test | **CAUGHT** |
| a stale declaration | **CAUGHT** |
| a **declared** cycle, so only the acyclic test can object | **CAUGHT** |
| a cross-file `$script:` read | **CAUGHT** |

Every sabotage was verified *in the file* before the result was believed — a check that has caught
three false readings this week, where a patch matched no anchor and the run then "proved" the
assertion vacuous from a setup that never ran.

## Two differences from the sibling's version

**No blind spots to work around.** That one documents two — a here-string the parser never sees,
and dispatch through a variable. `src/` here has neither, so every callee is resolvable. Both are
noted in the file as things to re-check if they ever appear, because each hides an edge in a way
that looks exactly like not having one.

**No "one Write-Host" assertion.** `PSAvoidUsingWriteHost` is not excluded here and `src/` contains
none, so PSScriptAnalyzer already fails the build. The sibling needs the test because it excludes
the rule for gate scripts that print for a living. A second gate over the same property is one more
thing to keep in step for no extra coverage.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 333 passed, 0 failed, all containers built |
| Coverage | 100% over `src/` |
| Analyzer | clean |
| Complexity | passes |
| Release consistency | consistent at 0.4.0 |

No `src/` change, so self-mutation is unaffected. The new file is **not** added to
`psmutant.self.config.json`: it is a structural gate rather than a covering suite, same as the
sibling's.

Once this lands, #39's Guards section wants a small pass.