### PR TITLE
ci: compare the two repos' CI with a shared rule set (#56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,17 @@ jobs:
           Import-Module ./PSComplexity.psd1 -Force
           Get-Command Measure-PSComplexity, Test-PSComplexity -ErrorAction Stop | Out-Null
 
+      # Early, because it is a text check costing under a second and the alternative is learning
+      # that a workflow lost its timeout after sixteen minutes of mutation testing.
+      #
+      # It watches THIS directory for drift from the sibling module's, which nothing did: the two
+      # repos gate each other, so their CI is assumed comparable, and it was not -- in thirteen
+      # ways at once. Each workflow reads fine on its own, which is why only a shared rule set
+      # catches it.
+      - name: CI parity (the capabilities both repos share)
+        shell: pwsh
+        run: ./tools/Test-PSCxCiParity.ps1
+
       - name: Release consistency (ModuleVersion, CHANGELOG, ReleaseNotes)
         shell: pwsh
         # -CheckGallery here and not locally: the question is whether this version has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
+### Internal
+
+- **The CI capabilities this repo shares with PSMutant are now checked by a rule set rather than
+  remembered.** The two modules gate each other, so their pipelines are assumed comparable; they
+  were thirteen capabilities apart, and nothing compared them, because every workflow reads fine on
+  its own and a gap is only visible from outside either repository.
+
+  `tools/Test-PSCxCiParity.ps1` runs in CI and by hand, over `.github/workflows/`. The rules are
+  stated as shape rather than by file name, so `tools/ParityDecisions.ps1` is byte-identical in both
+  repos apart from the command prefix -- which makes diffing the two copies the comparison, and
+  makes declining a rule a deletion somebody has to argue for rather than a silence.
+
+  It found a real gap on its first run against the sibling: PSMutant's publish workflow ran the
+  suite with the classic `Should` syntax still legal while its merge gate forbade it.
+
 ## [0.4.0] - 2026-08-23
 
 ### For consumers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ CI (`.github/workflows/ci.yml`) runs:
 | Gate | What it is |
 |---|---|
 | Lint | `tools/Invoke-PSCxAnalyzer.ps1` — **every severity**, and it throws. The same script code scanning and publish run |
+| CI parity | `tools/Test-PSCxCiParity.ps1` — the capabilities this repo and PSMutant both promise, checked over `.github/workflows/` |
 | Unit tests | whole `tests/` directory, 0 failures |
 | Order independence | `tools/Test-PSCxOrderIndependence.ps1` -- the same suite again, reversed, plus an environment comparison |
 | Complexity | **its own** `Test-PSComplexity` against `src/`, 15 / 15 per unit |
@@ -320,6 +321,32 @@ and expensive to rebuild, and because each one has already earned its keep.
   here and every other script in `tools/` prints that way. The sibling project made the opposite
   choice -- it excludes the rule because its gate scripts print for a living -- so this is the
   one part of its design not to copy across. Porting it failed this gate on its own first run.
+
+- **The two repositories' CI is compared by a rule set, not by memory.** This module and PSMutant
+  gate each other, which makes it easy to assume their pipelines are comparable. They were not --
+  thirteen capabilities apart at once, and *nothing compared them*, because each workflow reads
+  perfectly well on its own and a gap is only visible from outside either repo.
+
+  `tools/Test-PSCxCiParity.ps1` checks `.github/workflows/` against the shared rules in
+  `tools/ParityDecisions.ps1`: every job carries a `timeout-minutes`, every workflow a concurrency
+  group and a `permissions` block, `publish.yml` never cancels in progress, every action pinned to a
+  SHA with the version in a trailing comment, no version written out where `pins.env` should be
+  read, no lint spelled inline, every Pester configuration disabling the classic `Should` syntax,
+  and `ci.yml` running a matrix over both operating systems with `fail-fast: false`.
+
+  **The rules are stated as shape, never by file name**, so `ParityDecisions.ps1` is byte-identical
+  in both repos apart from the command prefix. That is the whole mechanism: **diffing the two copies
+  IS the comparison**, and declining a rule becomes a deletion somebody has to argue for in a diff
+  rather than a silence. Add a rule here and the sibling fails it until it adopts or declines it.
+
+  It reads **comment-stripped** text, which is not fussiness: PSMutant's `code-scanning.yml` spends
+  six lines of prose on `Invoke-ScriptAnalyzer` explaining why it does *not* call it, and a grep
+  reads that as an inline lint gate. It is text rather than parsed YAML because PowerShell ships no
+  YAML parser, and pinning one would add a dependency to the gate that watches the dependencies.
+
+  The rule set found a real gap on its first run: PSMutant's `publish.yml` ran the suite with the
+  classic `Should` syntax still legal while its `ci.yml` forbade it -- a publish-time gate weaker
+  than the merge gate, which is the direction that matters.
 
 - **An acceptance is a checkable claim, and there must never be a plain suppression beside
   it.** `-Accept` names one unit by file AND unit, carries a written argument, and the gate

