### PR TITLE
chore: pin PSMutant 0.4.0, and take the ternaries it unblocks

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -45,7 +45,7 @@ PESTER_COMPAT_VERSIONS=5.0.4 5.1.1 5.2.2 5.3.3 5.4.1 5.5.0 5.6.1 5.7.1 5.8.0 5.9
 PS_COMPAT_VERSIONS=7.0.13 7.1.7 7.2.24 7.3.12 7.4.19 7.5.10
 
 PSSA_VERSION=1.25.0
-PSMUTANT_VERSION=0.3.2
+PSMUTANT_VERSION=0.4.0
 CONVERTTOSARIF_VERSION=1.0.0
 
 # What PSScriptAnalyzer looks at. Shared so the lint gate and the code-scanning check cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ against 5.0.0 and believed the verdict, that is why.
 
 ### Internal
 
+- **PSMutant is pinned at 0.4.0**, whose `ConditionForcing` operator dispatches to three condition
+  kinds rather than one -- `if`, ternary and `switch`, where 0.3.2 saw only `IfStatementAst`.
+
+- **Four `if/else` expressions became ternaries**, for readability. That change was written and
+  deliberately held back first: under 0.3.2 it cost eight mutants (554 -> 546, still 100%), because
+  a condition moving into a `TernaryExpressionAst` stopped being forced to `$true` and `$false`.
+  Green over a smaller set is the shape this project exists to distrust. Re-measured on 0.4.0 the
+  count is 554 again, so the trade is gone rather than accepted.
+
+  Neither performance nor the metric is a reason for the rewrite, and both were checked so they are
+  not offered as one later: ternary is 1.04x against the `if/else` expression over 300k iterations,
+  and total cognitive drops 262 -> 258 because SonarSource scores a ternary +1 against an
+  `if/else`'s +2 -- an asymmetry faithful to the spec and pinned by two reference cases. Lowering
+  our own numbers by choosing syntax would be the worst possible reason in this module.
+
 - **The gate uses no Pester at all**, deliberately. The Pester gate asks whether a consumer can gate
   on this module from inside Pester N; this one asks whether the module loads and computes correctly
   on PowerShell N. Crossing them would multiply the legs and, worse, confound this one: Pester 6.1.0

--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -192,7 +192,7 @@ function Initialize-PSCxAstIndex {
             continue
         }
         $script:PSCxBoundaryCache[$n] = $script:PSCxBoundaryCache[$p]
-        $raises = if ($p.GetType().Name -in $script:PSCxNestingTypes) { 1 } else { 0 }
+        $raises = ($p.GetType().Name -in $script:PSCxNestingTypes) ? 1 : 0
         $script:PSCxNestingCache[$n] = [int]$script:PSCxNestingCache[$p] + $raises
     }
     # LAST, so a walk that throws part-way leaves the root unmarked and the next ask rebuilds it

--- a/src/BaselineFile.ps1
+++ b/src/BaselineFile.ps1
@@ -71,7 +71,7 @@ function Write-PSCxBaselineFile {
     )
     # Absent is the ordinary first run, not an error: seeding a baseline is the reason this
     # switch exists.
-    $existing = if (Test-Path -LiteralPath $Path -PathType Leaf) { Read-PSCxDocument -Path $Path } else { $null }
+    $existing = (Test-Path -LiteralPath $Path -PathType Leaf) ? (Read-PSCxDocument -Path $Path) : $null
     # Only compare against a file whose numbers still mean the same thing. When the metric
     # version has moved, the recorded scores are not smaller or larger -- they are answers to a
     # different question, and a ratchet cannot be enforced across that. Regenerating wholesale is

