### PR TITLE
perf: give Ast.ps1 a covering suite that does not measure real source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ keys it holds could not distinguish units the tool could.
 
 ### Internal
 
+- **`src/Ast.ps1` has its own covering suite, taking about ten minutes off the self-mutation gate.**
+  It was mapped to two suites and paid for both on each of its 57 mutants -- 39% of the whole gate,
+  for a file that only parses and walks and never touches a disk. `tests/Ast.Tests.ps1` runs in two
+  seconds against those suites' 22, and kills all 57.
+
+  Dropping the second suite instead was measured and refused: it scores 84% **and** shrinks the set
+  to 50 mutants, because `coveredLinesOnly` sees fewer covered lines. The acceptance test for a move
+  like this is the same mutant count *and* the same verdicts -- a score on its own cannot tell a
+  clean run from a smaller one.
+
 - **The policy layer is its own two files, and the reason is measured.** Acceptances and baselines
   share a unit-identity key, so they share `src/Policy.ps1`; reading and writing the baseline file
   is I/O, so it sits in `src/BaselineFile.ps1` and the deciding half stays pure. Both have their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ under both. Tracked in **#10**.
 ## Layout
 
 ```
-src/Ast.ps1                    unit discovery, attribution, nesting depth. Shared.
+src/Ast.ps1                    unit discovery, attribution, nesting depth. Shared. Pure: it
+                               parses and walks, and never touches a disk -- which is what lets
+                               tests/Ast.Tests.ps1 cover it in two seconds.
 src/Cyclomatic.ps1             decision-point counting.
 src/Cognitive.ps1              the SonarSource metric (B1 structural, B2 nesting, B3 level).
 src/Policy.ps1                 which units are excused from the ceilings, and on what terms:
@@ -84,9 +86,23 @@ guessed.** Every mutant of a file re-runs that file's covering suite, so the gat
 and that is the right price for what it proves -- but it is the wrong price to pay 100+ times.
 
 That is why `src/Policy.ps1` and `src/BaselineFile.ps1` exist as separate files with their own
-suites rather than sitting in `Measure-PSComplexity.ps1`. Measured, not assumed: Policy's 125
-mutants cost **19 minutes** against the measuring suite and **59 seconds** against a pure one,
-and moving the two baseline-file functions out took another eight minutes off. The end-to-end
+suites rather than sitting in `Measure-PSComplexity.ps1`, and why `src/Ast.ps1` has
+`tests/Ast.Tests.ps1`. Measured, not assumed: Policy's 125 mutants cost **19 minutes** against the
+measuring suite and **59 seconds** against a pure one; moving the two baseline-file functions out
+took another eight minutes off; and Ast's 57 mutants went from **~22s each** -- it was mapped to
+*two* suites and paid for both -- to a suite that runs in 2 seconds.
+
+**The obvious cheaper fix for Ast was tried first and is provably wrong, which is worth knowing
+before anyone proposes it again.** Simply dropping the second suite gives 84% and **50** mutants
+where there were 57: with fewer covered lines, `coveredLinesOnly` produces fewer candidates. A
+smaller set scoring the same is precisely the failure this project exists to find in other people's
+code. So the acceptance test for moving a file to a cheaper suite is **two** numbers, not one --
+the same mutant COUNT and the same verdicts. A score alone cannot tell the two apart.
+
+The eight mutants only the expensive suite had been killing were all in the naming and identity
+functions, which the cheap sibling suite never exercised because it tests scores rather than names.
+That is the general shape: when one suite covers something only incidentally, moving to a cheaper
+one means writing the assertions that were never written. The end-to-end
 proofs did not move -- `Measure.Tests.ps1` still drives all of it through `Test-PSComplexity`,
 because covering a function is not covering its application and neither gate can tell the
 difference. They are simply not what each mutant pays for.

--- a/psmutant.self.config.json
+++ b/psmutant.self.config.json
@@ -18,8 +18,7 @@
   "_tests_comment": "A covering suite is re-run once per mutant of the file it covers, so it has to be CHEAP as well as complete. Policy.ps1 maps to its own tests/Policy.Tests.ps1 rather than to Measure.Tests.ps1, which also drives it end to end: against the measuring suite its 125 mutants cost 19 minutes, and against the pure one they cost 59 seconds. The end-to-end proofs did not move; they are simply not what each mutant pays for. NOTE: a _-prefixed key is exempt only at the TOP level -- inside this object it is read as a mutate path and the run dies looking for a file named after the comment.",
   "tests": {
     "src/Ast.ps1": [
-      "tests/Cognitive.Tests.ps1",
-      "tests/Measure.Tests.ps1"
+      "tests/Ast.Tests.ps1"
     ],
     "src/BaselineFile.ps1": [
       "tests/BaselineFile.Tests.ps1"

--- a/tests/Ast.Tests.ps1
+++ b/tests/Ast.Tests.ps1
@@ -1,0 +1,336 @@
+# The AST walk: what a unit is, what it is called, and how deep a node sits inside it.
+#
+# The COVERING SUITE for src/Ast.ps1, and cheap on purpose -- everything here parses a string and
+# calls a function. Nothing writes a file or measures a directory.
+#
+# That is the whole reason it exists. Ast.ps1 was mapped to Cognitive.Tests.ps1 AND
+# Measure.Tests.ps1 and paid for both on every one of its 57 mutants, at roughly 22s a mutant --
+# 39% of the entire gate, for a file whose functions never touch a disk. Measured, not assumed.
+#
+# Dropping the second suite instead was tried first and is provably wrong: with Cognitive.Tests
+# alone the score falls to 84% AND the mutant set shrinks from 57 to 50, because coveredLinesOnly
+# sees fewer covered lines. A smaller set scoring the same is exactly the failure this project
+# exists to find. So the eight mutants only the expensive suite killed are covered HERE instead,
+# directly -- all eight are in the naming and identity functions, which Cognitive.Tests never
+# exercised because it tests scores rather than names.
+#
+# The end-to-end proofs did not move: tests/Measure.Tests.ps1 still drives all of this through
+# Measure-PSComplexity. Covering a function is not covering its application.
+
+BeforeAll {
+    $src = Join-Path (Split-Path -Parent $PSScriptRoot) 'src'
+    # Every src file, discovered rather than listed. A hand-kept list here is a second copy
+    # of the one in PSComplexity.psm1, and this is the copy that goes stale -- a file
+    # missing from it fails with 'term not recognized' in whichever test happens to call
+    # into it, which reads as a broken test rather than an unloaded file. Order does not
+    # matter: every cross-file reference sits in a function body and resolves at call time.
+    foreach ($f in Get-ChildItem $src -Filter *.ps1) { . $f.FullName }
+
+    function script:Tree { param([string]$Code)
+        return [System.Management.Automation.Language.Parser]::ParseInput($Code, [ref]$null, [ref]$null)
+    }
+    function script:Nodes { param($Ast, [string]$TypeName)
+        # Collect everything, then filter. The obvious form puts $TypeName inside the FindAll
+        # predicate and needs .GetNewClosure() to bind it -- which the analyzer cannot see
+        # through, so it reports the parameter as unused. Filtering outside the predicate keeps
+        # the reference where both PowerShell and PSScriptAnalyzer can find it.
+        return @($Ast.FindAll({ param($n) $null -ne $n }, $true) |
+                Where-Object { $_.GetType().Name -eq $TypeName })
+    }
+    function script:FirstNode { param($Ast, [string]$TypeName) return (Nodes $Ast $TypeName)[0] }
+    # Unit names carry an @offset suffix, which is deliberate and unstable across fixtures.
+    function script:Bare { param([string]$Name) return ($Name -replace '@\d+$', '') }
+}
+
+Describe 'Resolve-PSCxUnitBoundary' {
+    It 'returns a plain function unchanged' {
+        $fn = FirstNode (Tree 'function Get-Thing { 1 }') 'FunctionDefinitionAst'
+        [object]::ReferenceEquals((Resolve-PSCxUnitBoundary -Boundary $fn), $fn) | Should-BeTrue
+    }
+
+    It 'resolves a method body up to the MEMBER that knows the class name' {
+        # A class method's body is itself a FunctionDefinitionAst nested inside the
+        # FunctionMemberAst. Both own a body, so without this the same method is discovered
+        # twice, once unqualified.
+        $t = Tree 'class Widget { [int] Render() { return 1 } }'
+        $body = FirstNode $t 'FunctionDefinitionAst'
+        (Resolve-PSCxUnitBoundary -Boundary $body).GetType().Name | Should-Be 'FunctionMemberAst'
+    }
+}
+
+Describe 'Get-PSCxUnitBoundary' {
+    It 'finds the nearest enclosing function' {
+        $t = Tree 'function Get-Thing { if ($x) { 1 } }'
+        (Get-PSCxUnitBoundary -Node (FirstNode $t 'IfStatementAst')).Name | Should-Be 'Get-Thing'
+    }
+
+    It 'returns nothing for code at file scope' {
+        # Paired with the case above: top-level code has no owner, and that is what makes
+        # <script-body> a unit rather than an error.
+        $t = Tree 'if ($x) { 1 }'
+        Get-PSCxUnitBoundary -Node (FirstNode $t 'IfStatementAst') | Should-BeNull
+    }
+
+    It 'stops at the NEAREST owner, not the outermost' {
+        $t = Tree 'function Outer { function Inner { if ($x) { 1 } } }'
+        (Get-PSCxUnitBoundary -Node (FirstNode $t 'IfStatementAst')).Name | Should-Be 'Inner'
+    }
+}
+
+Describe 'Get-PSCxDisplayName' {
+    # Where the gate's most expensive coverage gap was. Three of the eight mutants that only
+    # Measure.Tests.ps1 killed live in this function, and all three are about the ORDINAL that
+    # disambiguates same-named units.
+
+    It 'leaves a unique name alone' {
+        $out = Get-PSCxDisplayName -OrderedKeys @('Get-A@0', 'Get-B@10')
+        $out['Get-A@0'] | Should-Be 'Get-A'
+        $out['Get-B@10'] | Should-Be 'Get-B'
+    }
+
+    It 'suffixes EVERY member of a duplicate group, the first one included' {
+        # Were only the second suffixed, adding an overload would silently rename the first --
+        # and a baseline keyed on the name would then describe a different unit.
+        $out = Get-PSCxDisplayName -OrderedKeys @('Get-A@0', 'Get-A@10')
+        $out['Get-A@0'] | Should-Be 'Get-A#1'
+        $out['Get-A@10'] | Should-Be 'Get-A#2'
+    }
+
+    It 'numbers a group of two, which is the boundary' {
+        # The count test is -gt 1. Written -gt 2 a PAIR gets no ordinal at all and the two units
+        # merge under one name; that mutant survives any fixture with three or more duplicates,
+        # so the discriminating group size is exactly two.
+        $out = Get-PSCxDisplayName -OrderedKeys @('Dup@0', 'Dup@5')
+        @($out.Values | Sort-Object) -join ',' | Should-Be 'Dup#1,Dup#2'
+    }
+
+    It 'counts UP, so a group of three numbers 1, 2, 3' {
+        # The running count is `1 + [int]$counts[...]`. Flip that + to - and the counts go
+        # negative, -gt 1 is never true, and no group is ever numbered.
+        $out = Get-PSCxDisplayName -OrderedKeys @('Dup@0', 'Dup@5', 'Dup@9')
+        @($out.Values | Sort-Object) -join ',' | Should-Be 'Dup#1,Dup#2,Dup#3'
+    }
+
+    It 'groups on the bare name, ignoring the offset suffix' {
+        # The keys differ (@0, @5) and the names do not. Strip the wrong thing and nothing is
+        # ever a duplicate.
+        (Get-PSCxDisplayName -OrderedKeys @('Same@0', 'Same@5')).Values |
+            Should-NotContainCollection 'Same'
+    }
+
+    It 'keeps distinct names distinct even when one group repeats' {
+        $out = Get-PSCxDisplayName -OrderedKeys @('Dup@0', 'Dup@5', 'Solo@9')
+        $out['Solo@9'] | Should-Be 'Solo'
+    }
+
+    It 'returns an empty map for no keys' {
+        (Get-PSCxDisplayName -OrderedKeys @()).Count | Should-Be 0
+    }
+}
+
+Describe 'Get-PSCxUnitOwnName' {
+    It 'names a function by its own name' {
+        $fn = FirstNode (Tree 'function Get-Thing { 1 }') 'FunctionDefinitionAst'
+        Get-PSCxUnitOwnName -Boundary $fn | Should-Be 'Get-Thing'
+    }
+
+    It 'qualifies a class member with its class' {
+        $m = FirstNode (Tree 'class Widget { [int] Render() { return 1 } }') 'FunctionMemberAst'
+        Get-PSCxUnitOwnName -Boundary $m | Should-Be 'Widget.Render'
+    }
+
+    It 'names a constructor after its class, twice' {
+        $m = FirstNode (Tree 'class Order { Order() { $this.X = 1 } }') 'FunctionMemberAst'
+        Get-PSCxUnitOwnName -Boundary $m | Should-Be 'Order.Order'
+    }
+}
+
+Describe 'Get-PSCxUnitName' {
+    It 'qualifies a nested function with the one enclosing it' {
+        # A bare name is not unique: Get-Inner defined inside two different outer functions
+        # produced two rows reading the same, so anything keyed on the name merged them.
+        $t = Tree 'function Outer { function Inner { 1 } }'
+        $inner = @(Nodes $t 'FunctionDefinitionAst' | Where-Object Name -eq 'Inner')[0]
+        Bare (Get-PSCxUnitName -Boundary $inner) | Should-Be 'Outer/Inner'
+    }
+
+    It 'does not qualify a top-level function with anything' {
+        $fn = FirstNode (Tree 'function Solo { 1 }') 'FunctionDefinitionAst'
+        Bare (Get-PSCxUnitName -Boundary $fn) | Should-Be 'Solo'
+    }
+
+    It 'never names a class method twice, although its body is a unit owner too' {
+        # The walk resolves each enclosing owner before comparing, so the member and its own
+        # body do not both contribute. Unresolved, this reads 'Widget.Render/Widget.Render'.
+        $m = FirstNode (Tree 'class Widget { [int] Render() { return 1 } }') 'FunctionMemberAst'
+        Bare (Get-PSCxUnitName -Boundary $m) | Should-Be 'Widget.Render'
+    }
+
+    It 'qualifies a function nested inside a class method' {
+        $t = Tree 'class Widget { [int] Render() { function Helper { 1 } ; return 1 } }'
+        $h = @(Nodes $t 'FunctionDefinitionAst' | Where-Object Name -eq 'Helper')[0]
+        Bare (Get-PSCxUnitName -Boundary $h) | Should-Be 'Widget.Render/Helper'
+    }
+
+    It 'suffixes the START OFFSET, so two units on ONE line stay distinct' {
+        # A line is not unique. Two functions written on one physical line shared a key and had
+        # their scores ADDED, so the file reported a unit that exists nowhere in the source.
+        $t = Tree 'function A { 1 } ; function B { 2 }'
+        $names = @(Nodes $t 'FunctionDefinitionAst' | ForEach-Object { Get-PSCxUnitName -Boundary $_ })
+        @($names | Sort-Object -Unique).Count | Should-Be 2
+        $names[0] | Should-MatchString '@\d+$'
+    }
+}
+
+Describe 'Get-PSCxUnitKey' {
+    It 'is the unit name inside a function' {
+        $t = Tree 'function Get-Thing { if ($x) { 1 } }'
+        Bare (Get-PSCxUnitKey -Node (FirstNode $t 'IfStatementAst')) | Should-Be 'Get-Thing'
+    }
+
+    It 'is the script-body key for code outside any unit' {
+        # The name avoids angle brackets on purpose: Pester 6 reads <...> in a test name as a
+        # -ForEach placeholder and fails to build the block.
+        # The paired half, and the one that matters: forcing the boundary test true means no
+        # node is ever attributed to the script body, so top-level decisions land on whichever
+        # unit happens to be nearby.
+        $t = Tree 'if ($x) { 1 }'
+        Get-PSCxUnitKey -Node (FirstNode $t 'IfStatementAst') | Should-Be '<script-body>'
+    }
+}
+
+Describe 'Get-PSCxNesting' {
+    It 'is zero for a decision directly inside a unit' {
+        $t = Tree 'function F { if ($x) { 1 } }'
+        Get-PSCxNesting -Node (FirstNode $t 'IfStatementAst') | Should-Be 0
+    }
+
+    It 'counts each nesting-raising ancestor' {
+        $t = Tree 'function F { if ($a) { if ($b) { if ($c) { 1 } } } }'
+        $inner = @(Nodes $t 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $inner | Should-Be 2
+    }
+
+    It 'stops at the unit boundary rather than counting through it' {
+        # A function declared inside three ifs starts its own count at zero. Walking past the
+        # boundary would charge a nested helper for the nesting of the code around it.
+        $t = Tree 'if ($a) { if ($b) { function F { if ($c) { 1 } } } }'
+        $inner = @(Nodes $t 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $inner | Should-Be 0
+    }
+}
+
+Describe 'Get-PSCxUnitTable' {
+    It 'always contains the script body, at line 1' {
+        # The line is a literal 1. A decision-free file must still report a unit, and it must
+        # report it at the top of the file rather than wherever the first node happens to sit.
+        $t = Get-PSCxUnitTable -Ast (Tree '$x = 1')
+        $t['<script-body>'] | Should-Be 1
+    }
+
+    It 'lists every function with its start line' {
+        $code = "function A { 1 }`nfunction B { 2 }"
+        $t = Get-PSCxUnitTable -Ast (Tree $code)
+        $lines = @($t.GetEnumerator() | Where-Object { (Bare $_.Key) -eq 'B' } | ForEach-Object Value)
+        $lines[0] | Should-Be 2
+    }
+
+    It 'lists a class method once, qualified' {
+        $t = Get-PSCxUnitTable -Ast (Tree 'class Widget { [int] Render() { return 1 } }')
+        @($t.Keys | ForEach-Object { Bare $_ } | Where-Object { $_ -eq 'Widget.Render' }).Count |
+            Should-Be 1
+    }
+
+    It 'counts an INITIALISED property as a unit' {
+        # There is code in an initialiser, so there is something to measure.
+        $t = Get-PSCxUnitTable -Ast (Tree 'class Widget { [int] $Size = 3 }')
+        @($t.Keys | ForEach-Object { Bare $_ }) | Should-ContainCollection 'Widget.Size'
+    }
+
+    It 'does NOT count an uninitialised property' {
+        $t = Get-PSCxUnitTable -Ast (Tree 'class Widget { [int] $Size }')
+        @($t.Keys | ForEach-Object { Bare $_ }) | Should-NotContainCollection 'Widget.Size'
+    }
+
+    It 'does NOT count an enum member, however it is written' {
+        # An enum member is a PropertyMemberAst too, and an initialised one would otherwise
+        # become a unit while a bare one would not -- making an enum's complexity depend on
+        # whether anyone numbered its members. A label is not code.
+        #
+        # BOTH members, because the guard is `(-not $isEnumMember) -and [bool]$x.InitialValue`:
+        # flip that -and to -or and the numbered member comes back as a unit while the bare one
+        # still does not, so a fixture with only one of the two cannot tell them apart.
+        $t = Get-PSCxUnitTable -Ast (Tree 'enum Colour { Red = 1 ; Green }')
+        $names = @($t.Keys | ForEach-Object { Bare $_ })
+        $names | Should-NotContainCollection 'Colour.Red'
+        $names | Should-NotContainCollection 'Colour.Green'
+        # And the paired half: an ordinary class property with the same shape IS a unit, so
+        # this is not passing because nothing is ever counted.
+        $c = Get-PSCxUnitTable -Ast (Tree 'class Palette { [int] $Red = 1 }')
+        @($c.Keys | ForEach-Object { Bare $_ }) | Should-ContainCollection 'Palette.Red'
+    }
+
+    It 'keeps two same-named units apart by offset' {
+        $t = Get-PSCxUnitTable -Ast (Tree 'function Dup { 1 } ; function Dup { 2 }')
+        @($t.Keys | Where-Object { (Bare $_) -eq 'Dup' }).Count | Should-Be 2
+    }
+}
+
+Describe 'Get-PSCxEnclosingFunctionName' {
+    It 'names the nearest enclosing function' {
+        $t = Tree 'function Get-Thing { Get-Thing }'
+        Get-PSCxEnclosingFunctionName -Node (FirstNode $t 'CommandAst') | Should-Be 'Get-Thing'
+    }
+
+    It 'is null inside a class method, so recursion is not attributed to an outer function' {
+        # A bare command inside a method is a command lookup, never a call to the method.
+        $t = Tree 'function Outer { class W { [int] M() { Outer ; return 1 } } }'
+        Get-PSCxEnclosingFunctionName -Node (FirstNode $t 'CommandAst') | Should-BeNull
+    }
+
+    It 'is null at file scope' {
+        Get-PSCxEnclosingFunctionName -Node (FirstNode (Tree 'Get-Thing') 'CommandAst') |
+            Should-BeNull
+    }
+}
+
+Describe 'Get-PSCxEnclosingMethod' {
+    It 'returns the member for a node inside a class method' {
+        $t = Tree 'class W { [int] M() { if ($x) { return 1 } return 0 } }'
+        (Get-PSCxEnclosingMethod -Node (FirstNode $t 'IfStatementAst')).Name | Should-Be 'M'
+    }
+
+    It 'is null inside an ordinary function' {
+        $t = Tree 'function F { if ($x) { 1 } }'
+        Get-PSCxEnclosingMethod -Node (FirstNode $t 'IfStatementAst') | Should-BeNull
+    }
+}
+
+Describe 'Test-PSCxFlowCommand' {
+    It 'is true for a control-flow cmdlet' {
+        Test-PSCxFlowCommand -Node (FirstNode (Tree 'Where-Object { $_ }') 'CommandAst') |
+            Should-BeTrue
+    }
+
+    It 'is true for the alias spelling too' {
+        # Matched on the name as WRITTEN: % and ForEach-Object are one command at run time and
+        # different text to a static walk.
+        Test-PSCxFlowCommand -Node (FirstNode (Tree '1..3 | % { $_ }') 'CommandAst') |
+            Should-BeTrue
+    }
+
+    It 'is false for an ordinary command' {
+        Test-PSCxFlowCommand -Node (FirstNode (Tree 'Get-Item x') 'CommandAst') | Should-BeFalse
+    }
+
+    It 'is false for a node that is not a command at all' {
+        Test-PSCxFlowCommand -Node (FirstNode (Tree 'if ($x) { 1 }') 'IfStatementAst') |
+            Should-BeFalse
+    }
+
+    It 'is false for a command invoked through a variable, which has no name' {
+        # `& $cmd` has no command name. There is deliberately no null guard for it -- -contains
+        # already answers false -- and a guard would be unreachable by any observation.
+        Test-PSCxFlowCommand -Node (FirstNode (Tree '& $cmd 1') 'CommandAst') | Should-BeFalse
+    }
+}


