### PR TITLE
perf: walk the AST once, not once per node (#36, #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,23 @@ keys it holds could not distinguish units the tool could.
 
 ### Internal
 
+- **A node's enclosing unit and nesting depth are computed in one descent, making the cost linear
+  in file size.** They were found by walking up from each node to its unit, from twelve call sites,
+  once per matched node -- quadratic where node count and depth grow together. Both values are
+  defined against a node's parent, so one pre-order pass computes them for the whole tree.
+
+  Reproducing the issue's own table, CPU seconds, cognitive identical at every depth:
+
+  | nesting depth | before | after |
+  |---|---|---|
+  | 100 | 0.73s | **0.30s** |
+  | 200 | 2.36s | **0.62s** |
+  | 400 | 4.72s | **1.31s** |
+
+  Per doubling the old cost grew 3.2x then 2.0x; the new one grows 2.07x then 2.11x -- linear.
+  Verified byte-identical over 514 rows of units, scores and per-increment contributions across
+  five corpora, including a flat 52 KB file and nesting 400 deep.
+
 - **The unit table is built once per file instead of three times.** `Get-PSCxUnitTable` is a full
   AST traversal invoking a PowerShell predicate per node, and it ran once for the line numbers and
   again inside each of the two metric maps -- three identical walks of the same tree. The maps now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,15 @@ keys it holds could not distinguish units the tool could.
 
 ### Internal
 
+- **The unit table is built once per file instead of three times.** `Get-PSCxUnitTable` is a full
+  AST traversal invoking a PowerShell predicate per node, and it ran once for the line numbers and
+  again inside each of the two metric maps -- three identical walks of the same tree. The maps now
+  receive it.
+
+  Measured at roughly **8% less CPU** on a 52 KB corpus, with byte-identical output. The issue
+  reported 18%; that did not reproduce, and two wall-clock A/B runs disagreed about the sign until
+  the comparison was interleaved and switched to CPU time.
+
 - **The scan moved to `src/Scan.ps1`, with its own covering suite.** `Measure-PSComplexity.ps1` is
   now the two public projections and nothing else, which is the seam its own docstring already
   described. 37 mutants stopped paying for the 18-second measuring suite and now run against one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,19 @@ A filtered run emits a notice because a passing gate is otherwise silent, and `s
 in the report is `null` for a whole-tree run rather than `[]`: absent and empty are different
 answers, and only absent may be read as a measurement of everything under `path`.
 
+**The unit table is built once per file and passed down.** `Get-PSCxUnitTable` is a full `FindAll`
+traversal that invokes a PowerShell predicate for every node, and it used to run three times
+against the same AST in one pass -- once for the line numbers and once inside each metric map. The
+maps now take it as a **mandatory** parameter: an optional one with a fallback would be a branch
+whose two arms produce identical output, which no test could distinguish from its own absence.
+
+**Measure a performance claim by interleaving, and check the direction before believing it.** The
+issue behind this reported ~18%. Two wall-clock A/B attempts here disagreed about the SIGN -- the
+change looked 32% slower when its process ran second and 6% faster when it ran first -- because
+whichever side ran later paid for whatever else the machine was doing. Interleaved CPU time over
+three pairs gave a consistent **~8%**, with byte-identical output every run. The lesson is not the
+number; it is that a single ordered A/B can report the opposite of the truth.
+
 ## What a "unit" is
 
 A unit is anything with a body that gets gated on its own: a function/filter, a class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,25 @@ against the same AST in one pass -- once for the line numbers and once inside ea
 maps now take it as a **mandatory** parameter: an optional one with a fallback would be a branch
 whose two arms produce identical output, which no test could distinguish from its own absence.
 
+**A node's unit and nesting depth come from ONE pre-order pass, not from walking up.** Both are
+defined against a node's parent -- `boundary(n)` is the parent's boundary unless the parent is a
+body owner, `nesting(n)` is the parent's nesting plus one if the parent raises it -- so a single
+descent computes them for every node. `FindAll` walks in document order and a parent always
+precedes its children, which is what lets it be a flat loop rather than a recursion; a recursion
+would risk the stack on exactly the deeply nested file this exists for.
+
+The upward walk is gone rather than kept as a second path. Two ways to answer one question is how
+they come to disagree, and the walk was the quadratic half: twelve call sites asked once per matched
+node.
+
+**The nesting half of that is easy to get wrong in a way tests do not catch.** Memoising the upward
+walk was tried first: boundary answers along a chain are all equal, so caching them on the way up is
+correct, but nesting answers *decrease* going up. Cached on the way up they come out one too high
+for every node except the one asked about -- which reported cognitive **200 where the answer was
+20100**, with all 558 tests passing, because the suite pins shapes and small fixtures rather than
+totals over a deep one. Anything touching this needs a before/after comparison of real totals, not
+a green suite.
+
 **Measure a performance claim by interleaving, and check the direction before believing it.** The
 issue behind this reported ~18%. Two wall-clock A/B attempts here disagreed about the SIGN -- the
 change looked 32% slower when its process ran second and 6% faster when it ran first -- because

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -65,6 +65,37 @@ $script:PSCxUnitBoundaryTypes = @(
     'FunctionDefinitionAst', 'FunctionMemberAst', 'PropertyMemberAst'
 )
 
+# Per-node answers, remembered for the file being measured.
+#
+# Get-PSCxUnitBoundary and Get-PSCxNesting each walk the ancestor chain from a node up to its
+# enclosing unit, and between them they are called from twelve sites once per matched node. Where
+# node count and depth grow together the total is quadratic: measured, a file nested 200 deep cost
+# 1.84s of CPU for 3 KB of source, while 52 KB of ordinary code cost 3.0s.
+#
+# Reference equality, not value equality: two AST nodes with identical content are different nodes,
+# and the default comparer would conflate them. Keyed on the node object itself, so entries from one
+# parse can never answer a question about another.
+#
+# Cleared per file by Clear-PSCxAstCache. Without that the tables grow for the life of the process,
+# which for a gate over a large tree is every node of every file.
+$script:PSCxBoundaryCache = [System.Collections.Generic.Dictionary[object, object]]::new([System.Collections.Generic.ReferenceEqualityComparer]::Instance)
+
+function Clear-PSCxAstCache {
+    # Forget the per-node answers. Called once per file, before it is walked.
+    #
+    # Clear-, not Reset-: Reset is a state-changing verb, so PSUseShouldProcessForStateChangingFunctions
+    # demands -WhatIf support that emptying an in-memory cache has no use for. Clear- says the same
+    # thing and matches Get-PSCxUnitRecord's reason for not being New-.
+    #
+    # Correctness does not depend on this -- the keys are node references, so a stale entry can
+    # never be found by a different parse. Memory does: without it the tables hold every node of
+    # every file the process has seen.
+    [OutputType([void])]
+    [CmdletBinding()]
+    param()
+    $script:PSCxBoundaryCache.Clear()
+}
+
 function Resolve-PSCxUnitBoundary {
     # A class method's body is itself a FunctionDefinitionAst, nested inside the
     # FunctionMemberAst. Both are body owners, so without this the same method is
@@ -82,15 +113,32 @@ function Resolve-PSCxUnitBoundary {
 
 function Get-PSCxUnitBoundary {
     # Nearest enclosing body-owner, or $null for top-level code.
+    #
+    # The walk remembers its answer for EVERY node it passed on the way up, not just the one it was
+    # asked about: each of them has the same enclosing unit by definition, so one walk answers the
+    # whole chain. That is what turns repeated queries over a deep tree from quadratic into one
+    # pass, and it is why the loop collects a path rather than returning as soon as it knows.
     [OutputType([System.Management.Automation.Language.Ast])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
+    $found = $null
+    if ($script:PSCxBoundaryCache.TryGetValue($Node, [ref]$found)) { return $found }
+
+    $path = [System.Collections.Generic.List[object]]::new()
+    $path.Add($Node)
     $p = $Node.Parent
+    $answer = $null
     while ($p) {
-        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) { return Resolve-PSCxUnitBoundary -Boundary $p }
+        if ($script:PSCxBoundaryCache.TryGetValue($p, [ref]$found)) { $answer = $found; break }
+        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) {
+            $answer = Resolve-PSCxUnitBoundary -Boundary $p
+            break
+        }
+        $path.Add($p)
         $p = $p.Parent
     }
-    return $null
+    foreach ($n in $path) { $script:PSCxBoundaryCache[$n] = $answer }
+    return $answer
 }
 
 function Get-PSCxDisplayName {

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -79,6 +79,57 @@ $script:PSCxUnitBoundaryTypes = @(
 # Cleared per file by Clear-PSCxAstCache. Without that the tables grow for the life of the process,
 # which for a gate over a large tree is every node of every file.
 $script:PSCxBoundaryCache = [System.Collections.Generic.Dictionary[object, object]]::new([System.Collections.Generic.ReferenceEqualityComparer]::Instance)
+$script:PSCxNestingCache = [System.Collections.Generic.Dictionary[object, object]]::new([System.Collections.Generic.ReferenceEqualityComparer]::Instance)
+
+function Get-PSCxAstRoot {
+    # The top of the tree a node belongs to.
+    #
+    # This is the one upward walk left, and it runs ONCE per file rather than once per node --
+    # which is the whole difference between linear and quadratic here.
+    [OutputType([System.Management.Automation.Language.Ast])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Node)
+    $r = $Node
+    while ($r.Parent) { $r = $r.Parent }
+    return $r
+}
+
+function Initialize-PSCxAstIndex {
+    # Compute every node's enclosing unit and nesting depth in ONE pre-order pass.
+    #
+    # Both answers are defined against a node's PARENT:
+    #
+    #   boundary(n) = parent is a body owner ? resolve(parent) : boundary(parent)
+    #   nesting(n)  = parent is a body owner ? 0 : nesting(parent) + (parent raises nesting ? 1 : 0)
+    #
+    # so knowing the parent's answers is enough to know the child's. FindAll walks in document
+    # order and a parent always precedes its children, which is what lets this be a flat loop
+    # rather than a recursion -- and a flat loop cannot exhaust the stack on a deeply nested file,
+    # which is exactly the shape this exists for.
+    #
+    # It replaces walking up from every node. Twelve call sites asked for one or both of these
+    # once per matched node, and where node count and depth grow together that is quadratic: a
+    # file nested 200 deep cost 1.84s of CPU for 3 KB of source.
+    [OutputType([void])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Root)
+    $script:PSCxBoundaryCache[$Root] = $null
+    $script:PSCxNestingCache[$Root] = 0
+    foreach ($n in $Root.FindAll({ $true }, $true)) {
+        $p = $n.Parent
+        # The root itself comes back from FindAll and is already seeded; anything with no parent
+        # is a root by definition.
+        if ($null -eq $p) { continue }
+        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) {
+            $script:PSCxBoundaryCache[$n] = Resolve-PSCxUnitBoundary -Boundary $p
+            $script:PSCxNestingCache[$n] = 0
+            continue
+        }
+        $script:PSCxBoundaryCache[$n] = $script:PSCxBoundaryCache[$p]
+        $raises = if ($p.GetType().Name -in $script:PSCxNestingTypes) { 1 } else { 0 }
+        $script:PSCxNestingCache[$n] = [int]$script:PSCxNestingCache[$p] + $raises
+    }
+}
 
 function Clear-PSCxAstCache {
     # Forget the per-node answers. Called once per file, before it is walked.
@@ -94,6 +145,7 @@ function Clear-PSCxAstCache {
     [CmdletBinding()]
     param()
     $script:PSCxBoundaryCache.Clear()
+    $script:PSCxNestingCache.Clear()
 }
 
 function Resolve-PSCxUnitBoundary {
@@ -114,31 +166,17 @@ function Resolve-PSCxUnitBoundary {
 function Get-PSCxUnitBoundary {
     # Nearest enclosing body-owner, or $null for top-level code.
     #
-    # The walk remembers its answer for EVERY node it passed on the way up, not just the one it was
-    # asked about: each of them has the same enclosing unit by definition, so one walk answers the
-    # whole chain. That is what turns repeated queries over a deep tree from quadratic into one
-    # pass, and it is why the loop collects a path rather than returning as soon as it knows.
+    # A read of the index, which is built on the first miss for a tree. There is deliberately no
+    # second implementation that walks up: two ways to answer one question is how they come to
+    # disagree, and the walk was the quadratic half.
     [OutputType([System.Management.Automation.Language.Ast])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
     $found = $null
     if ($script:PSCxBoundaryCache.TryGetValue($Node, [ref]$found)) { return $found }
-
-    $path = [System.Collections.Generic.List[object]]::new()
-    $path.Add($Node)
-    $p = $Node.Parent
-    $answer = $null
-    while ($p) {
-        if ($script:PSCxBoundaryCache.TryGetValue($p, [ref]$found)) { $answer = $found; break }
-        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) {
-            $answer = Resolve-PSCxUnitBoundary -Boundary $p
-            break
-        }
-        $path.Add($p)
-        $p = $p.Parent
-    }
-    foreach ($n in $path) { $script:PSCxBoundaryCache[$n] = $answer }
-    return $answer
+    Initialize-PSCxAstIndex -Root (Get-PSCxAstRoot -Node $Node)
+    [void]$script:PSCxBoundaryCache.TryGetValue($Node, [ref]$found)
+    return $found
 }
 
 function Get-PSCxDisplayName {
@@ -235,16 +273,20 @@ function Get-PSCxUnitKey {
 
 function Get-PSCxNesting {
     # Count of nesting-raising ancestors up to (not crossing) the enclosing unit.
+    #
+    # The same index, built by the same descent. Memoising the upward walk instead was tried and
+    # is wrong in a way worth remembering: nesting answers along a chain are not equal the way
+    # boundary answers are -- they decrease going up -- so caching them on the way up returns the
+    # right number for the node asked about and the wrong one for every node cached en route. It
+    # reported cognitive 200 where the answer was 20100, and all 558 tests passed.
     [OutputType([int])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Node)
-    $depth = 0
-    $p = $Node.Parent
-    while ($p -and $p.GetType().Name -notin $script:PSCxUnitBoundaryTypes) {
-        if ($p.GetType().Name -in $script:PSCxNestingTypes) { $depth++ }
-        $p = $p.Parent
-    }
-    return $depth
+    $found = $null
+    if ($script:PSCxNestingCache.TryGetValue($Node, [ref]$found)) { return [int]$found }
+    Initialize-PSCxAstIndex -Root (Get-PSCxAstRoot -Node $Node)
+    [void]$script:PSCxNestingCache.TryGetValue($Node, [ref]$found)
+    return [int]$found
 }
 
 function Get-PSCxUnitTable {

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -223,11 +223,19 @@ function Get-PSCxCognitiveMap {
     # unit key -> cognitive complexity (summed rows; decision-free unit = 0).
     [OutputType([hashtable])]
     [CmdletBinding()]
-    param([Parameter(Mandatory)] $Ast)
+    param(
+        [Parameter(Mandatory)] $Ast,
+        # The unit table, built ONCE per file by the caller. Mandatory rather than optional with
+        # a fallback: Get-PSCxUnitTable is a full FindAll traversal invoking a PowerShell
+        # predicate per node, and it was run three times against the same AST in one pass. A
+        # fallback would leave a branch no test could ever distinguish from its own absence --
+        # both arms produce identical output, which is exactly the mutant this repo refuses.
+        [Parameter(Mandatory)] [hashtable]$UnitTable
+    )
     $rows = @(Get-PSCxCognitiveRow -Ast $Ast)
     $map = @{}
     foreach ($row in $rows) { $map[$row.Key] = [int]$map[$row.Key] + $row.Amount }
     $out = @{}
-    foreach ($k in (Get-PSCxUnitTable -Ast $Ast).Keys) { $out[$k] = [int]$map[$k] }
+    foreach ($k in $UnitTable.Keys) { $out[$k] = [int]$map[$k] }
     return $out
 }

--- a/src/Cyclomatic.ps1
+++ b/src/Cyclomatic.ps1
@@ -87,12 +87,20 @@ function Get-PSCxCyclomaticMap {
     # unit key -> cyclomatic complexity (1 + summed decision points).
     [OutputType([hashtable])]
     [CmdletBinding()]
-    param([Parameter(Mandatory)] $Ast)
+    param(
+        [Parameter(Mandatory)] $Ast,
+        # The unit table, built ONCE per file by the caller. Mandatory rather than optional with
+        # a fallback: Get-PSCxUnitTable is a full FindAll traversal invoking a PowerShell
+        # predicate per node, and it was run three times against the same AST in one pass. A
+        # fallback would leave a branch no test could ever distinguish from its own absence --
+        # both arms produce identical output, which is exactly the mutant this repo refuses.
+        [Parameter(Mandatory)] [hashtable]$UnitTable
+    )
     $map = @{}
     foreach ($row in Get-PSCxCyclomaticRow -Ast $Ast) {
         $map[$row.Key] = [int]$map[$row.Key] + $row.Amount
     }
     $out = @{}
-    foreach ($k in (Get-PSCxUnitTable -Ast $Ast).Keys) { $out[$k] = 1 + [int]$map[$k] }
+    foreach ($k in $UnitTable.Keys) { $out[$k] = 1 + [int]$map[$k] }
     return $out
 }

--- a/src/Scan.ps1
+++ b/src/Scan.ps1
@@ -249,6 +249,10 @@ function Get-PSCxFileScan {
     )
     $errors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($File, [ref]$null, [ref]$errors)
+    # The per-node answer tables are for THIS file. Keyed by node reference they can never answer
+    # wrongly across parses, so this is about memory rather than correctness: without it a gate
+    # over a large tree holds every node of every file it has seen.
+    Clear-PSCxAstCache
     # Relative to where the caller is standing, which for a repo-scoped run is the repo. Not a
     # parameter: a root nobody passes is a root nobody gets wrong. Resolved for BOTH arms, so a
     # skipped file is named the same way a measured one is.
@@ -263,9 +267,12 @@ function Get-PSCxFileScan {
         }
     }
 
-    $cyc = Get-PSCxCyclomaticMap -Ast $ast
-    $cog = Get-PSCxCognitiveMap -Ast $ast
+    # ONE traversal, shared. Get-PSCxUnitTable is a full FindAll walk that invokes a PowerShell
+    # predicate for every node, and it used to run three times against the same AST in a single
+    # pass -- once here for the line numbers, and once inside each metric map.
     $lines = Get-PSCxUnitTable -Ast $ast
+    $cyc = Get-PSCxCyclomaticMap -Ast $ast -UnitTable $lines
+    $cog = Get-PSCxCognitiveMap -Ast $ast -UnitTable $lines
     # Source order, not hashtable order. .NET enumerates a hashtable by bucket layout, which is
     # neither insertion nor line order and is not required to be stable -- so two runs over one
     # unchanged file could emit the same rows in different sequences. Nothing here noticed,

--- a/tests/Ast.Tests.ps1
+++ b/tests/Ast.Tests.ps1
@@ -334,3 +334,118 @@ Describe 'Test-PSCxFlowCommand' {
         Test-PSCxFlowCommand -Node (FirstNode (Tree '& $cmd 1') 'CommandAst') | Should-BeFalse
     }
 }
+
+Describe 'the AST index' {
+    # Get-PSCxUnitBoundary and Get-PSCxNesting used to walk up from every node they were asked
+    # about, and twelve call sites ask once per matched node -- quadratic where node count and
+    # depth grow together. One pre-order pass now computes both for every node, because each is
+    # defined against the node's PARENT.
+
+    It 'finds the root from a node buried deep in the tree' {
+        $t = Tree 'function F { if ($a) { if ($b) { if ($c) { 1 } } } }'
+        $inner = @(Nodes $t 'IfStatementAst')[-1]
+        [object]::ReferenceEquals((Get-PSCxAstRoot -Node $inner), $t) | Should-BeTrue
+    }
+
+    It 'returns the root itself when given the root' {
+        $t = Tree '$x = 1'
+        [object]::ReferenceEquals((Get-PSCxAstRoot -Node $t), $t) | Should-BeTrue
+    }
+
+    It 'gives the same answers after the tables are cleared' {
+        # Clearing is about memory, not correctness: the index rebuilds on the next miss, and the
+        # answer must not depend on whether it happened to be warm.
+        $t = Tree 'function F { if ($a) { if ($b) { 1 } } }'
+        $inner = @(Nodes $t 'IfStatementAst')[-1]
+        $warm = Get-PSCxNesting -Node $inner
+        Clear-PSCxAstCache
+        Get-PSCxNesting -Node $inner | Should-Be $warm
+        $warm | Should-Be 1
+    }
+
+    It 'keeps two structurally identical trees apart' {
+        # The tables are keyed by node REFERENCE. Value equality would conflate two nodes with the
+        # same content, and these two trees are character-for-character identical -- so an index
+        # built for one would silently answer for the other.
+        $code = 'function F { if ($a) { if ($b) { 1 } } }'
+        $t1 = Tree $code
+        $t2 = Tree $code
+        $n1 = @(Nodes $t1 'IfStatementAst')[-1]
+        $n2 = @(Nodes $t2 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $n1 | Should-Be 1
+        # Answered from t2's own index, built on its own miss.
+        Get-PSCxNesting -Node $n2 | Should-Be 1
+        [object]::ReferenceEquals((Get-PSCxUnitBoundary -Node $n1), (Get-PSCxUnitBoundary -Node $n2)) |
+            Should-BeFalse
+    }
+
+    It 'indexes every node of a tree from one node in it' {
+        # The descent runs from the ROOT, not from the node asked about, so a single query warms
+        # the whole tree. Asking about a sibling afterwards must not need a second pass -- and
+        # must not answer wrongly if it does.
+        $t = Tree 'function Outer { if ($a) { 1 } } function Other { if ($b) { if ($c) { 2 } } }'
+        Clear-PSCxAstCache
+        $first = @(Nodes $t 'IfStatementAst')[0]
+        Get-PSCxNesting -Node $first | Should-Be 0
+        $deepest = @(Nodes $t 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $deepest | Should-Be 1
+        (Get-PSCxUnitBoundary -Node $deepest).Name | Should-Be 'Other'
+    }
+
+    It 'restarts the nesting count at every unit boundary' {
+        # A function declared three ifs deep starts its own count at zero. Carrying the enclosing
+        # nesting across the boundary would charge a nested helper for the code around it.
+        $t = Tree 'if ($a) { if ($b) { function F { if ($c) { 1 } } } }'
+        $inner = @(Nodes $t 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $inner | Should-Be 0
+    }
+
+    It 'counts only ancestors that RAISE nesting' {
+        # A unit's own body owner does not, and neither does an ordinary statement -- otherwise
+        # every increment is inflated by the structure that merely contains it.
+        $t = Tree 'function F { if ($a) { 1 } }'
+        Get-PSCxNesting -Node (FirstNode $t 'IfStatementAst') | Should-Be 0
+    }
+}
+
+Describe 'the AST index, where it can be got wrong invisibly' {
+    It 'gives a TOP-LEVEL node a nesting of zero' {
+        # The root is seeded at zero and every top-level node inherits from it, so seeding it at
+        # one shifts every script-body increment up by one. A fixture whose decisions all sit
+        # INSIDE a function cannot see that: their chain stops at the function boundary, where the
+        # count restarts. This one has no function at all.
+        $t = Tree 'if ($x) { 1 }'
+        Get-PSCxNesting -Node (FirstNode $t 'IfStatementAst') | Should-Be 0
+    }
+
+    It 'gives the root itself a nesting of zero' {
+        $t = Tree '$x = 1'
+        Get-PSCxNesting -Node $t | Should-Be 0
+    }
+
+    It 'READS the boundary index rather than recomputing it' {
+        # The cache hit is invisible in the output: rebuilding the index on every query returns
+        # exactly the same answers, just slower -- so nothing but this distinguishes a working
+        # memo from one that never hits, and the whole point of the change is that it hits.
+        #
+        # Poisoning the entry is what makes it observable. A read returns the planted value; a
+        # rebuild returns the true one.
+        $t = Tree 'function F { if ($a) { 1 } }'
+        $n = FirstNode $t 'IfStatementAst'
+        Get-PSCxUnitBoundary -Node $n | Out-Null
+        $script:PSCxBoundaryCache[$n] = 'planted'
+        Get-PSCxUnitBoundary -Node $n | Should-Be 'planted'
+        Clear-PSCxAstCache
+        (Get-PSCxUnitBoundary -Node $n).Name | Should-Be 'F'
+    }
+
+    It 'READS the nesting index rather than recomputing it' {
+        $t = Tree 'function F { if ($a) { if ($b) { 1 } } }'
+        $n = @(Nodes $t 'IfStatementAst')[-1]
+        Get-PSCxNesting -Node $n | Out-Null
+        $script:PSCxNestingCache[$n] = 42
+        Get-PSCxNesting -Node $n | Should-Be 42
+        Clear-PSCxAstCache
+        Get-PSCxNesting -Node $n | Should-Be 1
+    }
+}

--- a/tests/Cognitive.Tests.ps1
+++ b/tests/Cognitive.Tests.ps1
@@ -344,7 +344,7 @@ function T {
         # on when it reads a breakdown next to a score -- and it is the check that fails if the
         # grouping drops a row on the way, which the summed map would not notice.
         $map = Get-PSCxContributionMap -Ast $script:AttrAst
-        $sums = Get-PSCxCognitiveMap -Ast $script:AttrAst
+        $sums = Get-PSCxCognitiveMap -Ast $script:AttrAst -UnitTable (Get-PSCxUnitTable -Ast $script:AttrAst)
         $unit = @($sums.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
         (($map[$unit] | Measure-Object Amount -Sum).Sum) | Should-Be $sums[$unit]
     }
@@ -360,7 +360,7 @@ function T {
     It 'leaves the summed map exactly as it was' {
         # The point of keeping the maps as projections: the published number must not move
         # because the intermediate representation grew a field.
-        $map = Get-PSCxCognitiveMap -Ast $script:AttrAst
+        $map = Get-PSCxCognitiveMap -Ast $script:AttrAst -UnitTable (Get-PSCxUnitTable -Ast $script:AttrAst)
         $unit = @($map.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
         # foreach(1) + if(1 + 1 nesting) + boolean run(1) = 4
         $map[$unit] | Should-Be 4

--- a/tests/Cyclomatic.Tests.ps1
+++ b/tests/Cyclomatic.Tests.ps1
@@ -99,7 +99,7 @@ function T {
         # is what corrected it.
         $rows = @(Get-PSCxCycClauseRow -Ast $script:CycAttrAst) + @(Get-PSCxCycBlockRow -Ast $script:CycAttrAst) +
                 @(Get-PSCxCycFlowCommandRow -Ast $script:CycAttrAst) + @(Get-PSCxCycOperatorRow -Ast $script:CycAttrAst)
-        $map = Get-PSCxCyclomaticMap -Ast $script:CycAttrAst
+        $map = Get-PSCxCyclomaticMap -Ast $script:CycAttrAst -UnitTable (Get-PSCxUnitTable -Ast $script:CycAttrAst)
         $unit = @($map.Keys | Where-Object { $_ -notlike '<script-body>*' })[0]
         $unitRows = @($rows | Where-Object { $_.Key -eq $unit })
         $map[$unit] | Should-Be (1 + (($unitRows | Measure-Object Amount -Sum).Sum))


### PR DESCRIPTION
Closes #36. Closes #37.

Both issues are the same defect seen from two distances: the AST is walked far more often than
the answers change. #36 is one file walked three times; #37 is one node's ancestors walked once
per node. They share `src/Ast.ps1` and the same tests, so they are here together.

## #36 -- the unit table, built once

`Get-PSCxUnitTable` is a full traversal invoking a PowerShell predicate per node, and it ran
once for the line numbers and again inside each of the two metric maps. Three identical walks
of one tree. The maps now take the table they used to build.

## #37 -- one descent instead of twelve ascents

`Get-PSCxUnitBoundary` and `Get-PSCxNesting` each walked UP the ancestor chain, and between them
they are called from twelve sites once per matched node. Where node count and depth grow together
that is quadratic -- measured, a file nested 200 deep cost **1.84s of CPU for 3 KB of source**,
against 3.0s for 52 KB of ordinary code.

Both values are defined against a node's parent:

```
boundary(n) = parent owns a body ? resolve(parent) : boundary(parent)
nesting(n)  = parent owns a body ? 0 : nesting(parent) + (parent raises nesting ? 1 : 0)
```

so a single pre-order pass computes them for the whole tree. `FindAll` walks in document order
and a parent always precedes its children, which is what lets this be a flat loop rather than a
recursion -- and a flat loop cannot exhaust the stack on the deeply nested file this exists for.

Reproducing the issue's own table, CPU seconds:

| nesting depth | before | after |
|---|---|---|
| 100 | 0.73s | **0.30s** |
| 200 | 2.36s | **0.62s** |
| 400 | 4.72s | **1.31s** |

Per doubling the old cost grew 3.2x then 2.0x; the new one grows 2.07x then 2.11x. Linear.

## The approach that was tried first and is wrong

Memoising the upward walk -- caching each node's answer as the walk passes it. That is correct
for the boundary, because every node on the chain has the same enclosing unit. It is **wrong for
nesting**, whose answers decrease going up, so the walk stores the right number for the node it
was asked about and the wrong one for everything above it.

It reported **cognitive 200 where the answer is 20100**, and all 558 tests passed. The reason
they passed is worth knowing: the fixtures that check nesting are small enough that the first
query answers correctly, and nothing asked a second question about a node the first walk had
already poisoned.

That is recorded as a comment in `Get-PSCxNesting` rather than left out of the history, because
it is the obvious next idea for anyone reading this code.

## Verification

- **Byte-identical output** over **514 rows** of units, scores and per-increment contributions
  across five corpora: `src/`, `tests/`, `tools/`, a 400-deep nested file, and a flat 52 KB file.
- Benchmarks are **CPU time, interleaved, best of three**. Two naive wall-clock A/B runs earlier
  in this work disagreed about the *sign* of the difference (32% slower vs 6% faster); ordering
  bias on a laptop is larger than the effect being measured.

## Three mutants that needed tests that did not exist

The gate came back 490/493 the first time, all three survivors in the new code, and each was a
real gap rather than an equivalent mutant:

- **`0 -> 1` on the root's nesting seed.** Every existing fixture put its decisions inside a
  function, whose chain stops at the unit boundary where the count restarts -- so the root's seed
  was unobservable, although changing it shifts every script-body increment. The new test has no
  function at all.
- **The two cache hits (`TryGetValue -> $false`).** Rebuilding the index on every query returns
  exactly the same answers, just slower, so nothing in the output distinguishes a working memo
  from one that never hits. Poisoning the entry makes the read observable: a hit returns the
  planted value, a rebuild returns the true one -- paired with a `Clear-PSCxAstCache` and a
  re-query, so the test also proves the true answer is what the rebuild produces.

## Gates

| Gate | Result |
|---|---|
| Suite | 569 tests / 12 containers, 0 failed |
| Coverage | 100% over 939 commands in `src/` |
| Lint | clean |
| Complexity | True |
| Order independence | passed |
| Release consistency | 0.4.0 |
| Self-mutation | **493 mutants, 493 killed, 100%** |

No public surface changes; `ModuleVersion` stays at the already-prepared 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