--- a/src/Scan.ps1
+++ b/src/Scan.ps1
@@ -85,8 +85,9 @@ function Get-PSCxRelativePath {
     # caller happened to pass an absolute path AND a Root equal to the CWD -- two conditions
     # that both had to hold and neither of which was stated. The sibling project shipped the
     # same shape and it was a live hole there, because a config may name a file by full path.
-    $full = if ([System.IO.Path]::IsPathRooted($Path)) { [System.IO.Path]::GetFullPath($Path) }
-    else { [System.IO.Path]::GetFullPath((Join-Path $Root $Path)) }
+    $full = [System.IO.Path]::IsPathRooted($Path) ?
+        [System.IO.Path]::GetFullPath($Path) :
+        [System.IO.Path]::GetFullPath((Join-Path $Root $Path))
     $rootFull = [System.IO.Path]::GetFullPath($Root)
     if (-not $rootFull.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
         $rootFull += [System.IO.Path]::DirectorySeparatorChar
@@ -201,7 +202,7 @@ function Get-PSCxEmptyScanFault {
         [Parameter(Mandatory)] [bool]$Recurse
     )
     if ($UnitCount -gt 0 -or $Filtered) { return $null }
-    $hint = if ($Recurse) { '' } else { ', or add -Recurse if they are in subdirectories' }
+    $hint = $Recurse ? '' : ', or add -Recurse if they are in subdirectories'
     return ('Measured no units under: ' + ($Path -join ', ') + '. Nothing was checked, so a pass ' +
         'here would describe an empty set. Check the path exists and holds .ps1 or .psm1 files' +
         $hint + '.')


### PR DESCRIPTION
Two changes, and the first is what makes the second free.

## The pin

PSMutant **0.4.0**, released today. Its `ConditionForcing` operator now dispatches to three
condition kinds rather than one — `if`, **ternary** and **switch** — where 0.3.2 matched
`IfStatementAst` alone.

On `main` the gate is unchanged at **554 mutants, 554 killed**, and that is explained rather than
lucky: `src/` currently holds **zero** switch statements and **zero** ternary expressions, so the
broadened operator has nothing new to reach. It becomes load-bearing the moment either appears —
which is the second commit.

## The ternaries, and why they were not merged a week's worth of commits ago

Four `if/else` expressions rewritten for readability:

```
src/Ast.ps1           the nesting increment
src/BaselineFile.ps1  read the baseline if the file is there
src/Scan.ps1          the -Recurse hint
src/Scan.ps1          the rooted-path resolution
```

This was written, measured, and **deliberately parked**, because under 0.3.2 it cost eight mutants:

| | mutants | killed |
|---|---|---|
| `main` + 0.3.2 | 554 | 554 |
| ternary + 0.3.2 | **546** | 546 |
| `main` + 0.4.0 | 554 | 554 |
| ternary + 0.4.0 | **554** | 554 |

Still 100%, over a **smaller set** — the shape this project exists to distrust in other people's
code. The cause was exact rather than suspected: a condition moving into a `TernaryExpressionAst`
stopped being forced to `$true` and `$false`. Four conversions × two forced values = exactly eight.

0.4.0 restores them. There is no window in this history where the gate proved less than it claimed.

## Three things that are not the reason

Recorded so none is offered as one later:

- **Performance.** Measured over 300k iterations: ternary **1.04×** against the `if/else`
  expression, `??=` **1.01×** against if-null-assign. Noise.
- **The metric.** Total cognitive drops **262 → 258**, one per site, because SonarSource scores a
  ternary +1 and an `if/else` +2 (`if` +1, `else` +1). That asymmetry is faithful to the spec and
  pinned by two reference cases. Lowering our own numbers by choosing syntax would be the worst
  possible reason in the module whose product *is* those numbers.
- **Line count.** Four lines either way.

Readability is the reason.

## Gates

| Gate | Result |
|---|---|
| Suite | 649 tests, 0 failed |
| Coverage | 100% over 1076 commands (1081 before — an `if` statement is more command nodes than an expression) |
| Lint / CI parity / Complexity | clean / clean / True |
| Release consistency | 0.5.1 |
| **Self-mutation** | **554/554 under 0.4.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