### PR DESCRIPTION
Closes #96. **Self-mutation gate: 28.8 -> 21.3 minutes.**

`src/Ast.ps1` was mapped to **both** `Cognitive.Tests.ps1` and `Measure.Tests.ps1` and paid for
both on every one of its 57 mutants -- about 22s each, **39% of the whole gate**, for a file that
only parses and walks and never touches a disk.

The gate costs *mutants x suite*, and `Measure.Tests.ps1` is 18s because it measures real files:

| file | mutants | suite | share |
|---|---|---|---|
| `Measure-PSComplexity.ps1` | 77 | 18.0s | 42% |
| **`Ast.ps1`** | **57** | **22.6s** (two suites) | **39%** |
| `Cognitive.ps1` | 77 | 4.6s | 11% |
| everything else | 227 | ≤2.1s | 8% |

`tests/Ast.Tests.ps1` runs in **2 seconds** and kills all 57.

## The obvious fix is provably wrong, and that is the part worth keeping

Simply dropping the second suite was tried first:

```
AST with ONE suite:  50 mutants, killed 42, score 84%
```

Not just 8 lost kills -- **50 mutants where there were 57**. With fewer covered lines,
`coveredLinesOnly` produces fewer candidates, so the run would have got faster *partly by measuring
less*. A smaller set scoring the same is exactly the failure this project exists to find in other
people's code.

