### PR TITLE
test: check the suite gives the same answer in a different order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,15 @@ jobs:
               -ContainerName @($r.Containers | ForEach-Object { Split-Path $_.Item -Leaf })
           if ($fault) { throw $fault }
 
+      # The step above ran the suite alphabetically. The mutation baseline below runs the
+      # mapped covering suites in config order, and those two orders differ -- so an
+      # order-dependent suite is green in one and red in the other, which is how the sibling
+      # spent three CI rounds on a variable one file had cleared and not restored. Runs on both
+      # platforms: only one of them reaches the mutation gate at all.
+      - name: Order independence (the suite, reversed)
+        shell: pwsh
+        run: ./tools/Test-PSCxOrderIndependence.ps1
+
       # A committed script, not a snippet here, so measuring by hand and measuring in CI
       # cannot drift. The figure in CLAUDE.md was a claim nothing checked, and the one in
       # CHANGELOG.md had been wrong for two releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ keys it holds could not distinguish units the tool could.
   acyclic, and holds `Report.ps1` as a sink so a serialiser cannot start deciding what a number
   means. Each of its five assertions was checked by making it fail.
 
+- **The suite now has to give the same answer in a different order.** This project runs its own
+  tests in two orders -- alphabetically by hand, in config order under the mutation baseline -- and
+  nothing checked they agree, so an order-dependent suite would be green in one and red in the
+  other. A new gate runs the suite reversed and compares the environment before and after it. The
+  reversed run catches such a dependency by its symptom; the environment comparison catches the
+  cause, and is the half that fires on the file that leaks rather than the file that happens to
+  read. Values are never printed -- a variable holds tokens as often as it holds flags.
+
 - **The one entry the vocabulary sweep could not pin now says why.** `FunctionMemberAst` sits in
   the unit-boundary list and removing it broke nothing -- the single exception in a leave-one-out
   sweep that fails on 28 of 29 entries. It turns out to be unreachable for a reason rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ CI (`.github/workflows/ci.yml`) runs:
 |---|---|
 | Lint | `tools/Invoke-PSCxAnalyzer.ps1` — **every severity**, and it throws. The same script code scanning and publish run |
 | Unit tests | whole `tests/` directory, 0 failures |
+| Order independence | `tools/Test-PSCxOrderIndependence.ps1` -- the same suite again, reversed, plus an environment comparison |
 | Complexity | **its own** `Test-PSComplexity` against `src/`, 15 / 15 per unit |
 | Self-mutation | PSMutant against `psmutant.self.config.json`, break = 100 |
 
@@ -270,6 +271,31 @@ and expensive to rebuild, and because each one has already earned its keep.
   versions. That negative was itself checked for vacuity -- renaming the loop variable so `$tn`
   is genuinely unresolvable collapses the score and breaks ten tests -- so the fixture does
   discriminate and the result means what it says.
+
+- **The suite runs in two orders here, and both are checked.** `Invoke-Pester ./tests` discovers
+  files alphabetically; the mutation baseline runs the mapped covering suites in the order
+  `psmutant.self.config.json` lists them. Those orders differ, so a developer running the suite by
+  hand and the gate running it never see the same sequence -- and an order-dependent suite is green
+  in one and red in the other. That is not hypothetical: the sibling spent three CI rounds finding
+  a variable one file cleared in an `AfterEach` and never restored.
+
+  `tools/Test-PSCxOrderIndependence.ps1` runs the suite **reversed** and compares the environment
+  before and after. The two halves fail on opposite ends of the same problem, which is why both are
+  there: the reversed run catches a dependency by its **symptom** and is a probe rather than a
+  proof -- one more permutation, not all of them -- while the environment comparison catches the
+  **cause** and is direction-blind, firing on the file that leaks whether or not anything reads it
+  yet. Only the second half would have caught the sibling's instance.
+
+  **Two other kinds of state were tried and rejected, and the measurements are in the script.** The
+  working directory cannot fire, because Pester restores it around a run -- verified with a test
+  that wanders off with `Set-Location` and still leaves the location unchanged. Global variables
+  fire on a *clean* suite, because Pester promotes every `-ForEach` case table to global scope, so
+  keeping them would mean an allowlist that grows with the tests it is watching. A check that
+  cannot fire and a check that always fires are the same defect wearing different clothes; neither
+  was written and left in.
+
+  The failure message names keys and **never values**. An environment variable holds tokens as
+  often as it holds flags, and this message is printed into a build log anyone can read.
 
 ## Practices to adopt
 

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -268,6 +268,68 @@ Describe 'Get-PSCxTestRunFault' {
     }
 }
 
