### PR TITLE
Stop calling a function once per AST node when indexing (#124)

### DIFF
--- a/src/Ast.ps1
+++ b/src/Ast.ps1
@@ -65,6 +65,17 @@ $script:PSCxUnitBoundaryTypes = @(
     'FunctionDefinitionAst', 'FunctionMemberAst', 'PropertyMemberAst'
 )
 
+# The same two vocabularies as HashSets, built once at load. The lists above stay as the
+# declaration -- they carry the reasons, and the vocabulary test reads them -- but the INDEX
+# consults them once per node over a whole tree, and `-in` over an array is a linear scan of
+# string comparisons. Measured over 259,144 nodes: 138ms for `-in` against 69ms for
+# HashSet.Contains, per list.
+$script:PSCxNestingTypeSet = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]$script:PSCxNestingTypes, [System.StringComparer]::Ordinal)
+$script:PSCxUnitBoundaryTypeSet = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]$script:PSCxUnitBoundaryTypes, [System.StringComparer]::Ordinal)
+
+
 # Per-node answers, remembered for the file being measured.
 #
 # Get-PSCxUnitBoundary and Get-PSCxNesting each walk the ancestor chain from a node up to its
@@ -180,19 +191,34 @@ function Initialize-PSCxAstIndex {
     foreach ($n in $Root.FindAll({ $true }, $true)) {
         # BEFORE the parent test below, which skips the root: FindAll returns the root itself, and
         # a bucket that silently omitted it would be a whole-tree query that is not one.
-        Add-PSCxIndexedNode -Node $n -Position $position
+        # INLINE, not a call per node, and this is why the index was expensive. A PowerShell
+        # function with [CmdletBinding()] and mandatory parameters costs about 9us to invoke;
+        # over 259,144 nodes that is 2.4s against 62ms for the same work written here -- 39x,
+        # measured. Nothing else in this module runs a function once per AST node.
+        $script:PSCxOrderCache[$n] = $position
+        $nodeType = $n.GetType()
+        $bucket = $null
+        if (-not $script:PSCxTypeCache.TryGetValue($nodeType, [ref]$bucket)) {
+            $bucket = [System.Collections.Generic.List[object]]::new()
+            $script:PSCxTypeCache[$nodeType] = $bucket
+            $script:PSCxTypeNameCache[$nodeType.Name] = $bucket
+        }
+        $bucket.Add($n)
         $position++
         $p = $n.Parent
         # The root itself comes back from FindAll and is already seeded; anything with no parent
         # is a root by definition.
         if ($null -eq $p) { continue }
-        if ($p.GetType().Name -in $script:PSCxUnitBoundaryTypes) {
+        # Once per node, not twice: both tests below want it, and it was recomputed for
+        # every node that is not a boundary.
+        $parentType = $p.GetType().Name
+        if ($script:PSCxUnitBoundaryTypeSet.Contains($parentType)) {
             $script:PSCxBoundaryCache[$n] = Resolve-PSCxUnitBoundary -Boundary $p
             $script:PSCxNestingCache[$n] = 0
             continue
         }
         $script:PSCxBoundaryCache[$n] = $script:PSCxBoundaryCache[$p]
-        $raises = ($p.GetType().Name -in $script:PSCxNestingTypes) ? 1 : 0
+        $raises = $script:PSCxNestingTypeSet.Contains($parentType) ? 1 : 0
         $script:PSCxNestingCache[$n] = [int]$script:PSCxNestingCache[$p] + $raises
     }
     # LAST, so a walk that throws part-way leaves the root unmarked and the next ask rebuilds it
@@ -216,31 +242,6 @@ function Confirm-PSCxAstIndex {
     Initialize-PSCxAstIndex -Root $Root
 }
 
-function Add-PSCxIndexedNode {
-    # File one node into its type bucket and record where it sat in the walk.
-    #
-    # Split out of the loop above rather than inlined: the loop is the hot path of the whole
-    # module and already carries two conditionals against the cognitive ceiling this module gates
-    # itself on. It is also the one piece of the index whose contract -- buckets hold nodes in
-    # document order -- is worth being able to test on its own.
-    [OutputType([void])]
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)] $Node,
-        [Parameter(Mandatory)] [int]$Position
-    )
-    $script:PSCxOrderCache[$Node] = $Position
-    $type = $Node.GetType()
-    $bucket = $null
-    if (-not $script:PSCxTypeCache.TryGetValue($type, [ref]$bucket)) {
-        $bucket = [System.Collections.Generic.List[object]]::new()
-        $script:PSCxTypeCache[$type] = $bucket
-        # The same list under both keys, not a copy. An exact-name lookup and a type lookup are
-        # two ways of asking for one bucket, and two lists would be two things to keep in step.
-        $script:PSCxTypeNameCache[$type.Name] = $bucket
-    }
-    $bucket.Add($Node)
-}
 
 function Clear-PSCxAstCache {
     # Forget the per-node answers. Called once per file, before it is walked.

--- a/src/Cognitive.ps1
+++ b/src/Cognitive.ps1
@@ -39,7 +39,7 @@ function Get-PSCxCogIfRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.IfStatementAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'IfStatementAst')) {
         $extra = ($n.Clauses.Count - 1) + [int][bool]$n.ElseClause
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'if'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) + $extra }
     }