**So the acceptance test for a move like this is two numbers, not one: the same mutant COUNT and
the same verdicts.** A score alone cannot tell a clean run from a smaller one. Verified at both
scopes:

```
AST with the NEW cheap suite:  57 mutants (want 57), killed 57, score 100%,  45.2s
FULL GATE:                    438 mutants (want 438), killed 438, score 100%, 21.3 min
```

## What the eight mutants were, and why they hid

All in **naming and identity**: `Get-PSCxDisplayName`'s duplicate-name ordinal (3),
`Get-PSCxUnitName`'s qualification walk, `Get-PSCxUnitKey`'s `<script-body>` fallback, and
`Get-PSCxUnitTable`'s enum-member guard (3).

`Cognitive.Tests.ps1` tests **scores**, not **names**, so identity was covered only *incidentally*,
end to end, through the slowest suite in the repo. That is the general shape of this work: moving
to a cheaper suite means writing the assertions nobody had written. Each of the eight now has a
test aimed at it, with the discriminating input named in the comment -- the ordinal boundary needs
a group of exactly **two**, for instance, because `-gt 2` survives any fixture with three.

The end-to-end proofs did not move. `Measure.Tests.ps1` still drives all of this through
`Measure-PSComplexity`, because covering a function is not covering its application and neither
gate can tell the difference.

