### PR TITLE
feat: watch the compatibility lists in three tiers (#119)

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -44,6 +44,15 @@ PESTER_COMPAT_VERSIONS=5.0.4 5.1.1 5.2.2 5.3.3 5.4.1 5.5.0 5.6.1 5.7.1 5.8.0 5.9
 # the floor is the alternative, and is a product decision rather than a technical one.
 PS_COMPAT_VERSIONS=7.0.13 7.1.7 7.2.24 7.3.12 7.4.19 7.5.10
 
+# Minors deliberately NOT given a leg, so the freshness watcher does not report a choice somebody
+# already made. Each one is a claim: the watcher fails if an exempted minor has never been released,
+# or if it turns out to be covered after all -- the same rule a stale equivalence declaration gets,
+# because an exemption nobody can disprove is how a list quietly stops meaning anything.
+#
+# 7.6 is the runners' own PowerShell. The ordinary suite runs on it every build, so downloading it
+# again as a compatibility leg would prove something already proven, twice, at 90 MB.
+PS_COMPAT_EXEMPT_MINORS=7.6
+
 PSSA_VERSION=1.25.0
 PSMUTANT_VERSION=0.4.0
 CONVERTTOSARIF_VERSION=1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,34 @@ against 5.0.0 and believed the verdict, that is why.
 
 ### Internal
 
+- **The compatibility version lists are now watched, in three tiers.** `pin-freshness.yml` checked
+  four single pins and neither list, so the twelve Pester legs and six PowerShell legs could fall
+  behind in silence. A single pin is stale when something newer exists; a per-minor list is stale
+  three different ways, and they are three different decisions:
+
+  | Tier | Meaning | Response |
+  |---|---|---|
+  | `PATCH` | a leg is no longer the newest patch of its minor | bump it -- mechanical |
+  | `MINOR` | a released minor has no leg | add one -- a small choice |
+  | `MAJOR` | a whole major exists untested | decide whether the range still means what it says |
+
+  This matters because **an open-ended minimum promises every future release**: `>= 7.0` and
+  `>= 5.0.0` have no upper bound, so PowerShell 8.0 is claimed the day it ships.
+
+  Bounded downward by the lowest leg, because everything below the floor is out of scope rather
+  than uncovered -- without that the first run reported Pester 3.0 through 4.10 and two whole majors
+  as gaps.
+
+- **An exemption is a declaration that can go stale.** `PS_COMPAT_EXEMPT_MINORS` records a minor
+  deliberately left uncovered, with its reason beside it in `pins.env` -- today only 7.6, the
+  runners' own PowerShell. The watcher fails if an exempted minor was never released, or turns out
+  to be covered after all: an exemption nobody can disprove is how a list quietly stops meaning
+  anything, which is the rule a stale equivalence declaration already gets.
+
+- PowerShell releases are read from the GitHub API, **paged**. One page of 100 reaches back only to
+  7.2.3, so a single request cannot see 7.0 or 7.1 -- the watcher would have been blind to its own
+  floor going stale while reporting cheerfully on everything newer.
+
 - **PSMutant is pinned at 0.4.0**, whose `ConditionForcing` operator dispatches to three condition
   kinds rather than one -- `if`, ternary and `switch`, where 0.3.2 saw only `IfStatementAst`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,20 @@ and expensive to rebuild, and because each one has already earned its keep.
   version could not be obtained or started" from "this module is wrong under it", because the whole
   family exists to stop the second accusation being made from the first's evidence.
 
+- **A watcher that cannot see reports no faults, which looks exactly like nothing being wrong.**
+  `tools/Test-PSCxPinFreshness.ps1` grew from four single pins to also cover the two per-minor
+  compatibility lists, and building it turned up two ways to be silently blind. Both were caught by
+  planting a stale leg and checking the watcher noticed -- never by reading the code.
+
+  **`@(Invoke-RestMethod ...)` NESTS rather than flattens.** That cmdlet hands back a JSON array as
+  a single object, so the wrap produces one element whose `.tag_name` is every tag at once, `.Count`
+  is 1, a paging loop breaks after one page, and a `Where-Object` filter removes the lone nested
+  entry. Assign it directly.
+
+  **The GitHub releases API is paged**, and one page of 100 reaches back only to PowerShell 7.2.3 --
+  so an unpaged request cannot see 7.0 or 7.1, and the check is blind to precisely the floor it
+  exists to guard while reporting confidently on everything newer.
+
 - **`Write-Output` inside a value-returning function joins its return value.** `PSAvoidUsingWriteHost`
   is deliberately not excluded here, so every `tools/` script prints through the pipeline -- and a
   helper that prints progress AND returns a path hands the caller both, concatenated. The symptom

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -196,6 +196,78 @@ Describe 'Get-PSCxPinValue' {
     }
 }
 