@@ -63,7 +63,7 @@ function Get-PSCxCogTernaryRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.TernaryExpressionAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'TernaryExpressionAst')) {
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'ternary'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
     }
 }
@@ -76,7 +76,7 @@ function Get-PSCxCogFlowCommandRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.CommandAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'CommandAst')) {
         if (-not (Test-PSCxFlowCommand -Node $n)) { continue }
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'flow-command'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
     }
@@ -88,12 +88,12 @@ function Get-PSCxCogNullCoalesceRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.BinaryExpressionAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'BinaryExpressionAst')) {
         if ($n.Operator -eq 'QuestionQuestion') {
             [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'null-coalesce'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
         }
     }
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.AssignmentStatementAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'AssignmentStatementAst')) {
         if ($n.Operator -eq 'QuestionQuestionEquals') {
             [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'null-coalesce'; Line = $n.Extent.StartLineNumber; Amount = 1 + (Get-PSCxNesting -Node $n) }
         }
@@ -108,7 +108,7 @@ function Get-PSCxCogPipelineChainRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.PipelineChainAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'PipelineChainAst')) {
         if ($n.Parent -isnot [System.Management.Automation.Language.PipelineChainAst] -or
             $n.Parent.Operator -ne $n.Operator) {
             [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'pipeline-chain'; Line = $n.Extent.StartLineNumber; Amount = 1 }
@@ -121,7 +121,7 @@ function Get-PSCxCogBooleanRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.BinaryExpressionAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'BinaryExpressionAst')) {
         if (Test-PSCxLogicalRunStart -Node $n) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'boolean-run'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }
@@ -144,7 +144,7 @@ function Get-PSCxCogRecursionRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.CommandAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'CommandAst')) {
         $fn = Get-PSCxEnclosingFunctionName -Node $n
         if ($fn -and $n.GetCommandName() -eq $fn) { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'recursion'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }

--- a/src/Cyclomatic.ps1
+++ b/src/Cyclomatic.ps1
@@ -16,10 +16,10 @@ function Get-PSCxCycClauseRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.IfStatementAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'IfStatementAst')) {
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'clause'; Line = $n.Extent.StartLineNumber; Amount = $n.Clauses.Count }
     }
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.SwitchStatementAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'SwitchStatementAst')) {
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'clause'; Line = $n.Extent.StartLineNumber; Amount = $n.Clauses.Count }
     }
 }
