### PR TITLE
Run the self-mutation gate three-wide on PSMutant 0.5.0

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -54,7 +54,7 @@ PS_COMPAT_VERSIONS=7.0.13 7.1.7 7.2.24 7.3.12 7.4.19 7.5.10
 PS_COMPAT_EXEMPT_MINORS=7.6
 
 PSSA_VERSION=1.25.0
-PSMUTANT_VERSION=0.4.0
+PSMUTANT_VERSION=0.5.0
 CONVERTTOSARIF_VERSION=1.0.0
 
 # What PSScriptAnalyzer looks at. Shared so the lint gate and the code-scanning check cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
+### Internal
+
+**The self-mutation gate runs three mutants at once, on PSMutant 0.5.0.** 554 mutants, **289s to
+142s** on the same machine. `PSMUTANT_VERSION` moves 0.4.0 -> 0.5.0 and the config gains
+`"workers": 3`.
+
+Three because the ubuntu-latest runner gives a public repo 4 vCPU and the orchestrator wants one.
+`workers: 0` means "this machine" and would resolve to the same number in CI, but to something past
+the useful point on a developer's machine -- PSMutant's own measurements put the optimum at four
+workers for a repo with few covering suites and eight for one with many, and wall clock gets *worse*
+beyond it, because every worker is a runspace in one process sharing one GC heap.
+
+**The acceptance was two numbers, not one:** the same mutant COUNT and the same VERDICTS as a
+serial run -- 554 both ways, identical and in order, no stale equivalence declarations. A smaller
+mutant set scoring the same is precisely the failure this project exists to find in other people's
+code, so a matching score alone would not have been evidence.
+
+**It is safe here because nothing in `tests/` touches PROCESS state**, and that is worth stating
+because it is not automatic. Every worker is a runspace in ONE process, so they share the
+environment and they share `$PID`. No test here writes an environment variable, and every temp
+fixture is already named with a GUID rather than the process id. Both of those bit PSMutant's own
+suite and had to be fixed there before it could turn this on; they are the first things to check if
+a parallel run ever starts disagreeing with a serial one.
+
+
 ## [0.5.1] - 2026-08-28
 
 ### For consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,6 @@ All notable changes to PSComplexity are documented here. Format follows
 
 ## [Unreleased]
 
-### Internal
-
-**The self-mutation gate runs three mutants at once, on PSMutant 0.5.0.** 554 mutants, **289s to
-142s** on the same machine. `PSMUTANT_VERSION` moves 0.4.0 -> 0.5.0 and the config gains
-`"workers": 3`.
-
-Three because the ubuntu-latest runner gives a public repo 4 vCPU and the orchestrator wants one.
-`workers: 0` means "this machine" and would resolve to the same number in CI, but to something past
-the useful point on a developer's machine -- PSMutant's own measurements put the optimum at four
-workers for a repo with few covering suites and eight for one with many, and wall clock gets *worse*
-beyond it, because every worker is a runspace in one process sharing one GC heap.
-
-**The acceptance was two numbers, not one:** the same mutant COUNT and the same VERDICTS as a
-serial run -- 554 both ways, identical and in order, no stale equivalence declarations. A smaller
-mutant set scoring the same is precisely the failure this project exists to find in other people's
-code, so a matching score alone would not have been evidence.
-
-**It is safe here because nothing in `tests/` touches PROCESS state**, and that is worth stating
-because it is not automatic. Every worker is a runspace in ONE process, so they share the
-environment and they share `$PID`. No test here writes an environment variable, and every temp
-fixture is already named with a GUID rather than the process id. Both of those bit PSMutant's own
-suite and had to be fixed there before it could turn this on; they are the first things to check if
-a parallel run ever starts disagreeing with a serial one.
-
-
 ## [0.5.1] - 2026-08-28
 
 ### For consumers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,28 @@ CI (`.github/workflows/ci.yml`) runs:
 | Unit tests | whole `tests/` directory, 0 failures |
 | Order independence | `tools/Test-PSCxOrderIndependence.ps1` -- the same suite again, reversed, plus an environment comparison |
 | Complexity | **its own** `Test-PSComplexity` against `src/`, 15 / 15 per unit |