--- a/tests/Parity.Tests.ps1
+++ b/tests/Parity.Tests.ps1
@@ -1,0 +1,262 @@
+# The CI parity gate's decisions.
+#
+# This file exists because of the shape of the thing it guards: every rule in ParityDecisions.ps1
+# is a claim about text that is nearly always compliant, so a rule that stopped being able to fire
+# would look exactly like a repository that passes. Each rule therefore gets a compliant fixture
+# AND one that breaks precisely that rule -- the pairing this repo already requires of every
+# "this is filtered" assertion, for the same reason.
+
+BeforeAll {
+    . (Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath 'tools/ParityDecisions.ps1')
+
+    # A workflow that satisfies every rule. Single-quoted so ${{ matrix.os }} and $env: survive: in
+    # a double-quoted here-string PowerShell reads ${ as the start of a variable name, and the
+    # fixture would stop resembling the file it stands in for.
+    function script:GoodCi {
+        $t = @'
+name: CI
+concurrency:
+  group: ci-ref
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Load pinned versions
+        run: |
+          if (-not $pins[$k]) { throw ".github/pins.env is missing a value for $k" }
+      - name: Install pinned modules
+        run: |
+          Install-Module Pester -RequiredVersion $env:PESTER_VERSION -Force -Scope CurrentUser
+      - name: Tests
+        run: |
+          $cfg = New-PesterConfiguration
+          $cfg.Should.DisableV5 = $true
+'@
+        return @($t -split "`r?`n")
+    }
+
+    function script:GoodPublish {
+        $t = @'
+name: Publish
+concurrency:
+  group: publish
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+'@
+        return @($t -split "`r?`n")
+    }
+
+    # One line changed, everything else compliant: a fixture that breaks two rules cannot tell you
+    # which one fired. Contains, not -like -- an anchor here holds `os: [ubuntu-latest, ...]`, and
+    # in a wildcard those brackets are a character class matching a single character, so the anchor
+    # would silently match nothing and the test would assert against an unmodified file.
+    function script:Broken {
+        param([string[]]$Line, [string]$Find, [string]$Replace)
+        $hit = $false
+        $out = foreach ($l in $Line) {
+            if (-not $hit -and $l.Contains($Find)) { $hit = $true; $l.Replace($Find, $Replace) } else { $l }
+        }
+        if (-not $hit) { throw "fixture anchor '$Find' not found -- the test would assert against an unchanged file" }
+        return @($out)
+    }
+
+    function script:CiFact { param([string[]]$Line) Get-PSCxWorkflowFact -Name 'ci.yml' -Line $Line }
+    function script:PubFact { param([string[]]$Line) Get-PSCxWorkflowFact -Name 'publish.yml' -Line $Line }
+
+    function script:Faults {
+        param([string[]]$Ci, [string[]]$Pub)
+        $c = if ($Ci) { $Ci } else { GoodCi }
+        $p = if ($Pub) { $Pub } else { GoodPublish }
+        return @(Get-PSCxParityFault -Fact @((CiFact $c), (PubFact $p)))
+    }
+}
+
+Describe 'Get-PSCxWorkflowCode' {
+    It 'drops a trailing comment' {
+        (Get-PSCxWorkflowCode -Line @('  timeout-minutes: 30 # generous')) -join '' |
+            Should-Be '  timeout-minutes: 30'
+    }
+
+    It 'drops a whole-line comment' {
+        (Get-PSCxWorkflowCode -Line @('   # Invoke-ScriptAnalyzer is NOT called here')).Trim() |
+            Should-Be ''
+    }
+
+    It 'keeps a hash that opens no comment' {
+        # The kept half. Without it a stripper that deleted every line from the first hash would
+        # satisfy the two cases above, and every rule would then read a truncated workflow.
+        (Get-PSCxWorkflowCode -Line @("if (`$t.StartsWith('#')) { continue }")) -join '' |
+            Should-BeLikeString '*continue*'
+    }
+}
+
+Describe 'Get-PSCxWorkflowFact' {
+    It 'counts one job per runs-on' {
+        (CiFact (GoodCi)).JobCount | Should-Be 1
+    }
+
+    It 'reads the matrix from the os list, not from every mention of a runner' {
+        # `if: matrix.os == 'ubuntu-latest'` names a platform without adding a leg. Counting
+        # mentions would read a Linux-only workflow with one conditional step as a matrix over two.
+        $f = CiFact (Broken -Line (GoodCi) -Find 'os: [ubuntu-latest, windows-latest]' -Replace 'os: [ubuntu-latest]')
+        $f.MatrixOs -join ',' | Should-Be 'ubuntu-latest'
+    }
+
+    It 'judges a uses: line before comments are stripped' {
+        # The version comment is part of what that rule REQUIRES, so reading the stripped text
+        # would report every correctly pinned action as unpinned.
+        (CiFact (GoodCi)).UnpinnedUses.Count | Should-Be 0
+    }
+}
+
+Describe 'the guards every workflow owes' {
+    It 'accepts a compliant workflow' {
+        @(Get-PSCxWorkflowGuardFault -Fact (CiFact (GoodCi))).Count | Should-Be 0
+    }
+
+    It 'catches a job with no timeout' {
+        @(Get-PSCxWorkflowGuardFault -Fact (CiFact (Broken -Line (GoodCi) -Find 'timeout-minutes: 30' -Replace 'x: 30'))) -join ' ' |
+            Should-BeLikeString '*timeout-minutes*'
+    }
+
+    It 'catches a missing concurrency group' {
+        @(Get-PSCxWorkflowGuardFault -Fact (CiFact (Broken -Line (GoodCi) -Find 'concurrency:' -Replace 'x:'))) -join ' ' |
+            Should-BeLikeString '*concurrency group*'
+    }
+
+    It 'catches a missing permissions block' {
+        @(Get-PSCxWorkflowGuardFault -Fact (CiFact (Broken -Line (GoodCi) -Find 'permissions:' -Replace 'x:'))) -join ' ' |
+            Should-BeLikeString '*permissions block*'
+    }
+
+    It 'reports a file with no job once, and stops' {
+        # Every other rule passes over a file this gate cannot read, so the one fault has to be the
+        # shape failure rather than a silent clean bill.
+        $f = @(Get-PSCxWorkflowGuardFault -Fact (CiFact @('name: nothing')))
+        $f.Count | Should-Be 1
+        $f[0] | Should-BeLikeString '*declares no job*'
+    }
+}
+
+Describe 'how a workflow gets its tools' {
+    It 'accepts a compliant workflow' {
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (GoodCi))).Count | Should-Be 0
+    }
+
+    It 'catches an action pinned to a tag' {
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) `
+                        -Find 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1' -Replace 'actions/checkout@v7'))) -join ' ' |
+            Should-BeLikeString '*40-character SHA*'
+    }
+
+    It 'catches a SHA pinned with no version comment' {
+        # The comment is the only thing saying WHICH version a SHA is, and a pin nobody can read is
+        # a pin nobody updates.
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) -Find ' # v7.0.1' -Replace ''))) -join ' ' |
+            Should-BeLikeString '*trailing comment*'
+    }
+
+    It 'catches an install that never asserts the pins arrived' {
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) -Find 'throw ".github/pins.env' -Replace 'Write-Host "'))) -join ' ' |
+            Should-BeLikeString '*pins.env*'
+    }
+
+    It 'leaves a workflow that installs nothing alone' {
+        # The paired half: the publish fixture loads no pins and installs no module, and must not be
+        # failed for it. A rule that fired on every workflow would satisfy the case above without
+        # proving the condition works at all.
+        @(Get-PSCxWorkflowToolingFault -Fact (PubFact (GoodPublish))).Count | Should-Be 0
+    }
+
+    It 'catches a version written out instead of read from the pins file' {
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) `
+                        -Find '-RequiredVersion $env:PESTER_VERSION' -Replace '-RequiredVersion 6.1.0'))) -join ' ' |
+            Should-BeLikeString '*names a version literally*'
+    }
+
+    It 'catches a lint gate spelled out inline' {
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) `
+                        -Find 'Install-Module Pester' -Replace 'Invoke-ScriptAnalyzer -Path ./src #'))) -join ' ' |
+            Should-BeLikeString '*committed script*'
+    }
+
+    It 'catches a Pester configuration that does not disable the classic syntax' {
+        # The rule that found the sibling repository's real gap: its publish gate ran the suite with
+        # classic Should syntax still legal, while its merge gate forbade it.
+        @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) -Find '$cfg.Should.DisableV5 = $true' -Replace '$cfg.Run.Path = 1'))) -join ' ' |
+            Should-BeLikeString '*DisableV5*'
+    }
+}
+
+Describe 'the rules that depend on which workflow it is' {
+    It 'accepts a compliant pair' {
+        (Faults).Count | Should-Be 0
+    }
+
+    It 'refuses to pass over an empty set' {
+        # An empty set satisfies every per-workflow rule, which is the vacuous green this gate
+        # exists to prevent elsewhere.
+        @(Get-PSCxParityFault -Fact @()) -join ' ' | Should-BeLikeString '*compared nothing*'
+    }
+
+    It 'catches a publish that cancels itself' {
+        (Faults -Pub (Broken -Line (GoodPublish) -Find 'cancel-in-progress: false' -Replace 'cancel-in-progress: true')) -join ' ' |
+            Should-BeLikeString '*cannot be withdrawn*'
+    }
+
+    It 'catches a publish whose cancel flag is an expression rather than the literal false' {
+        # An expression is right for CI and wrong here, and it is the value a copy-paste from
+        # ci.yml brings with it.
+        (Faults -Pub (Broken -Line (GoodPublish) -Find 'cancel-in-progress: false' -Replace 'cancel-in-progress: ${{ true }}')) -join ' ' |
+            Should-BeLikeString '*must be the literal false*'
+    }
+
+    It 'catches a single-platform matrix' {
+        (Faults -Ci (Broken -Line (GoodCi) -Find 'os: [ubuntu-latest, windows-latest]' -Replace 'os: [ubuntu-latest]')) -join ' ' |
+            Should-BeLikeString '*windows-latest*'
+    }
+
+    It 'catches fail-fast left on' {
+        (Faults -Ci (Broken -Line (GoodCi) -Find 'fail-fast: false' -Replace 'fail-fast: true')) -join ' ' |
+            Should-BeLikeString '*fail-fast*'
+    }
+
+    It 'catches a missing publish workflow' {
+        @(Get-PSCxParityFault -Fact @((CiFact (GoodCi)))) -join ' ' |
+            Should-BeLikeString '*No publish.yml*'
+    }
+
+    It 'catches a missing ci workflow' {
+        @(Get-PSCxParityFault -Fact @((PubFact (GoodPublish)))) -join ' ' |
+            Should-BeLikeString '*No ci.yml*'
+    }
+}
+
+Describe 'this repository, right now' {
+    It 'holds every capability the shared rule set names' {
+        # The gate itself, against the real files. The synthetic cases above prove the rules can
+        # fire; this proves they are satisfied here, and it is the assertion that fails when
+        # somebody edits a workflow rather than this file.
+        $dir = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath '.github/workflows'
+        $facts = foreach ($f in Get-ChildItem -LiteralPath $dir -Filter *.yml -File) {
+            Get-PSCxWorkflowFact -Name $f.Name -Line @(Get-Content -LiteralPath $f.FullName)
+        }
+        @(Get-PSCxParityFault -Fact @($facts)) -join "`n" | Should-Be ''
+    }
+}