@@ -48,7 +48,7 @@ function Get-PSCxCycFlowCommandRow {
     # Test-PSCxFlowCommand answers False for anything that is not a CommandAst, so asking the
     # index for the CommandAst nodes and testing those is the same set in the same order -- at the
     # cost of the commands in the file rather than every node in it.
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.CommandAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'CommandAst')) {
         if (-not (Test-PSCxFlowCommand -Node $n)) { continue }
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'flow-command'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
@@ -63,16 +63,16 @@ function Get-PSCxCycOperatorRow {
     [OutputType([pscustomobject])]
     [CmdletBinding()]
     param([Parameter(Mandatory)] $Ast)
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.PipelineChainAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'PipelineChainAst')) {
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.TernaryExpressionAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'TernaryExpressionAst')) {
         [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 }
     }
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.BinaryExpressionAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'BinaryExpressionAst')) {
         if ($n.Operator -in 'And', 'Or', 'QuestionQuestion') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
-    foreach ($n in (Get-PSCxNodeByKind -Ast $Ast -Type ([System.Management.Automation.Language.AssignmentStatementAst]))) {
+    foreach ($n in (Get-PSCxNodeByTypeName -Ast $Ast -TypeName 'AssignmentStatementAst')) {
         if ($n.Operator -eq 'QuestionQuestionEquals') { [pscustomobject]@{ Key = Get-PSCxUnitKey -Node $n; Construct = 'operator'; Line = $n.Extent.StartLineNumber; Amount = 1 } }
     }
 }


### PR DESCRIPTION
Closes #124. Two commits, and they are separate changes with very different payoffs.

## The real fix: 29% faster, byte-identical

`Initialize-PSCxAstIndex` invoked a helper for **every node in the tree**. A PowerShell function
with `[CmdletBinding()]` and mandatory parameters costs about 9µs to invoke, and the corpus this was
measured against holds 259,144 nodes:

```
259,144 x CmdletBinding function call    2,437 ms
259,144 x the same work inline              62 ms      39x
```

Inlined into its only caller, so the function is gone rather than left unused. Two smaller things in
the same loop: **HashSet companions** for the two type vocabularies (the lists stay as the
declaration — they carry the reasons and the vocabulary test reads them — but the index consults
them per node, where `-in` is a linear string scan: 138 ms vs 69 ms per list), and **one
`GetType().Name` per node instead of two**.

| | wall | cpu |
|---|---|---|
| before | 9,737 ms | 12,723 ms |
| after | **6,872 ms** | **9,152 ms** |

Interleaved, three pairs, same direction each time.

## Verified rather than assumed

- **Byte-identical output**: 1,317 units, every `-Detailed` contribution row included.
- **Mutant surface unchanged: 572 candidates** before and after. This is the check that matters —
  a smaller set scoring the same is the failure this project exists to find in other people's code,
  and "100%" after a refactor means nothing without it.
- Complexity gate passes; inlining leaves the top unit at cog=12 of 15.

## The first commit is smaller than its issue claimed, and that is on me

The other commit switches 15 of 17 collector queries from the assignable lookup to the exact one,
where the type has no subclass. Of the ten types queried, only `InvokeMemberExpressionAst` has one
(`BaseCtorInvokeMemberExpressionAst`) — exactly as CLAUDE.md records — so it and the one two-type
union keep the assignable form.

I filed #124 claiming that path was 69% of a scan. **It was not.** The measurements were real; the
attribution was wrong:

```
first = ClauseRow                     first = OperatorRow
  Get-PSCxCycClauseRow    5,638ms       Get-PSCxCycOperatorRow    5,662ms
  Get-PSCxCycOperatorRow     64ms       Get-PSCxCycClauseRow        115ms
```

**Cost follows position, not collector** — because the index is built lazily on the first node
lookup of a file, so whichever collector asks first is billed for indexing the whole tree. That is
the actual 62%, and the first commit is worth ~3% on its own.

It is kept because it is right on its own terms — asking exactly what you mean, and the non-first
collectors do get 3–7× cheaper — but the claim is corrected, in the issue and in the commit message.

## The lesson, which outlives the fix

**Profile by phase, not by function, wherever anything is lazy.** The first caller is billed for
work belonging to all of them. The check costs ten seconds: reorder the callers and see whether the
cost follows position or code. I had already been caught by an ordering artefact once while
profiling this, and then made the same class of mistake one level down.

## Gates

Suite **660 / 0** · coverage **100% over 1062 commands** · lint clean · CI parity clean ·
self-mutation **100% (546/546)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)