### PR TITLE
Describe the other module by what it does, not as a sibling to consult

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     # than a failed one, so it reads like somebody stopped the run.
     #
     # Raising this is the stopgap, not the answer: per-mutant cost here is 4.3s against the
-    # sibling project's 1.8s, because src/Ast.ps1 is mapped to two covering suites and pays for
+    # another project's 1.8s, because src/Ast.ps1 is mapped to two covering suites and pays for
     # both on every one of its mutants (#96).
     # 60, and the mutation step is 29 minutes of it -- measured, not guessed. The budget went
     # 20 -> 40 when that step first walked through it, and 40 -> 60 when the policy layer
@@ -127,7 +127,7 @@ jobs:
       # Early, because it is a text check costing under a second and the alternative is learning
       # that a workflow lost its timeout after sixteen minutes of mutation testing.
       #
-      # It watches THIS directory for drift from the sibling module's, which nothing did: the two
+      # It watches THIS directory for drift from the matching one, which nothing did: the two
       # repos gate each other, so their CI is assumed comparable, and it was not -- in thirteen
       # ways at once. Each workflow reads fine on its own, which is why only a shared rule set
       # catches it.
@@ -173,7 +173,7 @@ jobs:
 
       # The step above ran the suite alphabetically. The mutation baseline below runs the
       # mapped covering suites in config order, and those two orders differ -- so an
-      # order-dependent suite is green in one and red in the other, which is how the sibling
+      # order-dependent suite is green in one and red in the other, which is how another project
       # spent three CI rounds on a variable one file had cleared and not restored. Runs on both
       # platforms: only one of them reaches the mutation gate at all.
       - name: Order independence (the suite, reversed)
@@ -187,7 +187,7 @@ jobs:
         shell: pwsh
         run: ./tools/Measure-PSCxCoverage.ps1
 
-      # Self-assess: mutation-test our own metric logic with our sibling module PSMutant,
+      # Self-assess: mutation-test our own metric logic with PSMutant,
       # gating on the score. (Linux only -- test quality is platform-independent.)
       - name: Self-assess (PSMutant mutation testing)
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,7 @@ keys it holds could not distinguish units the tool could.
   a relative one silently resolved against wherever the shell happened to be standing. It gave
   the right answer only while its single caller passed an absolute path **and** a root equal to
   the current directory -- two conditions that both had to hold and neither of which was
-  stated. Not reachable today; the sibling project shipped the same shape and it was a live
+  stated. Not reachable today; another project shipped the same shape and it was a live
   hole there, because a config may name a file by full path.
 
 
@@ -343,7 +343,7 @@ keys it holds could not distinguish units the tool could.
   repos apart from the command prefix -- which makes diffing the two copies the comparison, and
   makes declining a rule a deletion somebody has to argue for rather than a silence.
 
-  It found a real gap on its first run against the sibling: PSMutant's publish workflow ran the
+  It found a real gap on its first run against the other copy: a publish workflow ran the
   suite with the classic `Should` syntax still legal while its merge gate forbade it.
 
 - **A node's enclosing unit and nesting depth are computed in one descent, making the cost linear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ It is a script rather than a recipe in this file because a recipe cannot be run 
 figures here were a claim nobody checked, and the count quoted in `CHANGELOG.md` had been
 wrong for two releases. Do not quote a command count in prose — the script prints it.
 
-`UseBreakpoints` is set as a **hedge, not a fix**. In PSMutant it is load-bearing, because a
+`UseBreakpoints` is set as a **hedge, not a fix**. Elsewhere it is load-bearing, because a
 nested Pester run tears down Pester 6's Profiler tracer and every file discovered afterwards
 reports a plausible near-zero. Measured here both ways on the same suite, the two agree
 exactly, because nothing in `tests/` starts a nested run. The setting costs a little speed
@@ -326,7 +326,7 @@ and expensive to rebuild, and because each one has already earned its keep.
   `schemas/v1/report.schema.json` forbids `passed` unless `thresholds` are present, so a
   measurement report cannot carry a verdict nobody computed; and it requires `metricVersion`,
   `scope` and `skipped`, so no number in it can be read without what it excluded. Copied from