--- a/tools/ParityDecisions.ps1
+++ b/tools/ParityDecisions.ps1
@@ -1,0 +1,196 @@
+# The pass/fail decisions behind the CI parity gate, as pure functions over workflow text.
+#
+# They live apart from the script that reads the files for the same reason the release decisions
+# do: a gate that quietly stops being able to fail looks exactly like a green build, and this one
+# is watching the workflows every other gate runs inside.
+#
+# What this gate is FOR is drift between two repositories, not the correctness of one. PSComplexity
+# and PSMutant gate each other, so it is easy to assume their CI is comparable -- and for a long
+# time it was not, in thirteen ways, with nothing comparing them. The rules below are stated as
+# SHAPE rather than by file name (an action pinned to a SHA, a lint gate that is not spelled
+# inline) so that this file is byte-identical in both repos apart from the command prefix. Diffing
+# the two copies is then the comparison, and a rule one repo declines is a deletion somebody has to
+# argue for in a diff rather than a silence.
+#
+# Text, not a parsed document, and that is a deliberate limitation: PowerShell has no YAML parser
+# in the box, pinning one would add a dependency to the gate that watches the dependencies, and
+# every rule here is about a line that either appears or does not.
+
+function Get-PSCxWorkflowCode {
+    # Workflow text with comments removed, for the rules that ask what a workflow DOES.
+    #
+    # A capability named only in a comment is not a capability, and the two are indistinguishable
+    # to a grep: the sibling repo's code-scanning.yml spends six lines of prose on
+    # Invoke-ScriptAnalyzer explaining why it does NOT call it, which reads as an inline lint gate.
+    #
+    # A hash opens a comment where it starts a line or follows whitespace -- YAML's rule and
+    # PowerShell's. Inside a quoted string it does not, and that case is deliberately NOT handled:
+    # both repos hold one, and no rule here asks about the rest of that line, so the cost is nothing
+    # and the alternative is a quoting parser nobody would trust either.
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$Line)
+    $out = [System.Collections.Generic.List[string]]::new()
+    foreach ($l in $Line) { $out.Add(($l -replace '(^|\s)#.*$', '')) }
+    return $out.ToArray()
+}
+
+function Get-PSCxWorkflowFact {
+    # Everything the rules ask about one workflow, read once.
+    #
+    # Separated from the judging below because the parsing is where a regex is wrong and the judging
+    # is where an inversion hides, and those are worth failing separately.
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [AllowEmptyString()] [string[]]$Line
+    )
+    $code = @(Get-PSCxWorkflowCode -Line $Line)
+
+    $cancel = $null
+    $failFast = $null
+    $os = @()
+    foreach ($l in $code) {
+        if ($l -match 'cancel-in-progress:\s*(.+?)\s*$') { $cancel = $Matches[1] }
+        if ($l -match 'fail-fast:\s*(\S+)') { $failFast = $Matches[1] }
+        # The matrix list itself, not every mention of a runner: `if: matrix.os == 'ubuntu-latest'`
+        # names one without adding a leg, and counting mentions would read a Linux-only workflow
+        # with one conditional step as a matrix over two platforms.
+        if ($l -match '^\s+os:\s*\[(.+)\]') {
+            $os = @($Matches[1] -split ',' | ForEach-Object { $_.Trim().Trim("'", '"') })
+        }
+    }
+
+    [pscustomobject]@{
+        Name = $Name
+        # One runs-on per job, which is how a job is counted without a YAML parser.
+        JobCount            = @($code | Where-Object { $_ -match '^\s+runs-on:' }).Count
+        TimeoutCount        = @($code | Where-Object { $_ -match '^\s*timeout-minutes:' }).Count
+        HasConcurrency      = @($code | Where-Object { $_ -match '^concurrency:' }).Count -gt 0
+        HasConcurrencyGroup = @($code | Where-Object { $_ -match '^\s+group:' }).Count -gt 0
+        CancelInProgress    = $cancel
+        HasPermissions      = @($code | Where-Object { $_ -match '^\s*permissions:' }).Count -gt 0
+        # Raw lines, not the comment-stripped ones: the trailing version comment is part of what
+        # that rule requires, so stripping it first would report every correct pin as unpinned.
+        UnpinnedUses        = @($Line | Where-Object { $_ -match '\buses:' -and $_ -notmatch '@[0-9a-f]{40}\s*#\s*\S' })
+        InstallsModule      = @($code | Where-Object { $_ -match 'Install-Module' }).Count -gt 0
+        LoadsPins           = @($code | Where-Object { $_ -match 'pins\.env' }).Count -gt 0
+        AssertsPins         = @($code | Where-Object { $_ -match 'throw.*pins\.env' }).Count -gt 0
+        VersionLiteral      = @($code | Where-Object { $_ -match '-(?:Required|Minimum)Version\s+["'']?\d+\.\d+' } | ForEach-Object { $_.Trim() })
+        InlineAnalyzer      = @($code | Where-Object { $_ -match 'Invoke-ScriptAnalyzer' }).Count -gt 0
+        PesterConfigCount   = @($code | Where-Object { $_ -match 'New-PesterConfiguration' }).Count
+        DisableV5Count      = @($code | Where-Object { $_ -match 'Should\.DisableV5' }).Count
+        MatrixOs            = $os
+        FailFast            = $failFast
+    }
+}
+
+function Get-PSCxWorkflowGuardFault {
+    # The four guards every workflow owes regardless of what it does.
+    #
+    # Split from the tooling rules below to stay inside the complexity ceiling this repo gates
+    # itself on, and because they fail for different reasons: these are about the RUN -- what it may
+    # cancel, how long it may hold a required check, what token it executes with.
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Fact)
+    $faults = [System.Collections.Generic.List[string]]::new()
+
+    # Every rule below reads a shape this file could not find here, so reporting them all would be
+    # four restatements of one fact. The shape failure is the finding.
+    if ($Fact.JobCount -eq 0) {
+        $faults.Add("$($Fact.Name) declares no job. Either it is not a workflow or the shape this gate reads has changed, and every rule below would pass over it in silence.")
+        return $faults.ToArray()
+    }
+    if ($Fact.TimeoutCount -ne $Fact.JobCount) {
+        $faults.Add("$($Fact.Name) declares $($Fact.JobCount) job(s) and $($Fact.TimeoutCount) timeout-minutes. A wedged runner holds a required check pending for the six-hour default, which blocks every merge behind it.")
+    }
+    if (-not ($Fact.HasConcurrency -and $Fact.HasConcurrencyGroup)) {
+        $faults.Add("$($Fact.Name) declares no concurrency group. A superseded run answers a question nobody is asking any more, and for a publish it is worse: two tags racing on an action that cannot be undone.")
+    }
+    if (-not $Fact.HasPermissions) {
+        $faults.Add("$($Fact.Name) declares no permissions block, so it runs with the default write-scoped token while executing third-party code from the gallery.")
+    }
+    return $faults.ToArray()
+}
+
+function Get-PSCxWorkflowToolingFault {
+    # How a workflow gets its tools, and whether it does its own gating inline.
+    #
+    # Every rule here is a way the two repositories drifted apart before anything compared them: a
+    # version written out in one file and not the other, a lint gate spelled inline in two places
+    # that then disagreed about severity, a Pester configuration missing the one setting that makes
+    # the assertion style enforceable.
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Fact)
+    $faults = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($u in $Fact.UnpinnedUses) {
+        $faults.Add("$($Fact.Name) has an action that is not pinned to a 40-character SHA with the version in a trailing comment: $($u.Trim()). A tag is mutable, and a uses: line cannot read a variable, so this is the one pin no shared file can hold for you.")
+    }
+    if ($Fact.InstallsModule -and -not ($Fact.LoadsPins -and $Fact.AssertsPins)) {
+        $faults.Add("$($Fact.Name) installs a module without loading .github/pins.env and asserting its keys arrived. A missing key installs the latest release or analyses nothing, and both look like a clean run.")
+    }
+    foreach ($v in $Fact.VersionLiteral) {
+        $faults.Add("$($Fact.Name) names a version literally rather than reading it from the pins file: $v. Two workflows agreeing today is not the same as one file they both read.")
+    }
+    if ($Fact.InlineAnalyzer) {
+        $faults.Add("$($Fact.Name) calls Invoke-ScriptAnalyzer directly instead of the committed script both lint gates share. Spelled out in two places they agreed about scope and disagreed about severity, so a finding failed nothing and blocked everything.")
+    }
+    if ($Fact.PesterConfigCount -ne $Fact.DisableV5Count) {
+        $faults.Add("$($Fact.Name) builds $($Fact.PesterConfigCount) Pester configuration(s) but sets Should.DisableV5 on $($Fact.DisableV5Count). Pester 6 keeps the classic Should syntax working, so without it a suite drifts back into a mix one test at a time -- and a gate that permits what the merge gate forbids is not the same gate.")
+    }
+    return $faults.ToArray()
+}
+
+function Get-PSCxParityFault {
+    # Every parity fault across a repository's workflows. Empty means the two repos agree, to the
+    # extent anything here can tell.
+    #
+    # The two role rules are keyed on file NAME, which is the one place this file is not shape-only.
+    # Both repositories call them ci.yml and publish.yml; if that ever stops being true, the
+    # parameter is where it is said rather than an assumption buried in a regex.
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]]$Fact,
+        [string]$CiName = 'ci.yml',
+        [string]$PublishName = 'publish.yml'
+    )
+    $faults = [System.Collections.Generic.List[string]]::new()
+
+    if (-not $Fact) {
+        $faults.Add('No workflows were read, so this gate compared nothing. An empty set passes every rule below, which is the failure it exists to find.')
+        return $faults.ToArray()
+    }
+    foreach ($f in $Fact) {
+        $faults.AddRange([string[]]@(Get-PSCxWorkflowGuardFault -Fact $f))
+        $faults.AddRange([string[]]@(Get-PSCxWorkflowToolingFault -Fact $f))
+    }
+
+    $publish = @($Fact | Where-Object { $_.Name -eq $PublishName })
+    if (-not $publish) {
+        $faults.Add("No $PublishName was found. The irreversible workflow is the one whose guards matter most, so its absence is a fault rather than a repository that happens not to publish.")
+    }
+    elseif ($publish[0].CancelInProgress -ne 'false') {
+        $faults.Add("$PublishName has cancel-in-progress '$($publish[0].CancelInProgress)' where it must be the literal false. A half-finished publish is a gallery version that cannot be withdrawn; its group exists to serialise releases, not to drop them.")
+    }
+
+    $ci = @($Fact | Where-Object { $_.Name -eq $CiName })
+    if (-not $ci) {
+        $faults.Add("No $CiName was found, so nothing here checked the matrix that proves this module on more than one operating system.")
+        return $faults.ToArray()
+    }
+    foreach ($os in 'ubuntu-latest', 'windows-latest') {
+        if ($ci[0].MatrixOs -notcontains $os) {
+            $seen = if ($ci[0].MatrixOs) { $ci[0].MatrixOs -join ', ' } else { 'no os matrix at all' }
+            $faults.Add("$CiName does not run a matrix leg on ${os}: it has $seen. A guarantee about paths proven on one operating system is proven on one operating system.")
+        }
+    }
+    if ($ci[0].FailFast -ne 'false') {
+        $faults.Add("$CiName does not set fail-fast: false. With it on, the first leg to fail cancels the other, so a run that could have named two problems names one and hides whether the second platform is affected at all.")
+    }
+    return $faults.ToArray()
+}

