### PR TITLE
docs: stop pointing at a roadmap that no longer exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,8 +295,9 @@ and expensive to rebuild, and because each one has already earned its keep.
   claiming only to write it down.
 
   This file was deliberately not written earlier. With no interior node a cycle was unreachable
-  and an allowlist would have been ceremony; `ROADMAP.md` recorded the condition for revisiting
-  and `src/Report.ps1` met it. Writing it while the edges are few and obviously correct is the
+  and an allowlist would have been ceremony. The condition for revisiting was recorded in advance
+  -- a module that both exported commands consume, living in its own file -- and `src/Report.ps1`
+  met it. Writing it while the edges are few and obviously correct is the
   cheap moment -- ratifying a graph nobody remembers agreeing to is the expensive one.
 
   There is no "one Write-Host" assertion like the sibling's, and that is deliberate:

--- a/tests/Layering.Tests.ps1
+++ b/tests/Layering.Tests.ps1
@@ -7,7 +7,7 @@
 #
 # This file was deliberately NOT written while the graph had no interior node: with five files
 # and every arrow pointing at a sink, a cycle was not reachable and an allowlist would have been
-# ceremony. ROADMAP.md recorded the condition for revisiting -- a module that both exported
+# ceremony. The condition for revisiting was recorded in advance -- a module that both exported
 # commands consume, living in its own file -- and src/Report.ps1 met it.
 #
 # Two things this test does NOT have to work around, unlike the sibling project's version:


### PR DESCRIPTION
Follow-on from retiring the roadmap: `docs/sequencing` and PR #39 are gone, and two places in
`main` still named `ROADMAP.md`.

The branch held ordering rationale for queued work, and there is none left -- 0 open issues, with
0.4.0 prepared and awaiting a tag. Its own rule was that completed waves are **removed rather than
ticked**, so removing the last of them removes the file. What was worth keeping had already moved
into `CLAUDE.md` as each wave closed, which was always the intended destination: somebody about to
add an edge, a test file or a mutated source file meets it there rather than on a branch nobody
checks out.

Both references are fixed the same way -- by saying the thing rather than citing where it was
written:

- `CLAUDE.md`, on why `tests/Layering.Tests.ps1` was written when it was
- the same argument in the header of `tests/Layering.Tests.ps1` itself

Neither actually needed the file. The claim is that the condition for writing that test was fixed
**in advance** rather than invented afterwards, and the test's own header already stated the
condition inline. The citation added provenance, and provenance nobody can reach is worse than none:
it reads as though there is more to find.

Comment-only. 597 tests, complexity gate passes, lint clean; no `src/` file is touched, so the
mutation gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