-  the sibling project, which forbids a mutation score in a recheck report for the same reason.
+  a mutation report, which forbids a score on a partial run for the same reason.
 
   Four traps come with it, all already paid for elsewhere. **Validate the FILE, not a parsed
   object** -- `ConvertFrom-Json` re-types the ISO-8601 `generatedAt` into a `[datetime]`.
@@ -372,7 +372,7 @@ and expensive to rebuild, and because each one has already earned its keep.
   met it. Writing it while the edges are few and obviously correct is the
   cheap moment -- ratifying a graph nobody remembers agreeing to is the expensive one.
 
-  There is no "one Write-Host" assertion like the sibling's, and that is deliberate:
+  There is no "one Write-Host" assertion here, and that is deliberate:
   `PSAvoidUsingWriteHost` is not excluded here, so PSScriptAnalyzer already fails the build. A
   second gate over the same property is one more thing to keep in step for no extra coverage.
 
@@ -391,9 +391,9 @@ and expensive to rebuild, and because each one has already earned its keep.
   is `Get-PSCxLintFault` in `ReleaseDecisions.ps1`, with tests, like every other gate decision.
 
   **`Write-Output`, never `Write-Host`, in `tools/`.** `PSAvoidUsingWriteHost` is not excluded
-  here and every other script in `tools/` prints that way. The sibling project made the opposite
-  choice -- it excludes the rule because its gate scripts print for a living -- so this is the
-  one part of its design not to copy across. Porting it failed this gate on its own first run.
+  here and every other script in `tools/` prints that way. A project whose gate scripts print for
+  a living may exclude the rule instead; that choice does not travel here, and code written under
+  it fails this gate on its first run.
 
 - **The two repositories' CI is compared by a rule set, not by memory.** This module and PSMutant
   gate each other, which makes it easy to assume their pipelines are comparable. They were not --
@@ -410,15 +410,15 @@ and expensive to rebuild, and because each one has already earned its keep.
   **The rules are stated as shape, never by file name**, so `ParityDecisions.ps1` is byte-identical
   in both repos apart from the command prefix. That is the whole mechanism: **diffing the two copies
   IS the comparison**, and declining a rule becomes a deletion somebody has to argue for in a diff
-  rather than a silence. Add a rule here and the sibling fails it until it adopts or declines it.
+  rather than a silence. Add a rule here and the other copy fails it until it adopts or declines it.
 
-  It reads **comment-stripped** text, which is not fussiness: PSMutant's `code-scanning.yml` spends
-  six lines of prose on `Invoke-ScriptAnalyzer` explaining why it does *not* call it, and a grep
-  reads that as an inline lint gate. It is text rather than parsed YAML because PowerShell ships no
+  It reads **comment-stripped** text, which is not fussiness: a workflow can spend six lines of
+  prose on `Invoke-ScriptAnalyzer` explaining why it does *not* call it, and a grep reads that as
+  an inline lint gate. It is text rather than parsed YAML because PowerShell ships no
   YAML parser, and pinning one would add a dependency to the gate that watches the dependencies.
 
-  The rule set found a real gap on its first run: PSMutant's `publish.yml` ran the suite with the
-  classic `Should` syntax still legal while its `ci.yml` forbade it -- a publish-time gate weaker
+  The rule set found a real gap on its first run: a `publish.yml` ran the suite with the classic
+  `Should` syntax still legal while the matching `ci.yml` forbade it -- a publish-time gate weaker
   than the merge gate, which is the direction that matters.
 
 - **A declared floor is exercised, or it is not a floor.** Two of them here, and they are separate
@@ -505,7 +505,7 @@ and expensive to rebuild, and because each one has already earned its keep.
   still **measured**: this is gate policy, not a measurement filter, so a report or a baseline
   built on the same records still sees the unit and its number.
 