-| Self-mutation | PSMutant against `psmutant.self.config.json`, break = 100 |
+| Self-mutation | PSMutant against `psmutant.self.config.json`, break = 100. Three workers -- see below |
+
+**The self-mutation gate runs THREE MUTANTS AT ONCE, and that is safe here for a reason worth
+keeping.** `workers: 3` took 554 mutants from 289s to 142s. Every worker is a runspace in ONE
+process, so they share the environment and they share `$PID` -- a test that WRITES an environment
+variable, or names a temp fixture after the process id, is then a test racing itself. Nothing in
+`tests/` does either: no test writes `$env:`, and every fixture already carries a GUID. Both
+hazards bit PSMutant's own suite and had to be fixed there first, so this is a property to keep
+rather than one to assume.
+
+`Push-Location` is fine, checked rather than assumed: a location is per-runspace, and a child
+setting its own leaves both `$PWD` and `[Environment]::CurrentDirectory` alone in the parent.
+
+**The acceptance for changing that number is TWO numbers** -- the same mutant COUNT and the same
+VERDICTS as a serial run, not a score that happens to match. That is the same rule this file
+already states for moving a file to a cheaper covering suite, and for the same reason: a smaller
+mutant set scoring the same is precisely the failure this project exists to find in other people's
+code. Measured before it was switched on: 554 both ways, identical and in order.
+
+Three rather than `0`, which means ProcessorCount - 1. The two are the same number on the
+ubuntu-latest runner a public repo gets, and `0` is worse on a developer's machine: wall clock has
+an optimum and gets worse past it, because the workers share one GC heap.
 
 Coverage is measured by one committed script, and it is enforced:
 

--- a/psmutant.self.config.json
+++ b/psmutant.self.config.json
@@ -5,6 +5,8 @@
     "tests",
     "schemas"
   ],
+  "_workersComment": "Evaluate three mutants at once, each in its own sandbox copy and its own Pester runspace (PSMutant 0.5.0). THREE because the ubuntu-latest runner gives a public repo 4 vCPU and the orchestrator wants one; `workers: 0` would resolve to the same number there and to something past the useful point on a developer's machine -- PSMutant's own measurements put the optimum at four workers for a repo with few covering suites and eight for one with many, and this repo has eight. THE ACCEPTANCE IS TWO NUMBERS, not one: the same mutant COUNT and the same VERDICTS as a serial run, because a smaller mutant set scoring the same is exactly the failure this project exists to find in other people's code. Measured before this was turned on. SAFE HERE BECAUSE NOTHING IN tests/ TOUCHES PROCESS STATE: no test writes an environment variable, and every temp fixture is named with a GUID rather than $PID -- which every worker shares, since they are runspaces in one process. Both of those bit PSMutant's own suite and are the first things to check if this ever starts disagreeing with a serial run.",
+  "workers": 3,
   "_sandboxSubtrees_comment": "schemas is copied for the same reason src and tests are: tests/Report.Tests.ps1 reads schemas/v1/report.schema.json to validate what a real run wrote. Without it the sandboxed suite cannot find the file and the BASELINE goes red -- before a single mutant is tried, and with an error that names a missing path rather than the missing subtree.",
   "mutate": [
     "src/Ast.ps1",


### PR DESCRIPTION
`PSMUTANT_VERSION` moves **0.4.0 -> 0.5.0** and `psmutant.self.config.json` gains `"workers": 3`,
so the self-mutation gate evaluates three mutants at once -- each in its own sandbox copy and its
own Pester runspace.

**554 mutants, 289s -> 142s** on the same machine. The committed config, run on its own
afterwards: 554 / 554, score 100, 143s.

## The acceptance was two numbers, not one

| | mutants | verdicts | stale equivalents | wall |
|---|---|---|---|---|
| serial | 554 | -- | none | 289s |
| `workers: 3` | 554 | **identical, in order** | none | 142s |

The same mutant **COUNT** and the same **VERDICTS**, not a score that happens to match. That is the
rule `CLAUDE.md` already states for moving a file to a cheaper covering suite, and it holds for the
same reason: a smaller mutant set scoring the same is precisely the failure this project exists to
find in other people's code.

## It is safe here because nothing in `tests/` touches PROCESS state

Worth stating rather than assuming, because it is not automatic. Every worker is a runspace in ONE
process, so they share the environment and they share `$PID`:

- a test that **writes** an environment variable is then a test racing itself;
- a temp fixture named after the process id is a file every worker writes and every worker deletes.

Neither exists here. No test writes `$env:`, and every fixture already carries a GUID. **Both of
those bit PSMutant's own suite** and had to be fixed there before it could turn this on, so this is
a property to keep rather than one to rely on by accident -- `CLAUDE.md` now says so, and names them
as the first things to check if a parallel run ever starts disagreeing with a serial one.

`Push-Location` is fine, checked rather than assumed: a location is per-runspace, and a child
setting its own leaves both `$PWD` and `[Environment]::CurrentDirectory` alone in the parent.

## Three rather than 0

`0` means `ProcessorCount - 1`. The two are the same number on the ubuntu-latest runner a public
repo gets, so CI is unaffected by the choice. They differ on a developer's machine, and there `0` is
worse: wall clock has an optimum and gets **worse** past it, because every worker is a runspace in
one process sharing one GC heap. PSMutant's own measurements put that optimum at four workers for a
repo with few covering suites and eight for one with many; this repo has eight files and eight
suites.

The condition for revisiting is recorded beside the number: the runner size changing.

## Gates

660 tests, 100% coverage over 1062 commands, self-mutation **554 / 554, score 100**, complexity
12/12 against a ceiling of 15, lint clean, CI parity, pin freshness.
