### PR TITLE
docs: file the parity gate under the version that contains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,6 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
-### Internal
-
-- **The CI capabilities this repo shares with PSMutant are now checked by a rule set rather than
-  remembered.** The two modules gate each other, so their pipelines are assumed comparable; they
-  were thirteen capabilities apart, and nothing compared them, because every workflow reads fine on
-  its own and a gap is only visible from outside either repository.
-
-  `tools/Test-PSCxCiParity.ps1` runs in CI and by hand, over `.github/workflows/`. The rules are
-  stated as shape rather than by file name, so `tools/ParityDecisions.ps1` is byte-identical in both
-  repos apart from the command prefix -- which makes diffing the two copies the comparison, and
-  makes declining a rule a deletion somebody has to argue for rather than a silence.
-
-  It found a real gap on its first run against the sibling: PSMutant's publish workflow ran the
-  suite with the classic `Should` syntax still legal while its merge gate forbade it.
-
 ## [0.4.0] - 2026-08-23
 
 ### For consumers
@@ -136,6 +121,19 @@ keys it holds could not distinguish units the tool could.
   anything above a unit is edited.
 
 ### Internal
+
+- **The CI capabilities this repo shares with PSMutant are now checked by a rule set rather than
+  remembered.** The two modules gate each other, so their pipelines are assumed comparable; they
+  were thirteen capabilities apart, and nothing compared them, because every workflow reads fine on
+  its own and a gap is only visible from outside either repository.
+
+  `tools/Test-PSCxCiParity.ps1` runs in CI and by hand, over `.github/workflows/`. The rules are
+  stated as shape rather than by file name, so `tools/ParityDecisions.ps1` is byte-identical in both
+  repos apart from the command prefix -- which makes diffing the two copies the comparison, and
+  makes declining a rule a deletion somebody has to argue for rather than a silence.
+
+  It found a real gap on its first run against the sibling: PSMutant's publish workflow ran the
+  suite with the classic `Should` syntax still legal while its merge gate forbade it.
 
 - **A node's enclosing unit and nesting depth are computed in one descent, making the cost linear
   in file size.** They were found by walking up from each node to its unit, from twelve call sites,


### PR DESCRIPTION
`v0.4.0` tags `31360fa`, and the CI parity gate is **in that commit**. Filing it under
`[Unreleased]` therefore describes a release that does not exist and omits it from the one that
does.

It also clears a gate that would otherwise fail `main` from the moment 0.4.0 reaches the gallery.
`Get-PSCxStaleVersionFault` faults on the **pair** -- a published `ModuleVersion` and unreleased
entries above it -- because two people installing "0.4.0", one from the gallery and one from a
clone, would get different code with nothing in the repo able to tell them apart. Either condition
alone is a normal state; only the pair is wrong, and publishing creates the pair.

**Bumping to 0.4.1 would have cleared it too, and would have been wrong twice**: it would ship a
package byte-identical to 0.4.0 -- `tools/` does not travel in the package -- and it would leave
the changelog still claiming 0.4.0 lacks something it has.

The shipped `ReleaseNotes` are unchanged: they are built from the `### For consumers` block and this
entry is `### Internal`. Still 3950 characters, and `Test-PSCxRelease.ps1` still reports consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