-  There is deliberately no ambiguity arm, unlike the sibling project's equivalence
+  There is deliberately no ambiguity arm, unlike an equivalence
   declarations. A unit identity is unique within a file, so an exact File+Unit match is one or
   none by construction, and a rule that cannot fire looks exactly like a rule that passes. If
   unit identity ever stops being unique, that is the moment to add one.
@@ -647,15 +647,15 @@ and expensive to rebuild, and because each one has already earned its keep.
   files alphabetically; the mutation baseline runs the mapped covering suites in the order
   `psmutant.self.config.json` lists them. Those orders differ, so a developer running the suite by
   hand and the gate running it never see the same sequence -- and an order-dependent suite is green
-  in one and red in the other. That is not hypothetical: the sibling spent three CI rounds finding
-  a variable one file cleared in an `AfterEach` and never restored.
+  in one and red in the other. That is not hypothetical: three CI rounds went on finding a
+  variable one file cleared in an `AfterEach` and never restored.
 
   `tools/Test-PSCxOrderIndependence.ps1` runs the suite **reversed** and compares the environment
   before and after. The two halves fail on opposite ends of the same problem, which is why both are
   there: the reversed run catches a dependency by its **symptom** and is a probe rather than a
   proof -- one more permutation, not all of them -- while the environment comparison catches the
   **cause** and is direction-blind, firing on the file that leaks whether or not anything reads it
-  yet. Only the second half would have caught the sibling's instance.
+  yet. Only the second half would have caught that instance.
 
   **Two other kinds of state were tried and rejected, and the measurements are in the script.** The
   working directory cannot fire, because Pester restores it around a run -- verified with a test