--- a/tools/Test-PSCxCiParity.ps1
+++ b/tools/Test-PSCxCiParity.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    Assert this repository's CI still holds every capability the sibling module's does.
+
+.DESCRIPTION
+    PSComplexity and PSMutant gate each other -- one measures the other's complexity, the other
+    mutation-tests this one's suite -- so it is easy to assume their CI is comparable. It was not,
+    in thirteen ways, and nothing compared them: each workflow reads fine on its own, and a
+    capability present in one repository and absent in the other is invisible from inside either.
+
+    The rules are stated as shape rather than by file name, so tools/ParityDecisions.ps1 is
+    byte-identical in both repositories apart from the command prefix. That makes diffing the two
+    copies the comparison, and makes declining a rule a deletion somebody has to argue for in a
+    diff rather than a silence.
+
+    Throws on a fault, so the exit code is the answer and running it by hand is the same as
+    passing it. A gate that reports and exits 0 is a report.
+
+.PARAMETER WorkflowPath
+    Directory of workflow files. Defaults to .github/workflows beside this script's repository.
+
+.PARAMETER PassThru
+    Return the faults instead of throwing, for a caller that wants to render them.
+
+.OUTPUTS
+    [string[]] with -PassThru; nothing otherwise.
+#>
+[CmdletBinding()]
+[OutputType([string[]])]
+param(
+    [string]$WorkflowPath,
+    [switch]$PassThru
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'ParityDecisions.ps1')
+
+if (-not $WorkflowPath) {
+    $WorkflowPath = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath '.github/workflows'
+}
+if (-not (Test-Path -LiteralPath $WorkflowPath)) {
+    throw "No workflow directory at $WorkflowPath. This gate cannot compare what it cannot read, and an unreadable path would otherwise pass every rule."
+}
+
+$files = @(Get-ChildItem -LiteralPath $WorkflowPath -Filter *.yml -File | Sort-Object Name)
+$facts = foreach ($f in $files) {
+    Get-PSCxWorkflowFact -Name $f.Name -Line @(Get-Content -LiteralPath $f.FullName)
+}
+
+$faults = @(Get-PSCxParityFault -Fact @($facts))
+
+if ($PassThru) { return $faults }
+
+if ($faults) {
+    $body = ($faults | ForEach-Object { "  - $_" }) -join [Environment]::NewLine
+    throw "CI parity gate: $($faults.Count) fault(s) across $($files.Count) workflow(s).$([Environment]::NewLine)$body"
+}
+# Write-Output, not Write-Host: PSAvoidUsingWriteHost is NOT excluded in this repo, and the gate
+# scripts print through the pipeline for exactly that reason.
+Write-Output "CI parity: $($files.Count) workflow(s) hold every shared capability."