+Describe 'Get-PSCxVersionListFault' {
+    BeforeAll {
+        # One shape reused: three legs at 5.0/5.1/6.0, and a feed that has more.
+        $script:ours = @('5.0.4', '5.1.1', '6.0.1')
+        $script:feed = @('4.9.0', '5.0.1', '5.0.4', '5.1.0', '5.1.1', '6.0.0', '6.0.1')
+    }
+
+    It 'says nothing when every leg is the newest patch of its minor' {
+        # The kept case. Without it every assertion below would pass against a function that
+        # returned a fault for everything.
+        @(Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available $script:feed).Count | Should-Be 0
+    }
+
+    It 'reports a leg that is no longer the newest patch of its minor' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours @('5.0.1', '5.1.1', '6.0.1') -Available $script:feed) -join ' ' |
+            Should-BeLikeString '*PATCH: X leg 5.0.1 is superseded by 5.0.4*'
+    }
+
+    It 'reports a released minor that no leg covers' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours @('5.0.4', '6.0.1') -Available $script:feed) -join ' ' |
+            Should-BeLikeString '*MINOR: X 5.1 has been released*'
+    }
+
+    It 'reports a whole major that nothing tests' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours @('5.0.4', '5.1.1') -Available $script:feed) -join ' ' |
+            Should-BeLikeString '*MAJOR: X 6.x exists*'
+    }
+
+    It 'ignores everything below the lowest leg' {
+        # The floor. The feed holds 4.9.0 and the promise starts at 5.0 -- reporting it would be a
+        # gap in a range the module never claimed, and the first run of this check did exactly that
+        # for two whole Pester majors.
+        (Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available $script:feed) -join ' ' |
+            Should-NotBeLikeString '*4.9*'
+    }
+
+    It 'honours an exemption for a minor nobody covers' {
+        @(Get-PSCxVersionListFault -Name 'X' -Ours @('5.0.4', '6.0.1') -Available $script:feed -ExemptMinor @('5.1')).Count |
+            Should-Be 0
+    }
+
+    It 'refuses an exemption for a version that was never released' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available $script:feed -ExemptMinor @('9.9')) -join ' ' |
+            Should-BeLikeString '*EXEMPTION: X 9.9 is exempted but has never been released*'
+    }
+
+    It 'refuses an exemption for a minor that IS covered' {
+        # Both halves of a contradiction are faults, because either one alone is a lie about the
+        # list: an exemption that is also tested has stopped describing anything, exactly like a
+        # stale equivalence declaration.
+        (Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available $script:feed -ExemptMinor @('5.1')) -join ' ' |
+            Should-BeLikeString '*exempted and also covered by a leg*'
+    }
+
+    It 'reports an unreachable feed rather than reading silence as good news' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available @()) -join ' ' |
+            Should-BeLikeString '*could not be checked*'
+    }
+
+    It 'reports an empty list rather than passing over nothing' {
+        (Get-PSCxVersionListFault -Name 'X' -Ours @() -Available $script:feed) -join ' ' |
+            Should-BeLikeString '*no compatibility versions pinned*'
+    }
+
+    It 'survives a prerelease string in the feed' {
+        # A gallery feed answers with things like 6.2.0-beta1, which [version] refuses outright. One
+        # such entry must not fail the whole check -- and its MINOR still counts as released.
+        (Get-PSCxVersionListFault -Name 'X' -Ours $script:ours -Available ($script:feed + '6.2.0-beta1')) -join ' ' |
+            Should-BeLikeString '*MINOR: X 6.2*'
+    }
+}
+
 Describe 'the pins file itself' {
     It 'declares every key the workflows require' {
         # The workflows assert this at run time; asserting it here means a missing pin fails

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -156,6 +156,92 @@ function Get-PSCxStaleVersionFault {
         "ModuleVersion and give the entries their own heading.")
 }
 
+function Get-PSCxVersionMinor {
+    # 'MAJOR.MINOR' for a version string, or $null when it is not one.
+    #
+    # Its own function because every tier below groups by it, and because a gallery feed answers
+    # with prerelease strings like '6.2.0-beta1' that [version] refuses outright -- taking the part
+    # before the dash keeps one bad entry from failing the whole check.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string]$Version)
+    if ($Version.Split('-')[0] -match '^(\d+)\.(\d+)') { return "$($Matches[1]).$($Matches[2])" }
+    return $null
+}
+
+function Get-PSCxVersionListFault {
+    <#
+    .SYNOPSIS
+        Every way a per-minor compatibility list has fallen behind what has been released.
+    #>
+    [OutputType([string[]])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]]$Ours,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]]$Available,
+        # Minors deliberately not covered, each of which must still exist and still be uncovered.
+        [AllowEmptyCollection()] [string[]]$ExemptMinor = @()
+    )
+    # A single pin is stale when something newer exists. A LIST is stale in three ways, and they are
+    # three different decisions -- bumping a patch is mechanical, adding a minor is a small choice,
+    # and a whole new major may not run at all. Flattening them into "something is newer" would put
+    # the same weight on all three, and the one that matters would be read as noise.
+    $faults = [System.Collections.Generic.List[string]]::new()
+    if (-not $Ours) { return [string[]]@("$Name has no compatibility versions pinned.") }
+    # "Could not look" is not "nothing newer", for the same reason it is not in Get-PSCxStalePinFault:
+    # a checker that reads an unreachable feed as good news stops being able to fail.
+    if (-not $Available) {
+        return [string[]]@("$Name compatibility versions could not be checked; the feed did not answer, so freshness is unknown.")
+    }
+
+    $ourMinors = @($Ours | ForEach-Object { Get-PSCxVersionMinor -Version $_ } | Where-Object { $_ })
+
+    # The promise is open-ended UPWARD and bounded downward, so everything below the floor is out of
+    # scope rather than uncovered. Without this the first run reported Pester 3.0 through 4.10 and
+    # two whole majors as gaps -- versions the module never claimed and which predate the assertion
+    # style the suite is written in.
+    #
+    # The floor is the lowest leg rather than a separate pin, because the list IS the compatibility
+    # claim everywhere else in this repo, and a second source for the same number is a second thing
+    # to keep in step. It cannot drift silently: tests/Release.Tests.ps1 asserts the floor's minor is
+    # present, and for PowerShell ties it to the manifest's own PowerShellVersion.
+    $floor = @($ourMinors | Sort-Object { [version]$_ })[0]
+    $availMinors = @($Available | ForEach-Object { Get-PSCxVersionMinor -Version $_ } |
+            Where-Object { $_ -and [version]$_ -ge [version]$floor } | Sort-Object -Unique)
+
+    # Tier 1 -- a leg that is no longer the newest patch of its own minor. The rule for these lists
+    # is the newest patch of every minor, with no exception, so this needs no judgement to act on.
+    foreach ($leg in $Ours) {
+        $minor = Get-PSCxVersionMinor -Version $leg
+        $newest = @($Available | Where-Object { (Get-PSCxVersionMinor -Version $_) -eq $minor } |
+                Sort-Object { [version]($_.Split('-')[0]) })[-1]
+        if ($newest -and [version]($newest.Split('-')[0]) -gt [version]($leg.Split('-')[0])) {
+            $faults.Add("PATCH: $Name leg $leg is superseded by $newest.")
+        }
+    }
+    # Tier 2 -- a released minor no leg covers. The promise has no upper bound, so this is a version
+    # already claimed and not proven.
+    foreach ($m in $availMinors) {
+        if ($m -in $ourMinors -or $m -in $ExemptMinor) { continue }
+        $faults.Add("MINOR: $Name $m has been released and no leg covers it.")
+    }
+    # Tier 3 -- a whole major nobody covers. Stated separately because it is the one that may not be
+    # a bump at all: a major is where a construct disappears rather than appears.
+    $ourMajors = @($ourMinors | ForEach-Object { $_.Split('.')[0] } | Sort-Object -Unique)
+    foreach ($maj in @($availMinors | ForEach-Object { $_.Split('.')[0] } | Sort-Object -Unique)) {
+        if ($maj -in $ourMajors) { continue }
+        $faults.Add("MAJOR: $Name $maj.x exists and nothing tests it. Decide whether the supported range still means what it says.")
+    }
+    # An exemption is a claim, and a claim that stopped describing anything is how a list quietly
+    # widens. Same rule as a stale equivalence declaration: it fails rather than being ignored.
+    foreach ($ex in $ExemptMinor) {
+        if ($ex -notin $availMinors) { $faults.Add("EXEMPTION: $Name $ex is exempted but has never been released.") }
+        elseif ($ex -in $ourMinors) { $faults.Add("EXEMPTION: $Name $ex is exempted and also covered by a leg; one of the two is wrong.") }
+    }
+    return $faults.ToArray()
+}
+
 function Test-PSCxHasUnreleasedContent {
     <#
     .SYNOPSIS

--- a/tools/Test-PSCxPinFreshness.ps1
+++ b/tools/Test-PSCxPinFreshness.ps1
@@ -51,4 +51,57 @@ foreach ($name in $watched.Keys) {
     $fault = Get-PSCxStalePinFault -Name $name -Pinned $pinned -Latest $latest
     if ($fault) { $faults.Add($fault) }
 }
+# --- the LISTS ------------------------------------------------------------------------------------
+# A single pin and a per-minor list go stale differently, so they are asked different questions. The
+# loop above asks "is something newer out?"; this asks three, because the list IS the compatibility
+# claim and an open-ended minimum promises every future release.
+$lists = @(
+    @{ Name = 'Pester'; Key = 'PESTER_COMPAT_VERSIONS'; ExemptKey = 'PESTER_COMPAT_EXEMPT_MINORS'; Source = 'gallery' }
+    @{ Name = 'PowerShell'; Key = 'PS_COMPAT_VERSIONS'; ExemptKey = 'PS_COMPAT_EXEMPT_MINORS'; Source = 'github' }
+)
+foreach ($list in $lists) {
+    $ours = @((Get-PSCxPinValue -Line $pins -Name $list.Key) -split ' ' | Where-Object { $_ })
+    $exempt = @((Get-PSCxPinValue -Line $pins -Name $list.ExemptKey) -split ' ' | Where-Object { $_ })
+    $available = @()
+    try {
+        if ($list.Source -eq 'gallery') {
+            $available = @(Find-Module -Name $list.Name -AllVersions -ErrorAction Stop | ForEach-Object { [string]$_.Version })
+        }
+        else {
+            # PowerShell is a RUNTIME, not a gallery module, so its releases come from where the
+            # compatibility gate downloads them. Prereleases are excluded: a leg pins something
+            # installable, and reporting a beta as an uncovered minor would be noise every month.
+            #
+            # PAGED, and that is not tidiness. One page of 100 reaches back only to 7.2.3 -- so a
+            # single request cannot see 7.0 or 7.1 at all, and the watcher was blind to its own
+            # FLOOR going stale while reporting cheerfully on everything newer. A checker whose
+            # blind spot is the oldest thing it guards is worse than none.
+            #
+            # The cap exists so a paging bug cannot turn a weekly job into an unbounded crawl; ten
+            # pages is roughly triple the releases that exist above the floor today.
+            #
+            # Assigned WITHOUT @( ), which is the opposite of the usual advice and is load-bearing.
+            # Invoke-RestMethod hands back a JSON array as a SINGLE object, so @( ) wraps rather than
+            # flattens: the result is one element whose .tag_name is every tag at once, .Count is 1,
+            # the loop breaks after one page, and the filter removes the lone nested entry. The
+            # symptom is a watcher that silently sees nothing while reporting no faults.
+            $available = @()
+            for ($page = 1; $page -le 10; $page++) {
+                $batch = Invoke-RestMethod -ErrorAction Stop -Headers @{ 'User-Agent' = 'PSComplexity-pin-freshness' } `
+                    -Uri "https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100&page=$page"
+                if (-not $batch) { break }
+                $available += @($batch | Where-Object { -not $_.prerelease } | ForEach-Object { $_.tag_name -replace '^v', '' })
+                if ($batch.Count -lt 100) { break }
+            }
+        }
+    }
+    catch {
+        # Left empty on purpose, exactly as above: the decision reports "could not look" itself.
+        Write-Verbose "Version lookup failed for $($list.Name): $($_.Exception.Message)"
+    }
+    foreach ($f in (Get-PSCxVersionListFault -Name $list.Name -Ours $ours -Available $available -ExemptMinor $exempt)) {
+        $faults.Add($f)
+    }
+}
+
 return [string[]]@($faults)


### PR DESCRIPTION
Closes #119.

`pin-freshness` checked four single pins and **neither compatibility list**, so the twelve Pester
legs and six PowerShell legs could fall behind in silence. Dependabot cannot close that gap — there
is no PowerShell Gallery ecosystem, and PowerShell is a runtime from GitHub releases rather than a
manifest dependency — so this extends the watcher that already exists.

## Three tiers, because they are three decisions

| Tier | Meaning | Response |
|---|---|---|
| `PATCH` | a leg is no longer the newest patch of its minor | bump it — mechanical |
| `MINOR` | a released minor has no leg | add one — a small choice |
| `MAJOR` | a whole major exists untested | decide whether the range still means what it says |

The major tier is the one worth waking someone for. `New-PesterConfiguration` arriving in a *minor*
already cost this repo a gate that could not reach its own floor; a major is where a construct
disappears rather than appears.

**Why this is not housekeeping:** an open-ended minimum promises every future release. `>= 7.0` and
`>= 5.0.0` have no upper bound, so PowerShell 8.0 and Pester 7.0 are claimed the day they ship.

**Bounded downward by the lowest leg.** Everything below the floor is out of scope rather than
uncovered — without it the first run reported Pester 3.0 through 4.10 and two whole majors as gaps,
versions the module never claimed. The floor is the lowest leg rather than a separate pin, because
the list *is* the compatibility claim everywhere else here, and it cannot drift silently:
`Release.Tests.ps1` asserts the floor's minor is present and, for PowerShell, ties it to the
manifest's own `PowerShellVersion`.

## An exemption is a claim, not a mute button

`PS_COMPAT_EXEMPT_MINORS` records a minor deliberately left uncovered, with its reason beside it in
`pins.env` — today only `7.6`, the runners' own PowerShell, already covered by the ordinary suite.

The watcher **faults** if an exempted minor was never released, or turns out to be covered after
all. An exemption nobody can disprove is how a list quietly stops meaning anything — the same rule a
stale equivalence declaration gets. Without this the job would report the same deliberate choice
every week and get muted, which is the failure the workflow's own comment already names.

## Two ways to be silently blind, both found by planting rather than reading

Neither would have failed anything. Both make a watcher report *no faults because it can see
nothing* — the same failure as the thing being built.

**`@(Invoke-RestMethod ...)` nests rather than flattens.** The cmdlet returns a JSON array as a
single object, so the wrap yields one element whose `.tag_name` is every tag at once, `.Count` is 1,
the paging loop breaks after one page, and the prerelease filter removes the lone nested entry.

**The releases API is paged**, and one page of 100 reaches back only to **7.2.3** — so an unpaged
request cannot see 7.0 or 7.1, leaving the check blind to exactly the floor it guards while
reporting confidently on everything above it.

Verified by making a leg stale and watching it fire:

```
planted: PS_COMPAT_VERSIONS=7.0.13 7.1.0 7.2.24 7.3.12 7.4.19 7.5.10
         PATCH: PowerShell leg 7.1.0 is superseded by 7.1.7.
restored: (nothing — current)
```

## Tests

Eleven cases in `ReleaseDecisions.ps1`'s suite: every tier, both exemption rules, the floor, an
unreachable feed, an empty list, and a prerelease string in the feed — plus **the paired case where
nothing is stale**, without which all eleven would pass against a function that faulted on
everything.

| Gate | Result |
|---|---|
| Suite | 660 tests (+11), 0 failed |
| Coverage | 100% over 1076 commands |
| Lint / CI parity / Complexity | clean / clean / True |
| Release consistency | 0.5.1 |
| Self-mutation | untouched — no `src/` changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