## Two notes on the suite itself

- **Pester 6 reads `<...>` in a test name as a `-ForEach` placeholder**, so the script-body test
  cannot be named after the key it asserts -- the block fails to build, with an error about
  `Create` rather than about the name.
- **The `Nodes` helper filters after `FindAll`** rather than closing over `$TypeName` inside the
  predicate. The closure form needs `.GetNewClosure()` to bind it, which PSScriptAnalyzer cannot
  see through and reports as an unused parameter.

## Gates

| Gate | Result |
|---|---|
| Unit tests | 492 passed, 0 failed, all 11 containers |
| Coverage | 100% over 845 commands |
| Self-mutation | **438/438, 100%**, 21.3 min |
| Complexity | passes |
| Analyzer | clean |
| Order independence | 11 files reversed, environment unchanged |
| Release consistency | consistent at 0.4.0 |

## What is left

I estimated ~10.5 min saved and got 7.5 -- the cost model over-attributed to Ast, since mutants run
warm and `coveredLinesOnly` trims more than it assumed. Recorded because the model is now the basis
for judging the next lever.

`Measure-PSComplexity.ps1` is the remaining big term at 77 mutants x 18s. Two levers left: move its
pure functions (`Get-PSCxRelativePath`, `Get-PSCxUnitRecord`) to a cheap suite, and make
`Measure.Tests.ps1` itself cheaper -- it writes fixtures per Describe today.