### PR DESCRIPTION
Closes #56.

The tracking issue held thirteen capabilities PSMutant had and this repo did not. **All
thirteen are closed**, verified row by row against the files rather than taken on trust -- that
check is posted on the issue. PSMutant's mirror rows are closed too, including the OS matrix it
was missing.

What no linked issue ever owned is the second half of #56's own title: **keep something
comparing them**. Without it the matrix is accurate on the day it is written and stale
afterwards, which is how it got to thirteen rows the first time.

## Why nothing noticed the first thirteen

Every workflow reads perfectly well on its own. A capability present in one repository and
absent in the other is only visible from *outside* either one, and the two repos gate each
other, which makes the assumption that their pipelines are comparable feel safe.

## What this adds

`tools/Test-PSCxCiParity.ps1` runs in CI and by hand, checking `.github/workflows/` against
the rules in `tools/ParityDecisions.ps1`:

| Rule | The failure it prevents |
|---|---|
| every job has `timeout-minutes` | a wedged runner holds a required check pending for six hours, blocking every merge behind it |
| every workflow has a concurrency group | a superseded run answering a question nobody is asking; for a publish, two tags racing |
| every workflow has a `permissions` block | executing gallery code with the default write-scoped token |
| `publish.yml` never cancels in progress | a half-finished publish is a gallery version that cannot be withdrawn |
| every `uses:` a 40-char SHA with a version comment | a tag is mutable, and `uses:` cannot read a variable, so this is the one pin no shared file can hold |
| no version literal where `pins.env` should be read | two workflows agreeing today is not one file they both read |
| an install that reads pins asserts the keys arrived | a missing key installs latest or analyses nothing, and both look clean |
| no lint spelled inline | spelled twice, they agreed about scope and disagreed about severity |
| every Pester config disables classic `Should` | a gate that permits what the merge gate forbids is not the same gate |
| `ci.yml` matrix over both OSes, `fail-fast: false` | a path guarantee proven on one OS is proven on one OS |