+Describe 'Get-PSCxProcessStateFault' {
+    It 'says nothing about a run that put everything back' {
+        $m = @{ 'env:PATH' = '/usr/bin'; 'env:HOME' = '/home/x' }
+        Get-PSCxProcessStateFault -Before $m -After @{ 'env:PATH' = '/usr/bin'; 'env:HOME' = '/home/x' } |
+            Should-BeNull
+    }
+
+    It 'says nothing when there was nothing to compare' {
+        # Paired with the case above rather than left out: an empty environment must read as
+        # clean, not as every variable having been removed.
+        Get-PSCxProcessStateFault -Before @{} -After @{} | Should-BeNull
+    }
+
+    It 'names a variable the run added' {
+        Get-PSCxProcessStateFault -Before @{} -After @{ 'env:PSCX_LEAK' = '1' } |
+            Should-BeLikeString '*added: env:PSCX_LEAK*'
+    }
+
+    It 'names a variable the run removed' {
+        # The sibling's actual failure was this one: an AfterEach cleared a variable and never
+        # put it back, so every file after it ran in a different environment.
+        Get-PSCxProcessStateFault -Before @{ 'env:GITHUB_ACTIONS' = 'true' } -After @{} |
+            Should-BeLikeString '*removed: env:GITHUB_ACTIONS*'
+    }
+
+    It 'names a variable the run changed' {
+        Get-PSCxProcessStateFault -Before @{ 'env:TERM' = 'xterm' } -After @{ 'env:TERM' = 'dumb' } |
+            Should-BeLikeString '*changed: env:TERM*'
+    }
+
+    It 'treats a change of CASE as a change' {
+        # The comparison is -cne, not -ne. A case-insensitive compare calls 'true' and 'True'
+        # equal, and a variable whose value is read case-sensitively downstream is then reported
+        # as untouched. The one input that tells the two operators apart.
+        Get-PSCxProcessStateFault -Before @{ 'env:CI' = 'true' } -After @{ 'env:CI' = 'TRUE' } |
+            Should-BeLikeString '*changed: env:CI*'
+    }
+
+    It 'withholds the values' {
+        # Not tidiness. An environment variable holds tokens as often as it holds flags, and
+        # this message is printed into a build log that anybody can read. The key says which
+        # variable; the value would say what it was.
+        $fault = Get-PSCxProcessStateFault -Before @{ 'env:TOKEN' = 'ghp_secret' } `
+            -After @{ 'env:TOKEN' = 'ghp_other' }
+        $fault | Should-BeLikeString '*env:TOKEN*'
+        $fault | Should-NotBeLikeString '*ghp_secret*'
+        $fault | Should-NotBeLikeString '*ghp_other*'
+    }
+
+    It 'reports all three kinds at once, and every key in each' {
+        # One fault per run, so a message that stopped at the first kind would send the reader
+        # back for another round per variable.
+        $fault = Get-PSCxProcessStateFault `
+            -Before @{ 'env:GONE_A' = '1'; 'env:GONE_B' = '1'; 'env:SAME' = 'x'; 'env:MOVED' = 'x' } `
+            -After @{ 'env:SAME' = 'x'; 'env:MOVED' = 'y'; 'env:NEW' = '1' }
+        $fault | Should-BeLikeString '*added: env:NEW*'
+        $fault | Should-BeLikeString '*removed: env:GONE_A, env:GONE_B*'
+        $fault | Should-BeLikeString '*changed: env:MOVED*'
+        $fault | Should-NotBeLikeString '*env:SAME*'
+    }
+}
+
 Describe 'main must not claim a version that already shipped' {
     # It once did: main stood at 0.2.0, 0.2.0 was on the gallery, and merged work sat under
     # [Unreleased] with every gate passing. Two people installing "0.2.0" -- one from the

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -322,3 +322,45 @@ function Get-PSCxTestRunFault {
     }
     return $null
 }
+
+function Get-PSCxProcessStateFault {
+    # Why a suite run must be treated as having leaked, or $null when it has not.
+    #
+    # A test file can only change how a LATER file behaves if what it changed outlives it. So
+    # comparing the process before and against after asks the question that matters: did the
+    # suite leave anything behind. That is the precondition for order-dependence, and it is
+    # direction-blind -- it fires on the file that leaks rather than on the file that happens
+    # to read, which is the half a reversed run can miss.
+    #
+    # Keys are named and values are NEVER printed. An environment variable holds tokens as
+    # often as it holds flags, and a gate that quotes one into a public build log has turned a
+    # tidiness check into a disclosure.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        # Process state as key -> value, keyed by the path you would type: environment variables
+        # arrive as 'env:NAME'. One map rather than a parameter per kind of state, so a new kind
+        # is a new key at the call site and not a new comparison here to keep in step.
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [hashtable]$Before,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [hashtable]$After
+    )
+    $added = @($After.Keys | Where-Object { -not $Before.ContainsKey($_) } | Sort-Object)
+    $removed = @($Before.Keys | Where-Object { -not $After.ContainsKey($_) } | Sort-Object)
+    # Compare with -cne: on Linux two variables differing only in case are two variables, and a
+    # case-insensitive compare would call a genuine change no change at all.
+    $changed = @($Before.Keys |
+            Where-Object { $After.ContainsKey($_) -and [string]$Before[$_] -cne [string]$After[$_] } |
+            Sort-Object)
+
+    $parts = @()
+    foreach ($set in @(@{ N = 'added'; V = $added }, @{ N = 'removed'; V = $removed },
+            @{ N = 'changed'; V = $changed })) {
+        if ($set.V.Count -gt 0) { $parts += "$($set.N): $($set.V -join ', ')" }
+    }
+    if ($parts.Count -eq 0) { return $null }
+
+    return ('The suite changed process state it did not create -- ' + ($parts -join '; ') +
+        '. A test file that leaves the process different from how it found it decides what every ' +
+        'file after it sees, so the answer starts depending on the order. Restore it where you ' +
+        'change it. (Values are withheld: an environment variable can hold a token.)')
+}

--- a/tools/Test-PSCxOrderIndependence.ps1
+++ b/tools/Test-PSCxOrderIndependence.ps1
@@ -1,0 +1,101 @@
+# Run the suite in reverse file order, and fail if that changes the answer or if the run leaves
+# an environment variable behind.
+#
+# This project runs its own suite in TWO orders and nothing checked they agree. Invoke-Pester
+# over ./tests discovers files alphabetically; the mutation baseline runs the mapped covering
+# suites in the order psmutant.self.config.json lists them, and those orders differ. A developer
+# running the suite by hand and the gate running it therefore never see the same sequence, so an
+# order-dependent suite is green in one and red in the other -- which is exactly how it went in
+# the sibling repo, where three CI rounds went into finding a variable one file had cleared and
+# not restored.
+#
+# Two checks, because they fail on opposite halves of the problem:
+#
+#   The reversed RUN catches a dependency by its symptom. It is a probe rather than a proof: it
+#   exercises one more permutation, not all of them, so a dependency whose two files happen to
+#   keep their relative order under reversal survives it.
+#
+#   The state COMPARISON catches the cause, and is direction-blind. Anything a file leaves behind
+#   is visible to every file after it, so a leak is order-dependence waiting for a reader -- and
+#   this fires on the file that leaks whether or not anything reads it yet. That is the half the
+#   reversed run misses, and the half that shipped in the sibling.
+#
+# It is a committed script rather than a snippet in ci.yml so that running it by hand and running
+# it in CI cannot drift, and so that a developer can settle "is this mine?" without pushing.
+#
+# Known limit, stated rather than left to be rediscovered: the comparison spans the whole run, so
+# a file that leaks and a later file that coincidentally restores cancel out. Per-file granularity
+# needs a hook Pester does not offer, and would cost one process per file.
+#
+# Two other kinds of state were tried and are deliberately NOT compared. Both were measured, and
+# both would have been checks that cannot do their job -- which reads exactly like a check that
+# keeps passing:
+#
+#   The working DIRECTORY. Pester restores it around a run, so a test file that wanders off with
+#   Set-Location leaves it back where it started. Verified with a test that changes directory and
+#   passes: the location afterwards is unchanged. A cwd comparison here could never fire.
+#
+#   GLOBAL variables. A clean run of this suite already adds several -- Pester promotes a
+#   -ForEach case table to global scope, so every data-driven test file leaves one behind. The
+#   comparison would fail on a green suite, and the only way to keep it would be an allowlist
+#   that grows with the tests it is supposed to be watching.
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+
+function Get-ProcessStateSnapshot {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseLiteralInitializerForHashtable', '',
+        Justification = 'The literal @{} is case-INSENSITIVE, which is the one property this map must not have. On Linux PATH and Path are two different variables and the literal would silently merge them into one entry, so a change to either would compare equal.')]
+    param()
+    $snap = [hashtable]::new(0, [StringComparer]::Ordinal)
+    # Keyed by the path you would type, so the failure message names something the reader can go
+    # and look at. A second kind of state, if one ever earns its place, is a second key prefix
+    # here rather than a second comparison someone has to remember to invert correctly.
+    foreach ($item in Get-ChildItem env:) { $snap["env:$($item.Name)"] = [string]$item.Value }
+    return $snap
+}
+
+$before = Get-ProcessStateSnapshot
+
+$files = @(Get-ChildItem (Join-Path $root 'tests') -Filter *.Tests.ps1 |
+        Sort-Object Name -Descending | ForEach-Object FullName)
+# Refuse to certify order-independence over fewer than two files. Reversing a list of one yields
+# the same list, so the run would pass without ever having exercised a second order -- the shape
+# of green this whole script exists to distrust.
+if ($files.Count -lt 2) {
+    throw ("Found $($files.Count) test file(s) under $(Join-Path $root 'tests'): reversing that " +
+        'exercises no second order, so a pass here would certify nothing.')
+}
+
+Import-Module (Join-Path $root 'PSComplexity.psd1') -Force
+$cfg = New-PesterConfiguration
+$cfg.Run.Path = $files
+$cfg.Run.PassThru = $true
+$cfg.Output.Verbosity = 'None'
+# Match the other gates: the classic `Should -Be` form is an error here too.
+$cfg.Should.DisableV5 = $true
+$result = Invoke-Pester -Configuration $cfg
+
+# Pester is asked for a specific list; a file silently dropped from it would leave the run green
+# over less than it was given, and the count is the only place that shows.
+if ($result.Containers.Count -ne $files.Count) {
+    throw ("Asked Pester for $($files.Count) test file(s) and it ran $($result.Containers.Count). " +
+        'A reversed run over a subset proves nothing about the whole.')
+}
+
+. (Join-Path $PSScriptRoot 'ReleaseDecisions.ps1')
+$fault = Get-PSCxTestRunFault -FailedCount $result.FailedCount `
+    -ContainerResult @($result.Containers | ForEach-Object { [string]$_.Result }) `
+    -ContainerName @($result.Containers | ForEach-Object { Split-Path $_.Item -Leaf })
+if ($fault) {
+    throw ("$fault This is the suite in REVERSE file order. If it passes alphabetically, the " +
+        'failure is not in the test that reported it -- it is in what ran before it.')
+}
+
+$stateFault = Get-PSCxProcessStateFault -Before $before -After (Get-ProcessStateSnapshot)
+if ($stateFault) { throw $stateFault }
+
+Write-Output ("Order independence: $($files.Count) test file(s) reversed, " +
+    "$($result.PassedCount) test(s) passed, environment unchanged.")


### PR DESCRIPTION
Closes #101.

This project runs its own tests in **two** orders and nothing checked they agree.
`Invoke-Pester ./tests` discovers files alphabetically; the mutation baseline runs the mapped
covering suites in the order `psmutant.self.config.json` lists them:

```
config order:  Cognitive, Measure, Cyclomatic, Report
alphabetical:  Cognitive, Cyclomatic, Measure, Report
```

`Measure` and `Cyclomatic` swap. A developer running the suite by hand and the gate running it
never see the same sequence, so an order-dependent suite is green in one and red in the other.
Not hypothetical: the sibling spent three CI rounds on a variable one file cleared in an
`AfterEach` and never restored.

## Two checks, failing on opposite ends of the same problem

**The reversed run catches a dependency by its symptom.** It is a probe rather than a proof —
one more permutation, not all of them — so a dependency whose two files keep their relative
order under reversal survives it. Stated in the script rather than implied.

**The environment comparison catches the cause, and is direction-blind.** Anything a file leaves
behind is visible to every file after it, so a leak is order-dependence waiting for a reader,
and this fires on the file that *leaks* whether or not anything reads it yet. That is the half
the reversed run misses, and **the half that shipped in the sibling**.

Keys are named and values are **never printed**. An environment variable holds tokens as often
as it holds flags, and this message goes into a log anyone can read. There is a test for that
specifically, and a mutant that prints the value beside the key is killed by it.

## Two kinds of state were tried and rejected

Both measured, both recorded in the script rather than left to be rediscovered:

- **The working directory cannot fire.** Pester restores it around a run — verified with a test
  that wanders off with `Set-Location`, passes, and still leaves the location unchanged.
- **Global variables fire on a clean suite.** Pester promotes every `-ForEach` case table to
  global scope, so a green run already adds `CognitiveCases`, `CyclomaticCases`, `SpecCases` and
  more. Keeping the check would mean an allowlist that grows with the tests it is watching.

A check that cannot fire and a check that always fires are the same defect wearing different
clothes. Neither was written and left in.

## Refusals, because a pass has to mean something

- **Fewer than two test files** — reversing a list of one is the same list, so the run would
  pass without exercising a second order at all.
- **Pester returning fewer containers than it was given paths** — a reversed run over a subset
  proves nothing about the whole.

## The decision is pure and tested

`Get-PSCxProcessStateFault` lives in `ReleaseDecisions.ps1` with **eight** tests. `tools/` is
outside `sandboxSubtrees` and is never mutated, so tests are the only thing between an inverted
comparison and a gate that has quietly stopped being able to fail. Five hand-written mutants,
all killed:

| Mutant | |
|---|---|
| `-cne` weakened to `-ne` (case blindness) | KILLED |
| added/removed membership inverted | KILLED |
| reports only the first kind of change | KILLED |
| the fault is never returned | KILLED |
| the value printed beside the key | KILLED |

The `-cne` one has a test written for it specifically: `'true'` vs `'TRUE'` is the single input
that tells the two operators apart.

## Every check verified by making it fail — on the shipped code, not a draft

| Sabotage | |
|---|---|
| an order dependency (early file sets, late file reads) | **CAUGHT** by the reversed run |
| a leak nothing reads | **CAUGHT** as `added: env:PSCX_LEAK` |
| a clobbered `PATH` | **CAUGHT** as `changed: env:PATH` |
| a single test file | **CAUGHT** by the refusal |

An earlier draft also keyed `cwd` into the snapshot; the sabotage for it came back **MISSED**,
which is how the Pester-restores-the-location finding above was made. It was removed rather than
kept as an assertion that reads like coverage and is not.

## Notes

`PSUseLiteralInitializerForHashtable` is suppressed locally with its reason: the literal `@{}` is
case-**insensitive**, which is the one property this map must not have — on Linux `PATH` and
`Path` are two different variables the literal would silently merge into one entry. The repo has
zero settings-file exclusions and this does not add one.

The CI step runs on **both** platforms: only one of them reaches the mutation gate at all.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 336 passed, 0 failed, all 7 containers built |
| Order independence | 7 files reversed, 336 passed, environment unchanged |
| Coverage | 100% over 670 commands |
| Analyzer | clean |
| Complexity | passes |
| Release consistency | consistent at 0.4.0 |

No `src/` change, so self-mutation is unaffected. Once this and #103 land, #39's Guards section
wants a pass.