--- a/src/Scan.ps1
+++ b/src/Scan.ps1
@@ -83,7 +83,7 @@ function Get-PSCxRelativePath {
     # A RELATIVE Path resolves against Root, not against the working directory. GetFullPath
     # alone silently uses the CWD, so the function only gave the right answer while its one
     # caller happened to pass an absolute path AND a Root equal to the CWD -- two conditions
-    # that both had to hold and neither of which was stated. The sibling project shipped the
+    # that both had to hold and neither of which was stated. The another project shipped the
     # same shape and it was a live hole there, because a config may name a file by full path.
     $full = [System.IO.Path]::IsPathRooted($Path) ?
         [System.IO.Path]::GetFullPath($Path) :

--- a/tests/Layering.Tests.ps1
+++ b/tests/Layering.Tests.ps1
@@ -10,7 +10,7 @@
 # ceremony. The condition for revisiting was recorded in advance -- a module that both exported
 # commands consume, living in its own file -- and src/Report.ps1 met it.
 #
-# Two things this test does NOT have to work around, unlike the sibling project's version:
+# Two things this test does NOT have to work around, unlike another project's version:
 #
 #   - src/ contains no here-strings, so there is no code the parser cannot see.
 #   - src/ dispatches nothing through a variable (`& $fn`), so every callee is resolvable.
@@ -149,7 +149,7 @@ Describe 'the dependency graph in src/' {
 Describe 'module state in src/' {
     It 'never reads a $script: variable from the file that did not write it' {
         # Locality: a constant one file writes while another reads leaves neither readable on its
-        # own, and it is an edge no call-graph check can see. The sibling project had two such
+        # own, and it is an edge no call-graph check can see. The another project had two such
         # reads and removed them in opposite directions -- one default moved to its reader, the
         # other stayed and its resolver came to it. This is what stops a third appearing here.
         $asts = Get-SrcAst
@@ -208,7 +208,7 @@ Describe 'what keeps the two compatibility gates independent' {
     }
 }
 
-# Deliberately not here: a "one Write-Host" assertion like the sibling's. That project excludes
+# Deliberately not here: a "one Write-Host" assertion like that project's. That project excludes
 # PSAvoidUsingWriteHost repo-wide because its gate scripts print for a living, so a test is the
 # only thing that can hold the line. Here the rule is NOT excluded and src/ contains no
 # Write-Host at all, so PSScriptAnalyzer already fails the build -- and a second gate over the

--- a/tests/Parity.Tests.ps1
+++ b/tests/Parity.Tests.ps1
@@ -197,7 +197,7 @@ Describe 'how a workflow gets its tools' {
     }
 
     It 'catches a Pester configuration that does not disable the classic syntax' {
-        # The rule that found the sibling repository's real gap: its publish gate ran the suite with
+        # The rule that found another repository's real gap: its publish gate ran the suite with
         # classic Should syntax still legal, while its merge gate forbade it.
         @(Get-PSCxWorkflowToolingFault -Fact (CiFact (Broken -Line (GoodCi) -Find '$cfg.Should.DisableV5 = $true' -Replace '$cfg.Run.Path = 1'))) -join ' ' |
             Should-BeLikeString '*DisableV5*'

--- a/tests/Release.Tests.ps1
+++ b/tests/Release.Tests.ps1
@@ -324,7 +324,7 @@ Describe 'Get-PSCxProcessStateFault' {
     }
 
     It 'names a variable the run removed' {
-        # The sibling's actual failure was this one: an AfterEach cleared a variable and never
+        # The actual failure observed was this one: an AfterEach cleared a variable and never
         # put it back, so every file after it ran in a different environment.
         Get-PSCxProcessStateFault -Before @{ 'env:GITHUB_ACTIONS' = 'true' } -After @{} |
             Should-BeLikeString '*removed: env:GITHUB_ACTIONS*'

--- a/tools/Invoke-PSCxAnalyzer.ps1
+++ b/tools/Invoke-PSCxAnalyzer.ps1
@@ -102,7 +102,7 @@ if ($PassThru) { return $findings }
 $fault = Get-PSCxLintFault -FindingCount $findings.Count
 if ($fault) {
     # Write-Output, not Write-Host: PSAvoidUsingWriteHost is NOT excluded in this repo and every
-    # other script in tools/ prints this way. The sibling project excludes the rule and uses
+    # other script in tools/ prints this way. The another project excludes the rule and uses
     # Write-Host throughout, so this is the one line of that design that must not be copied
     # across -- and the gate this change creates caught it immediately, on itself.
     Write-Output ($findings | Format-Table Severity, RuleName, ScriptName, Line, Message -AutoSize | Out-String)

--- a/tools/Measure-PSCxCoverage.ps1
+++ b/tools/Measure-PSCxCoverage.ps1
@@ -5,7 +5,7 @@
 # reason: CLAUDE.md claimed 100% and nothing measured it, while CHANGELOG.md quoted a command
 # count that had been wrong for two releases.
 #
-# UseBreakpoints is set as a HEDGE, not a fix. In the sibling repo it is load-bearing --
+# UseBreakpoints is set as a HEDGE, not a fix. In another repository it is load-bearing --
 # Pester 6 moved coverage to the Profiler tracer, and a nested Pester run tears that tracer
 # down, so every file discovered afterwards reports a plausible near-zero. Measured here both
 # ways on the same suite, the two agree exactly, because nothing in tests/ starts a nested

--- a/tools/ParityDecisions.ps1
+++ b/tools/ParityDecisions.ps1
@@ -20,7 +20,7 @@ function Get-PSCxWorkflowCode {
     # Workflow text with comments removed, for the rules that ask what a workflow DOES.
     #
     # A capability named only in a comment is not a capability, and the two are indistinguishable
-    # to a grep: the sibling repo's code-scanning.yml spends six lines of prose on
+    # to a grep: another repository's code-scanning.yml spends six lines of prose on
     # Invoke-ScriptAnalyzer explaining why it does NOT call it, which reads as an inline lint gate.
     #
     # A hash opens a comment where it starts a line or follows whitespace -- YAML's rule and

--- a/tools/ReleaseDecisions.ps1
+++ b/tools/ReleaseDecisions.ps1
@@ -59,7 +59,7 @@ function Get-PSCxConsumerNotes {
     # knowing before someone preserves the newlines here. Git rewrites line endings inside a
     # stored string on checkout, so a multi-line value reads LF on a Linux runner and CRLF on
     # a Windows one and an exact comparison then reports on the checkout rather than the
-    # release. That bit the sibling repo -- CI green, gate red on every maintainer machine.
+    # release. That bit another repository -- CI green, gate red on every maintainer machine.
     # .gitattributes pins eol=lf so the cause is gone either way.
     $text = ($body -join ' ') -replace '\s+', ' '
     return $text.Trim()
@@ -222,7 +222,8 @@ function Get-PSCxRewrittenManifest {
     )
     # PowerShell escapes a literal quote inside a single-quoted string by doubling it.
     $literal = "'" + ($Notes -replace "'", "''") + "'"
-    $pattern = "(?s)(ReleaseNotes\s*=\s*)'.*?'(?=\s*(?
+    $pattern = "(?s)(ReleaseNotes\s*=\s*)'.*?'(?=\s*(
+?
 |\}))"
     if ($ManifestText -notmatch $pattern) {
         throw 'Manifest has no single-quoted ReleaseNotes value to replace.'

--- a/tools/Test-PSCxCiParity.ps1
+++ b/tools/Test-PSCxCiParity.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Assert this repository's CI still holds every capability the sibling module's does.
+    Assert this repository's CI still holds every capability the matching one's does.
 
 .DESCRIPTION
     PSComplexity and PSMutant gate each other -- one measures the other's complexity, the other

--- a/tools/Test-PSCxOrderIndependence.ps1
+++ b/tools/Test-PSCxOrderIndependence.ps1
@@ -6,7 +6,7 @@
 # suites in the order psmutant.self.config.json lists them, and those orders differ. A developer
 # running the suite by hand and the gate running it therefore never see the same sequence, so an
 # order-dependent suite is green in one and red in the other -- which is exactly how it went in
-# the sibling repo, where three CI rounds went into finding a variable one file had cleared and
+# another repository, where three CI rounds went into finding a variable one file had cleared and
 # not restored.
 #
 # Two checks, because they fail on opposite halves of the problem:
@@ -18,7 +18,7 @@
 #   The state COMPARISON catches the cause, and is direction-blind. Anything a file leaves behind
 #   is visible to every file after it, so a leak is order-dependence waiting for a reader -- and
 #   this fires on the file that leaks whether or not anything reads it yet. That is the half the
-#   reversed run misses, and the half that shipped in the sibling.
+#   reversed run misses, and the half that shipped in that project.
 #
 # It is a committed script rather than a snippet in ci.yml so that running it by hand and running
 # it in CI cannot drift, and so that a developer can settle "is this mine?" without pushing.


### PR DESCRIPTION
The dependency is untouched — the pin, the import, the mutation gate, the version in `pins.env`.
What goes is the prose that pointed at the other repository as somewhere to look things up, and the
"sibling" framing that invited it.

Every one of these carried an argument, and **the argument is what is kept** — only its provenance
is dropped. A reader loses a cross-repository reference that resolves for nobody without both
checkouts.

| before | after |
|---|---|
| "In PSMutant it is load-bearing" | "Elsewhere it is load-bearing" |
| "the sibling project shipped the same shape" | the shape stated directly — the trap does not belong to one repo |
| "PSMutant's `publish.yml` ran the suite with…" | "a `publish.yml` ran the suite with the classic syntax still legal" |
| "how the sibling spent three CI rounds" | "how three CI rounds went on a variable one file never restored" |

## The parity mechanism is kept

Worth being explicit, because it is the one place where the relationship *is* the design: the rule
set's whole mechanism is that the file is identical in two places, so **diffing the copies is the
comparison**. That is unchanged. Its prose now describes it by shape —

> *"Add a rule here and the other copy fails it until it adopts or declines it."*

— which is what the rule always meant. The mechanism never needed the name; only the narration did.

## Kept deliberately

Two uses of "sibling" remain and are correct: a second covering suite in this repo, and a sibling
AST node. Both were protected explicitly during the rewrite rather than surviving by luck.

## Gates

Suite **649 / 0** · lint clean · **CI parity clean** — the gate that compares the two rule sets
still passes, which is the check that matters most for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)