## The mechanism, which is the point

**The rules are stated as shape, never by file name** -- "a lint gate that is not spelled
inline", not "`Invoke-PSCxAnalyzer.ps1`". So `ParityDecisions.ps1` is byte-identical in both
repositories apart from the command prefix, and **diffing the two copies IS the comparison**.

That also fixes the thing a tracking issue cannot do: declining a rule becomes a **deletion
somebody has to argue for in a diff**, rather than a silence. Add a rule here and the sibling
fails it until it adopts or declines it.

It reads **comment-stripped** text, which is not fussiness. PSMutant's `code-scanning.yml`
spends six lines of prose on `Invoke-ScriptAnalyzer` explaining why it does *not* call it, and
a grep reads that as an inline lint gate -- it was the first false positive this hit. Text
rather than parsed YAML because PowerShell ships no YAML parser, and pinning one would add a
dependency to the gate that watches the dependencies.

## It found something on its first run

Pointed at the sibling's workflows:

```
publish.yml builds 1 Pester configuration(s) but sets Should.DisableV5 on 0.
```

PSMutant's publish gate ran the suite with the classic `Should` syntax still legal while its
merge gate forbade it -- a publish-time gate weaker than the merge gate, which is the
direction that matters. That is a one-line fix on the PSMutant side and belongs with #117.

