### PR TITLE
docs: stop naming the paired module in the shared parity rule set

### DIFF
--- a/tools/ParityDecisions.ps1
+++ b/tools/ParityDecisions.ps1
@@ -4,9 +4,9 @@
 # do: a gate that quietly stops being able to fail looks exactly like a green build, and this one
 # is watching the workflows every other gate runs inside.
 #
-# What this gate is FOR is drift between two repositories, not the correctness of one. PSComplexity
-# and PSMutant gate each other, so it is easy to assume their CI is comparable -- and for a long
-# time it was not, in thirteen ways, with nothing comparing them. The rules below are stated as
+# What this gate is FOR is drift between two repositories, not the correctness of one. This module
+# and the one it is paired with gate each other, so it is easy to assume their CI is comparable --
+# and for a long time it was not, in thirteen ways, with nothing comparing them. The rules below are stated as
 # SHAPE rather than by file name (an action pinned to a SHA, a lint gate that is not spelled
 # inline) so that this file is byte-identical in both repos apart from the command prefix. Diffing
 # the two copies is then the comparison, and a rule one repo declines is a deletion somebody has to

--- a/tools/Test-PSCxCiParity.ps1
+++ b/tools/Test-PSCxCiParity.ps1
@@ -3,9 +3,9 @@
     Assert this repository's CI still holds every capability the matching one's does.
 
 .DESCRIPTION
-    PSComplexity and PSMutant gate each other -- one measures the other's complexity, the other
-    mutation-tests this one's suite -- so it is easy to assume their CI is comparable. It was not,
-    in thirteen ways, and nothing compared them: each workflow reads fine on its own, and a
+    This module and the one it is paired with gate each other -- one measures the other's
+    complexity, the other mutation-tests its suite -- so it is easy to assume their CI is
+    comparable. It was not, in thirteen ways, and nothing compared them: each workflow reads fine on its own, and a
     capability present in one repository and absent in the other is invisible from inside either.
 
     The rules are stated as shape rather than by file name, so tools/ParityDecisions.ps1 is


### PR DESCRIPTION
Comment-only. No rule changes, no behaviour changes.

`tools/ParityDecisions.ps1` and `tools/Test-PSCxCiParity.ps1` named the module this one is paired with in their prose. Both now say "the one it is paired with".

## Why it needed care

The constraint is that neither module points at the other. The complication is that **this particular file's mechanism requires both copies to be byte-identical apart from the command prefix** -- diffing the two copies *is* the comparison -- so neutralising one side alone would have traded the invariant away for the wording.

Changing both copies keeps them together. The paired repo introduces its copy carrying this same text in the change that closes its parity tracker, and byte-identity was verified across the two afterwards rather than assumed:

```
diff <(sed 's/<prefix-a>/@@/g' a/tools/ParityDecisions.ps1) \
     <(sed 's/<prefix-b>/@@/g' b/tools/ParityDecisions.ps1)   # empty
```

## Gates

Parity gate green over 4 workflows; 28 parity tests pass. Diff is comments only -- verified by filtering the diff to non-comment lines, which comes back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)