## Testing

Every rule is paired: a compliant fixture and one that breaks **precisely** that rule. A
fixture that breaks two cannot tell you which fired, and a rule that has quietly stopped being
able to fire looks exactly like a repository that passes.

The `Broken` helper uses `Contains`, not `-like`: one anchor is `os: [ubuntu-latest,
windows-latest]`, and in a wildcard those brackets are a character class matching a single
character -- the anchor would match nothing and the test would assert against an unmodified
file. It throws when an anchor is missing, for the same reason.

The gate's own headline assertion is that the *real* workflows are clean, so that was checked
the same way, on copies with a `timeout-minutes`, a `permissions` block and publish's cancel
flag deliberately broken:

```
FIRES: ci.yml declares 1 job(s) and 0 timeout-minutes...
FIRES: code-scanning.yml declares no permissions block...
FIRES: publish.yml has cancel-in-progress 'true' where it must be the literal false...
```

Three planted, three fired, zero on the originals.

## Gates

| Gate | Result |
|---|---|
| Suite | 597 tests / 13 containers, 0 failed |
| Coverage | 100% over 939 commands in `src/` |
| Lint | clean |
| Complexity | True |
| CI parity | 4 workflows, no faults |
| Release consistency | 0.4.0 |
| Self-mutation | 493/493 -- unchanged, and untouched by this branch: no `src/` file changes, `tools/` is outside `sandboxSubtrees`, and `Parity.Tests.ps1` is not a mapped covering suite |

Two findings from writing it, both house rules the repo already had: `PSAvoidUsingWriteHost`
is deliberately *not* excluded here, so the runner prints with `Write-Output`; and fault
functions accumulate into a `List[string]` and return `.ToArray()`, which is what keeps
`PSUseOutputTypeCorrectly` quiet. Both were caught by the lint gate on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
